### PR TITLE
Fix panic on adding symbol for enum item

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3262,6 +3262,21 @@ fn unevaluatable_enum_variant() {
         errors[0],
         AnalyzerError::UnevaluatableEnumVariant { .. }
     ));
+
+    let code = r#"
+    package Pkg {
+        enum Foo {
+            FOO
+        }
+
+        enum Bar {
+            BAR = Foo::FOO,
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1560

Namespaces for identifiers on RHS of enum item are used to resolve symbols for those identifiers.
Symbol for enum item should be created at `Handler::After` phase because those namespaces have been created during `Handler::Before` phase.