### PR TITLE
fix build_args with non `--test` argument

### DIFF
--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -169,7 +169,7 @@ impl Runner for Cocotb {
                 "True",
                 "['--trace-fst', '--trace-structs', '--trace-threads', '2']",
             ),
-            None => ("False", ""),
+            None => ("False", "[]"),
         };
         let runner_path = temp_dir.path().join("runner.py");
         let runner_text = format!(


### PR DESCRIPTION
```
[INFO ]    Executing test (testAlu)
  File "/tmp/.tmpI7QCnb/runner.py", line 13
    build_args=,
    ^^^^^^^^^^^
SyntaxError: expected argument value expression
```

forgot to add `[]` to build_args

sorry 🙈