### PR TITLE
Fix wrong port definition

### DIFF
--- a/crates/std/veryl/src/synchronizer/synchronizer.veryl
+++ b/crates/std/veryl/src/synchronizer/synchronizer.veryl
@@ -2,8 +2,8 @@ pub proto module synchronizer #(
     param WIDTH : u32 = 8,
     param STAGES: u32 = 2,
 ) (
-    i_clk: input  `d clock,
-    i_rst: input  `d reset,
-    i_d  : input  `s logic,
-    o_d  : output `d logic,
+    i_clk: input  `d clock       ,
+    i_rst: input  `d reset       ,
+    i_d  : input  `s logic<WIDTH>,
+    o_d  : output `d logic<WIDTH>,
 );


### PR DESCRIPTION
Width of `i_d` and `o_d` should be parameterized by `WIDTH` parameter.