### PR TITLE
add 'case' keyword

### DIFF
--- a/support/vscode/syntaxes/veryl.tmLanguage.json
+++ b/support/vscode/syntaxes/veryl.tmLanguage.json
@@ -26,7 +26,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.veryl",
-					"match": "\\b(if|if_reset|else|for|in|step|repeat|inside|outside)\\b"
+					"match": "\\b(if|if_reset|else|case|for|in|step|repeat|inside|outside)\\b"
 				},
 				{
 					"name": "keyword.other.veryl",


### PR DESCRIPTION
Currently, VS code plugin does not highlight `case` keyword.
This PR is to fix this problem.