### PR TITLE
Not resolve inner symbol of the last path element

### DIFF
--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -37,6 +37,14 @@ impl SymbolPath {
     pub fn to_vec(self) -> SVec<StrId> {
         self.0
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl fmt::Display for SymbolPath {
@@ -372,7 +380,6 @@ impl GenericSymbolPath {
                 return true;
             }
         }
-
         // path contains generic parameter as generic argument
         for path in &self.paths {
             for arg in &path.arguments {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5560,16 +5560,16 @@ fn unresolvable_generic_argument() {
     );
 
     let code = r#"
+    module ModuleA::<PKG: ProtoPkg> {
+        function FuncB() -> u32 {
+            return FuncA::<PKG::T>();
+        }
+    }
     proto package ProtoPkg {
         type T;
     }
     package Pkg::<W: u32> for ProtoPkg {
         type T = logic<W>;
-    }
-    module ModuleA::<PKG: ProtoPkg> {
-        function FuncB() -> u32 {
-            return FuncA::<PKG::T>();
-        }
     }
     module ModuleB {
         inst u: ModuleA::<Pkg::<8>>;


### PR DESCRIPTION
refs: https://github.com/veryl-lang/veryl/issues/1603#issuecomment-2861996020

The above issue is caused by failure of resolving inner symbol of `PKG` generic parameter even though it is unnecessary.
To resolve the issue, I changed `symbol_table::resolve` method not to resolve inner symbol of the last path element.