### PR TITLE
Disable adjust line when emitting System Function

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -374,6 +374,7 @@ impl Emitter {
                     }
                 }
                 SymbolKind::SystemFunction => {
+                    self.adjust_line = false;
                     self.str("$");
                     self.identifier(&args[0]);
                 }


### PR DESCRIPTION
## issue
```veryl
module test () {
    initial {

        $display("Hello World!");
    }
}
```
this code was translated into 
```systemverilog
module test_test ();
    initial begin
        $
        display("Hello World!");
    end
endmodule
```
## what this PR changed
This bug is caused by adjusting line when emitting identifier after $.
https://github.com/veryl-lang/veryl/blob/2ee160a4a9696227dd18e12eb12c5735afc3c7f3/crates/emitter/src/emitter.rs#L376-L379
https://github.com/veryl-lang/veryl/blob/2ee160a4a9696227dd18e12eb12c5735afc3c7f3/crates/emitter/src/emitter.rs#L176-L180
So I changed adjust_line to false when emitting system function.
