### PR TITLE
Add checks for modport default member

### DIFF
--- a/crates/analyzer/src/handlers/create_symbol_table.rs
+++ b/crates/analyzer/src/handlers/create_symbol_table.rs
@@ -836,11 +836,13 @@ impl VerylGrammarTrait for CreateSymbolTable {
                         ModportDefault::Input(_) => Some(crate::symbol::ModportDefault::Input),
                         ModportDefault::Output(_) => Some(crate::symbol::ModportDefault::Output),
                         ModportDefault::SameLParenIdentifierRParen(x) => {
+                            reference_table::add(x.identifier.as_ref().into());
                             Some(crate::symbol::ModportDefault::Same(
                                 x.identifier.identifier_token.token,
                             ))
                         }
                         ModportDefault::ConverseLParenIdentifierRParen(x) => {
+                            reference_table::add(x.identifier.as_ref().into());
                             Some(crate::symbol::ModportDefault::Converse(
                                 x.identifier.identifier_token.token,
                             ))

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1800,6 +1800,25 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    interface InterfaceA {
+        var a: logic;
+        modport mp_0 {
+            a: input,
+        }
+        modport mp_1 {
+            ..converse(a)
+        }
+        modport mp_2 {
+            ..same(a)
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+    assert!(matches!(errors[1], AnalyzerError::MismatchType { .. }));
 }
 
 #[test]
@@ -2509,6 +2528,31 @@ fn undefined_identifier() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    interface InterfaceA {
+        var a: logic;
+        modport mp_0 {
+            a: input,
+        }
+        modport mp_1 {
+            ..converse(mp)
+        }
+        modport mp_2 {
+            ..same(mp)
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::UndefinedIdentifier { .. }
+    ));
+    assert!(matches!(
+        errors[1],
+        AnalyzerError::UndefinedIdentifier { .. }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1476

Add undefined variale and mismatch type checks for modport default member.