### PR TITLE
Execute `type check` afeter resolving generics

### DIFF
--- a/crates/analyzer/src/handlers.rs
+++ b/crates/analyzer/src/handlers.rs
@@ -99,7 +99,6 @@ pub struct Pass2Handlers<'a> {
     check_enum: CheckEnum<'a>,
     check_modport: CheckModport<'a>,
     check_function: CheckFunction<'a>,
-    check_type: CheckType<'a>,
     check_msb_lsb: CheckMsbLsb<'a>,
     check_assignment: CheckAssignment<'a>,
     check_clock_reset: CheckClockReset<'a>,
@@ -108,6 +107,7 @@ pub struct Pass2Handlers<'a> {
     check_expression: CheckExpression<'a>,
     check_clock_domain: CheckClockDomain<'a>,
     check_proto: CheckProto<'a>,
+    check_type: CheckType<'a>,
 }
 
 impl<'a> Pass2Handlers<'a> {
@@ -116,7 +116,6 @@ impl<'a> Pass2Handlers<'a> {
             check_enum: CheckEnum::new(text),
             check_modport: CheckModport::new(text),
             check_function: CheckFunction::new(text),
-            check_type: CheckType::new(text),
             check_msb_lsb: CheckMsbLsb::new(text),
             check_assignment: CheckAssignment::new(text),
             check_clock_reset: CheckClockReset::new(text),
@@ -125,6 +124,7 @@ impl<'a> Pass2Handlers<'a> {
             check_expression: CheckExpression::new(text),
             check_clock_domain: CheckClockDomain::new(text),
             check_proto: CheckProto::new(text),
+            check_type: CheckType::new(text),
         }
     }
 
@@ -133,7 +133,6 @@ impl<'a> Pass2Handlers<'a> {
             &mut self.check_enum as &mut dyn Handler,
             &mut self.check_modport as &mut dyn Handler,
             &mut self.check_function as &mut dyn Handler,
-            &mut self.check_type as &mut dyn Handler,
             &mut self.check_msb_lsb as &mut dyn Handler,
             &mut self.check_assignment as &mut dyn Handler,
             &mut self.check_clock_reset as &mut dyn Handler,
@@ -142,6 +141,7 @@ impl<'a> Pass2Handlers<'a> {
             &mut self.check_expression as &mut dyn Handler,
             &mut self.check_clock_domain as &mut dyn Handler,
             &mut self.check_proto as &mut dyn Handler,
+            &mut self.check_type as &mut dyn Handler,
         ]
     }
 
@@ -150,7 +150,6 @@ impl<'a> Pass2Handlers<'a> {
         ret.append(&mut self.check_enum.errors);
         ret.append(&mut self.check_modport.errors);
         ret.append(&mut self.check_function.errors);
-        ret.append(&mut self.check_type.errors);
         ret.append(&mut self.check_msb_lsb.errors);
         ret.append(&mut self.check_assignment.errors);
         ret.append(&mut self.check_clock_reset.errors);
@@ -159,6 +158,7 @@ impl<'a> Pass2Handlers<'a> {
         ret.append(&mut self.check_expression.errors);
         ret.append(&mut self.check_clock_domain.errors);
         ret.append(&mut self.check_proto.errors);
+        ret.append(&mut self.check_type.errors);
         ret
     }
 }

--- a/crates/analyzer/src/handlers.rs
+++ b/crates/analyzer/src/handlers.rs
@@ -45,6 +45,7 @@ use self::{check_assignment::CheckAssignment, create_type_dag::CreateTypeDag};
 
 pub struct Pass1Handlers<'a> {
     check_attribute: CheckAttribute<'a>,
+    check_direction: CheckDirection<'a>,
     check_embed_include: CheckEmbedInclude<'a>,
     check_identifier: CheckIdentifier<'a>,
     check_number: CheckNumber<'a>,
@@ -57,6 +58,7 @@ impl<'a> Pass1Handlers<'a> {
     pub fn new(text: &'a str, build_opt: &'a Build, lint_opt: &'a Lint) -> Self {
         Self {
             check_attribute: CheckAttribute::new(text),
+            check_direction: CheckDirection::new(text),
             check_embed_include: CheckEmbedInclude::new(text),
             check_identifier: CheckIdentifier::new(text, lint_opt),
             check_number: CheckNumber::new(text),
@@ -69,6 +71,7 @@ impl<'a> Pass1Handlers<'a> {
     pub fn get_handlers(&mut self) -> Vec<&mut dyn Handler> {
         vec![
             &mut self.check_attribute as &mut dyn Handler,
+            &mut self.check_direction as &mut dyn Handler,
             &mut self.check_embed_include as &mut dyn Handler,
             &mut self.check_identifier as &mut dyn Handler,
             &mut self.check_number as &mut dyn Handler,
@@ -81,6 +84,7 @@ impl<'a> Pass1Handlers<'a> {
     pub fn get_errors(&mut self) -> Vec<AnalyzerError> {
         let mut ret = Vec::new();
         ret.append(&mut self.check_attribute.errors);
+        ret.append(&mut self.check_direction.errors);
         ret.append(&mut self.check_embed_include.errors);
         ret.append(&mut self.check_identifier.errors);
         ret.append(&mut self.check_number.errors);
@@ -93,7 +97,6 @@ impl<'a> Pass1Handlers<'a> {
 
 pub struct Pass2Handlers<'a> {
     check_enum: CheckEnum<'a>,
-    check_direction: CheckDirection<'a>,
     check_modport: CheckModport<'a>,
     check_function: CheckFunction<'a>,
     check_type: CheckType<'a>,
@@ -111,7 +114,6 @@ impl<'a> Pass2Handlers<'a> {
     pub fn new(text: &'a str, _build_opt: &'a Build, _lint_opt: &'a Lint) -> Self {
         Self {
             check_enum: CheckEnum::new(text),
-            check_direction: CheckDirection::new(text),
             check_modport: CheckModport::new(text),
             check_function: CheckFunction::new(text),
             check_type: CheckType::new(text),
@@ -129,7 +131,6 @@ impl<'a> Pass2Handlers<'a> {
     pub fn get_handlers(&mut self) -> Vec<&mut dyn Handler> {
         vec![
             &mut self.check_enum as &mut dyn Handler,
-            &mut self.check_direction as &mut dyn Handler,
             &mut self.check_modport as &mut dyn Handler,
             &mut self.check_function as &mut dyn Handler,
             &mut self.check_type as &mut dyn Handler,
@@ -147,7 +148,6 @@ impl<'a> Pass2Handlers<'a> {
     pub fn get_errors(&mut self) -> Vec<AnalyzerError> {
         let mut ret = Vec::new();
         ret.append(&mut self.check_enum.errors);
-        ret.append(&mut self.check_direction.errors);
         ret.append(&mut self.check_modport.errors);
         ret.append(&mut self.check_function.errors);
         ret.append(&mut self.check_type.errors);

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -595,22 +595,6 @@ fn invalid_direction() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InvalidDirection { .. }));
-
-    let code = r#"
-    interface InterfaceG {
-        var value: logic;
-        modport mp {
-            value: input,
-        }
-    }
-
-    module ModuleG (
-        port_a: input InterfaceG
-    ){}
-    "#;
-
-    let errors = analyze(code);
-    assert!(matches!(errors[0], AnalyzerError::InvalidDirection { .. }));
 }
 
 #[test]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1089,6 +1089,84 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceN1 {
+        var a: logic;
+        modport mp {
+            a: input,
+        }
+    }
+    module ModuleN1 (
+        port_n1: input InterfaceN1::mp,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceN2::<W: const> {
+        var a: logic<W>;
+        modport mp {
+            a: input,
+        }
+    }
+    module ModuleN2 (
+        port_n2: input InterfaceN2::<2>::mp,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceN3 {
+        var a: logic;
+    }
+    module ModuleN3 (
+        port_n3: input InterfaceN3,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceN4::<W: const> {
+        var a: logic<W>;
+    }
+    module ModuleN4 (
+        port_n4: input InterfaceN4::<2>,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceO1 {
+        var a: logic;
+    }
+    module ModuleO1 (
+        port_o1: modport InterfaceO1,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceO2::<W: const> {
+        var a: logic<W>;
+    }
+    module ModuleO2 (
+        port_o2: modport InterfaceO2::<2>,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
 }
 
 #[test]


### PR DESCRIPTION
The `type check` checker requires resolved generic instanciations but, currently, it is executed before resolving them.
This is cause of #1006 and #1007.

Therefore, the checker should be executed after resolving generic instanciations.

fix #1006
fix #1007