### PR TITLE
Add new waveform target / Implement waveform for cocotb

### DIFF
--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -23,4 +23,4 @@ pub use project::Project;
 pub use pubfile::{Pubfile, Release};
 pub use publish::Publish;
 pub use semver;
-pub use test::{SimType, Test, WaveFormTarget};
+pub use test::{SimType, Test, WaveFormFormat, WaveFormTarget};

--- a/crates/metadata/src/test.rs
+++ b/crates/metadata/src/test.rs
@@ -14,6 +14,8 @@ pub struct Test {
     pub vivado: VivadoProperty,
     #[serde(default)]
     pub waveform_target: WaveFormTarget,
+    #[serde(default)]
+    pub waveform_format: WaveFormFormat,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -64,4 +66,22 @@ pub enum WaveFormTarget {
     Target,
     #[serde(rename = "directory")]
     Directory { path: PathBuf },
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum WaveFormFormat {
+    #[default]
+    #[serde(rename = "vcd")]
+    Vcd,
+    #[serde(rename = "fst")]
+    Fst,
+}
+
+impl WaveFormFormat {
+    pub fn extension(self) -> &'static str {
+        match self {
+            WaveFormFormat::Vcd => "vcd",
+            WaveFormFormat::Fst => "fst",
+        }
+    }
 }

--- a/crates/veryl/src/main.rs
+++ b/crates/veryl/src/main.rs
@@ -52,11 +52,13 @@ fn main() -> Result<ExitCode> {
                 "{} {}{}",
                 style.apply_to(format!("[{:<5}]", record.level())),
                 " ".repeat(
-                    12 - format!("{message}")
-                        .split_ascii_whitespace()
-                        .next()
-                        .unwrap()
-                        .len()
+                    12_usize.saturating_sub(
+                        format!("{message}")
+                            .split_ascii_whitespace()
+                            .next()
+                            .unwrap()
+                            .len()
+                    )
                 ),
                 message
             ))

--- a/crates/veryl/src/runner.rs
+++ b/crates/veryl/src/runner.rs
@@ -106,13 +106,22 @@ pub fn copy_wave(
     metadata: &Metadata,
     work_path: &Path,
 ) -> Result<()> {
+    // The file always has a `.vcd` extension, because `$dumpfile` doesn't have the metadata information
     let wave_src_path = work_path.join(format!("{}.vcd", test_name));
+
+    // but let's rename the target file to the correct extension, based on the selected format
+    let target_name = format!(
+        "{}.{}",
+        test_name,
+        metadata.test.waveform_format.extension()
+    );
+
     let wave_dst_path = match &metadata.test.waveform_target {
-        WaveFormTarget::Target => {
-            let target = PathBuf::from(test_path.to_string());
-            target.parent().unwrap().join(format!("{}.vcd", test_name))
-        }
-        WaveFormTarget::Directory { path } => path.join(format!("{}.vcd", test_name)),
+        WaveFormTarget::Target => PathBuf::from(test_path.to_string())
+            .parent()
+            .unwrap()
+            .join(target_name),
+        WaveFormTarget::Directory { path } => path.join(target_name),
     };
 
     let wave_dst_dir = wave_dst_path.parent().unwrap();

--- a/crates/veryl/src/runner/vivado.rs
+++ b/crates/veryl/src/runner/vivado.rs
@@ -1,6 +1,6 @@
 use crate::runner::{Runner, copy_wave, remap_msg_by_regex};
 use futures::prelude::*;
-use log::{error, info};
+use log::{error, info, warn};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -8,7 +8,7 @@ use std::process::Stdio;
 use tokio::process::{Child, Command};
 use tokio::runtime::Runtime;
 use tokio_util::codec::{FramedRead, LinesCodec};
-use veryl_metadata::Metadata;
+use veryl_metadata::{Metadata, WaveFormFormat};
 use veryl_parser::resource_table::{PathId, StrId};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -107,7 +107,7 @@ impl Runner for Vivado {
         test: StrId,
         _top: Option<StrId>,
         path: PathId,
-        wave: bool,
+        mut wave: bool,
     ) -> Result<bool> {
         self.success = true;
 
@@ -121,11 +121,16 @@ impl Runner for Vivado {
         ];
 
         if wave {
-            defines.push("-d".to_string());
-            defines.push(format!(
-                "__veryl_wavedump_{}_{}__",
-                metadata.project.name, test
-            ));
+            if WaveFormFormat::Vcd == metadata.test.waveform_format {
+                defines.push("-d".to_string());
+                defines.push(format!(
+                    "__veryl_wavedump_{}_{}__",
+                    metadata.project.name, test
+                ));
+            } else {
+                warn!("Only VCD is supported as a waveform format for vivado!");
+                wave = false;
+            }
         }
 
         let rt = Runtime::new().unwrap();
@@ -154,12 +159,13 @@ impl Runner for Vivado {
 
         info!("Elaborating test ({})", test);
 
-        let opt = if wave { vec!["-debug", "all"] } else { vec![] };
-
         let mut top = vec![test.to_string()];
-        if wave {
+        let opt = if wave && WaveFormFormat::Vcd == metadata.test.waveform_format {
             top.push("__veryl_wavedump".to_string());
-        }
+            vec!["-debug", "all"]
+        } else {
+            vec![]
+        };
 
         rt.block_on(async {
             let elaborate = Command::new("xelab")


### PR DESCRIPTION
This is a 2 in 1 (please tell me if I should split this up) merge.

This changes the option of `veryl test --wave`. You now have to provide either `vcd` or `fst` as a target format.

Also cocotb now supports waveform generation since it's the (my) main target of testing.