### PR TITLE
Check non meaningful generic parameter

### DIFF
--- a/crates/analyzer/src/handlers/check_proto.rs
+++ b/crates/analyzer/src/handlers/check_proto.rs
@@ -405,10 +405,8 @@ fn check_alias_compat(
         else {
             return ret;
         };
-        if let Some(ref proto) = symbol.found.proto() {
-            symbol_table::resolve((proto, &symbol.found.namespace))
-                .ok()
-                .map(|x| x.found)
+        if let Some(proto) = symbol.found.proto() {
+            symbol_table::get(proto)
         } else {
             None
         }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1741,6 +1741,30 @@ fn mismatch_type() {
     assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
 
     let code = r#"
+    module ModuleA {}
+    module ModuleB::<T: ModuleA> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    proto module ProtoModuleA;
+    module ModuleB::<T: inst ProtoModuleA> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    module ModuleA {}
+    module ModuleB::<T: inst ModuleA> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
     proto module ProtoA;
     proto module ProtoB;
 
@@ -1911,6 +1935,30 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package PkgA {}
+    module ModuleA::<PKG: PkgA> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    proto package ProtoPkgA {}
+    module ModuleA::<PKG: inst ProtoPkgA> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    package PkgA {}
+    module ModuleA::<PKG: inst PkgA> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
 
     let code = r#"
     proto package ProtoPkgA {}


### PR DESCRIPTION
close veryl-lang/veryl#1370

This PR is to add check for non meaningful generic parameter.
Generic parameters below are only allowed.

* Generic parameter
    * proto module
    * proto interface
    * proto package
* Generic inst parameter
    * non generic interface
