### PR TITLE
Rename `StripPrefix` error with `InvalidSourceLocation` error

### DIFF
--- a/crates/metadata/src/lockfile.rs
+++ b/crates/metadata/src/lockfile.rs
@@ -245,7 +245,9 @@ impl Lockfile {
                 let path = metadata.project_path();
 
                 for src in &veryl_path::gather_files_with_extension(&path, "veryl", false)? {
-                    let rel = src.strip_prefix(&path)?;
+                    let Ok(rel) = src.strip_prefix(&path) else {
+                        return Err(MetadataError::InvalidSourceLocation(src.clone()));
+                    };
                     let mut dst = base_dst.join(&lock.name);
                     dst.push(rel);
                     dst.set_extension("sv");

--- a/crates/metadata/src/metadata.rs
+++ b/crates/metadata/src/metadata.rs
@@ -284,7 +284,9 @@ impl Metadata {
 
         let mut ret = Vec::new();
         for src in src_files {
-            let src_relative = src.strip_prefix(&src_base)?;
+            let Ok(src_relative) = src.strip_prefix(&src_base) else {
+                return Err(MetadataError::InvalidSourceLocation(src));
+            };
             let dst = match self.build.target {
                 Target::Source => src.with_extension("sv"),
                 Target::Directory { ref path } => {

--- a/crates/metadata/src/metadata_error.rs
+++ b/crates/metadata/src/metadata_error.rs
@@ -20,9 +20,9 @@ pub enum MetadataError {
     #[error("toml load failed")]
     Deserialize(#[from] toml::de::Error),
 
-    #[diagnostic(code(MetadataError::StripPrefix), help(""))]
-    #[error("strip prefix error")]
-    StripPrefix(#[from] std::path::StripPrefixError),
+    #[diagnostic(code(MetadataError::InvalidSourceLocation), help(""))]
+    #[error("source file \"{0}\" is outside the project")]
+    InvalidSourceLocation(PathBuf),
 
     #[diagnostic(code(MetadataError::Git), help(""))]
     #[error("git operation failure: {0}")]


### PR DESCRIPTION
Veryl assumes that all source files are inside the project base.
This is chceked [here](https://github.com/veryl-lang/veryl/blob/e1a7a0c75f4de2cb618e3003eb4a62d934d7ef9f/crates/metadata/src/metadata.rs#L287) and `Metadata::StripPrefix` will be reported when the given source file is outside the project.
However, the printed message is not clear.

```
veryl build /home/ishitani/workspace/temp/veryl/test.veryl
Error: MetadataError::StripPrefix

  × strip prefix error
  ╰─▶ prefix not found
  help:
```

This PR is to rename the error name and make the message more clear.