### PR TITLE
Allow benches on non-Linuxes

### DIFF
--- a/crates/tests/benches/perf.rs
+++ b/crates/tests/benches/perf.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 use std::{fs::File, os::raw::c_int, path::Path};
 
 use criterion::profiler::Profiler;


### PR DESCRIPTION
Since crate pprof is only available on linux the module perf only compiles on linux.
This prevents executing benches on other OSes.
Can confirm that this works on Windows.