### PR TITLE
add 'default' keyword

### DIFF
--- a/support/vscode/syntaxes/veryl.tmLanguage.json
+++ b/support/vscode/syntaxes/veryl.tmLanguage.json
@@ -26,7 +26,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.veryl",
-					"match": "\\b(if|if_reset|else|case|for|in|step|repeat|inside|outside)\\b"
+					"match": "\\b(if|if_reset|else|case|default|for|in|step|repeat|inside|outside)\\b"
 				},
 				{
 					"name": "keyword.other.veryl",


### PR DESCRIPTION
VS code plugin does not also highlight `default` keyword.
This PR is to fix this problem.