### PR TITLE
Report error when enum variant cannot be evaluated

### DIFF
--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -616,6 +616,21 @@ pub enum AnalyzerError {
 
     #[diagnostic(
         severity(Error),
+        code(unevaluatable_enum_variant_value),
+        help(""),
+        url("")
+    )]
+    #[error("The implicit value of enum variant {identifier} cannot be evaluated")]
+    UnevaluatableEnumVariant {
+        identifier: String,
+        #[source_code]
+        input: NamedSource<String>,
+        #[label("Error location")]
+        error_location: SourceSpan,
+    },
+
+    #[diagnostic(
+        severity(Error),
         code(too_large_number),
         help("increase bit width"),
         url("https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#too_large_number")
@@ -1329,6 +1344,14 @@ impl AnalyzerError {
             identifier: identifier.to_string(),
             value,
             width,
+            input: AnalyzerError::named_source(source, token),
+            error_location: token.into(),
+        }
+    }
+
+    pub fn unevaluatable_enum_variant(identifier: &str, source: &str, token: &TokenRange) -> Self {
+        AnalyzerError::UnevaluatableEnumVariant {
+            identifier: identifier.to_string(),
             input: AnalyzerError::named_source(source, token),
             error_location: token.into(),
         }

--- a/crates/analyzer/src/handlers/create_symbol_table.rs
+++ b/crates/analyzer/src/handlers/create_symbol_table.rs
@@ -630,7 +630,13 @@ impl<'a> VerylGrammarTrait for CreateSymbolTable<'a> {
                         if let Some(value) = evaluated {
                             value
                         } else {
-                            todo!("report error")
+                            let name = arg.identifier.identifier_token.to_string();
+                            self.errors.push(AnalyzerError::unevaluatable_enum_variant(
+                                &name,
+                                self.text,
+                                &arg.identifier.as_ref().into(),
+                            ));
+                            return Ok(());
                         }
                     }
                     EnumMemberValue::ImplicitValue(value) => value,

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1389,6 +1389,36 @@ fn too_much_enum_variant() {
 }
 
 #[test]
+fn unevaluatable_enum_variant() {
+    let code = r#"
+    module ModuleA {
+        enum EnumA: logic<2> {
+            A = 2'b0x,
+            B = 2'b10,
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleB {
+        enum EnumA: logic<2> {
+            A = 2'b0x,
+            B,
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::UnevaluatableEnumVariant { .. }
+    ))
+}
+
+#[test]
 fn undefined_identifier() {
     let code = r#"
     module ModuleA {


### PR DESCRIPTION
Currently, the `todo!` macro is used when the value of enum variant is not specified and its implicit value cannot be evaluated.
https://github.com/veryl-lang/veryl/blob/d31f79771a1c6787c8378cde18dd0c7fe9bb612c/crates/analyzer/src/handlers/create_symbol_table.rs#L633

An appropriate error should be used for that case instead of the `todo!` macro.