### PR TITLE
Add `#[inline(never)]` to `expression*` as a workaround for long time compilation

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1002,6 +1002,9 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression'
+    // Add `#[inline(never)]` to `expression*` as a workaround for long time compilation
+    // https://github.com/rust-lang/rust/issues/106211
+    #[inline(never)]
     fn expression(&mut self, arg: &Expression) {
         self.expression01(&arg.expression01);
         for x in &arg.expression_list {
@@ -1013,6 +1016,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression01'
+    #[inline(never)]
     fn expression01(&mut self, arg: &Expression01) {
         self.expression02(&arg.expression02);
         for x in &arg.expression01_list {
@@ -1024,6 +1028,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression02'
+    #[inline(never)]
     fn expression02(&mut self, arg: &Expression02) {
         self.expression03(&arg.expression03);
         for x in &arg.expression02_list {
@@ -1035,6 +1040,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression03'
+    #[inline(never)]
     fn expression03(&mut self, arg: &Expression03) {
         self.expression04(&arg.expression04);
         for x in &arg.expression03_list {
@@ -1046,6 +1052,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression04'
+    #[inline(never)]
     fn expression04(&mut self, arg: &Expression04) {
         self.expression05(&arg.expression05);
         for x in &arg.expression04_list {
@@ -1057,6 +1064,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression05'
+    #[inline(never)]
     fn expression05(&mut self, arg: &Expression05) {
         self.expression06(&arg.expression06);
         for x in &arg.expression05_list {
@@ -1068,6 +1076,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression06'
+    #[inline(never)]
     fn expression06(&mut self, arg: &Expression06) {
         self.expression07(&arg.expression07);
         for x in &arg.expression06_list {
@@ -1079,6 +1088,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression07'
+    #[inline(never)]
     fn expression07(&mut self, arg: &Expression07) {
         self.expression08(&arg.expression08);
         for x in &arg.expression07_list {
@@ -1090,6 +1100,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression08'
+    #[inline(never)]
     fn expression08(&mut self, arg: &Expression08) {
         self.expression09(&arg.expression09);
         for x in &arg.expression08_list {
@@ -1101,6 +1112,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression09'
+    #[inline(never)]
     fn expression09(&mut self, arg: &Expression09) {
         self.expression10(&arg.expression10);
         for x in &arg.expression09_list {
@@ -1115,6 +1127,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression10'
+    #[inline(never)]
     fn expression10(&mut self, arg: &Expression10) {
         self.expression11(&arg.expression11);
         for x in &arg.expression10_list {
@@ -1126,6 +1139,7 @@ impl VerylWalker for Emitter {
     }
 
     /// Semantic action for non-terminal 'Expression11'
+    #[inline(never)]
     fn expression11(&mut self, arg: &Expression11) {
         if let Some(x) = &arg.expression11_opt {
             match x.casting_type.as_ref() {


### PR DESCRIPTION
Closes #975.

In some build configurations, Rust/LLVM luckily meets the inlining threshold, which inlined all expression functions to get a huge function, causing compile time problems.