### PR TITLE
Evaluate enum member value if it is possible

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -200,9 +200,21 @@ impl Symbol {
                     }
                     evaluator.expression(&x.value)
                 }
-                SymbolKind::EnumMember(_) => {
-                    // TODO: Actually Evaluate its Width
-                    Evaluated::create_unknown_static()
+                SymbolKind::EnumMember(x) => {
+                    let value = x.value.value();
+                    let SymbolKind::Enum(r#enum) = self.get_parent().unwrap().kind else {
+                        unreachable!()
+                    };
+
+                    match value {
+                        Some(value) if r#enum.width > 0 => Evaluated::create_fixed(
+                            value as isize,
+                            false,
+                            vec![r#enum.width],
+                            vec![],
+                        ),
+                        _ => Evaluated::create_unknown_static(),
+                    }
                 }
                 SymbolKind::Genvar => Evaluated::create_unknown_static(),
                 SymbolKind::Module(_)

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3256,11 +3256,14 @@ fn unevaluatable_enum_variant() {
     let code = r#"
     package Pkg {
         enum Foo {
-            FOO
+            FOO_0 = 2'b01,
+            FOO_1 = 2'b10,
         }
 
+        #[enum_encoding(onehot)]
         enum Bar {
-            BAR = Foo::FOO,
+            BAR_0 = Foo::FOO_0,
+            BAR_1 = Foo::FOO_1,
         }
     }
     "#;


### PR DESCRIPTION
fix veryl-lang/veryl#1567

Currenlty, an enum member values is treated as a unknown value even though it is actualy evaluatable.
It causes #1567.
This PR is to implement enum member value evaluation.