### PR TITLE
Support flattened array modport/instance

### DIFF
--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -585,6 +585,19 @@ impl From<&syntax_tree::WithGenericArgumentItem> for GenericSymbolPath {
     }
 }
 
+impl From<&syntax_tree::Identifier> for GenericSymbolPath {
+    fn from(value: &syntax_tree::Identifier) -> Self {
+        GenericSymbolPath {
+            paths: vec![GenericSymbol {
+                base: value.identifier_token.token,
+                arguments: Vec::new(),
+            }],
+            kind: GenericSymbolPathKind::Identifier,
+            range: value.into(),
+        }
+    }
+}
+
 impl From<&syntax_tree::ScopedIdentifier> for GenericSymbolPath {
     fn from(value: &syntax_tree::ScopedIdentifier) -> Self {
         let mut paths = Vec::new();

--- a/crates/metadata/src/build.rs
+++ b/crates/metadata/src/build.rs
@@ -40,6 +40,8 @@ pub struct Build {
     pub instance_depth_limit: usize,
     #[serde(default = "default_instance_total_limit")]
     pub instance_total_limit: usize,
+    #[serde(default)]
+    pub flatten_array_interface: bool,
 }
 
 fn default_source() -> PathBuf {


### PR DESCRIPTION
close veryl-lang/veryl#1403

Multi-demensional array instance/modport is flattened into a single demensional array instance/modport when the `flatten_array_interface` build option is set.