### PR TITLE
Allow using ModportVariableMember as factor

### DIFF
--- a/crates/analyzer/src/handlers/check_expression.rs
+++ b/crates/analyzer/src/handlers/check_expression.rs
@@ -57,7 +57,6 @@ impl<'a> VerylGrammarTrait for CheckExpression<'a> {
                         | SymbolKind::TypeDef(_)
                         | SymbolKind::Enum(_)
                         | SymbolKind::Modport(_)
-                        | SymbolKind::ModportVariableMember(_)
                         | SymbolKind::Namespace
                         | SymbolKind::GenericInstance(_) => {
                             self.errors.push(AnalyzerError::invalid_factor(


### PR DESCRIPTION
In #753, CheckExpression pass raises InvalidFactor Error when ModportVariableMember is used as factor.
But it's incorrect.

```veryl
interface InterfaceA {
    var a: logic;
    modport master {
        a: input ,
    }
}

module ModuleA (
    clk: input clock,
    mst: modport InterfaceA::master,
) {
    always_ff {
        $display("%d", mst.a);
    }
}
```
```
  💥 a of kind "modport variable member" cannot be used as a factor in an
  │ expression
    ╭─[:12:1]
 12 │     always_ff {
 13 │         $display("%d", mst.a);
    ·                        ──┬──
    ·                          ╰── Error location
 14 │     }
    ╰────
  help: remove modport variable member from expression
```