### PR TITLE
Referctor type check for generic argument

### DIFF
--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -580,8 +580,8 @@ impl From<&syntax_tree::BooleanLiteral> for GenericSymbolPath {
 impl From<&syntax_tree::WithGenericArgumentItem> for GenericSymbolPath {
     fn from(value: &syntax_tree::WithGenericArgumentItem) -> Self {
         match value {
-            syntax_tree::WithGenericArgumentItem::ScopedIdentifier(x) => {
-                x.scoped_identifier.as_ref().into()
+            syntax_tree::WithGenericArgumentItem::ExpressionIdentifier(x) => {
+                x.expression_identifier.as_ref().into()
             }
             syntax_tree::WithGenericArgumentItem::FixedType(x) => x.fixed_type.as_ref().into(),
             syntax_tree::WithGenericArgumentItem::Number(x) => x.number.as_ref().into(),
@@ -658,6 +658,26 @@ impl From<&syntax_tree::ScopedIdentifier> for GenericSymbolPath {
             kind: GenericSymbolPathKind::Identifier,
             range: value.into(),
         }
+    }
+}
+
+impl From<&syntax_tree::ExpressionIdentifier> for GenericSymbolPath {
+    fn from(value: &syntax_tree::ExpressionIdentifier) -> Self {
+        let mut path: GenericSymbolPath = value.scoped_identifier.as_ref().into();
+
+        for base in value
+            .expression_identifier_list0
+            .iter()
+            .map(|x| x.identifier.identifier_token.token)
+        {
+            path.paths.push(GenericSymbol {
+                base,
+                arguments: vec![],
+            });
+        }
+
+        path.range = value.into();
+        path
     }
 }
 

--- a/crates/parser/src/generated/veryl-exp.par
+++ b/crates/parser/src/generated/veryl-exp.par
@@ -876,7 +876,7 @@
 /*  859 */ WithGenericArgumentListList /* Vec<T>::New */: ;
 /*  860 */ WithGenericArgumentListOpt /* Option<T>::Some */: Comma;
 /*  861 */ WithGenericArgumentListOpt /* Option<T>::None */: ;
-/*  862 */ WithGenericArgumentItem: ScopedIdentifier;
+/*  862 */ WithGenericArgumentItem: ExpressionIdentifier;
 /*  863 */ WithGenericArgumentItem: FixedType;
 /*  864 */ WithGenericArgumentItem: Number;
 /*  865 */ WithGenericArgumentItem: BooleanLiteral;

--- a/crates/parser/src/generated/veryl_grammar_trait.rs
+++ b/crates/parser/src/generated/veryl_grammar_trait.rs
@@ -4651,13 +4651,13 @@ pub struct GenericProtoBoundFixedType {
 ///
 /// Type derived for production 862
 ///
-/// `WithGenericArgumentItem: ScopedIdentifier;`
+/// `WithGenericArgumentItem: ExpressionIdentifier;`
 ///
 #[allow(dead_code)]
 #[derive(Builder, Debug, Clone)]
 #[builder(crate = "parol_runtime::derive_builder")]
-pub struct WithGenericArgumentItemScopedIdentifier {
-    pub scoped_identifier: Box<ScopedIdentifier>,
+pub struct WithGenericArgumentItemExpressionIdentifier {
+    pub expression_identifier: Box<ExpressionIdentifier>,
 }
 
 ///
@@ -13687,7 +13687,7 @@ pub struct WithGenericArgument {
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum WithGenericArgumentItem {
-    ScopedIdentifier(WithGenericArgumentItemScopedIdentifier),
+    ExpressionIdentifier(WithGenericArgumentItemExpressionIdentifier),
     FixedType(WithGenericArgumentItemFixedType),
     Number(WithGenericArgumentItemNumber),
     BooleanLiteral(WithGenericArgumentItemBooleanLiteral),
@@ -34057,21 +34057,22 @@ impl<'t, 'u> VerylGrammarAuto<'t, 'u> {
 
     /// Semantic action for production 862:
     ///
-    /// `WithGenericArgumentItem: ScopedIdentifier;`
+    /// `WithGenericArgumentItem: ExpressionIdentifier;`
     ///
     #[parol_runtime::function_name::named]
     fn with_generic_argument_item_0(
         &mut self,
-        _scoped_identifier: &ParseTreeType<'t>,
+        _expression_identifier: &ParseTreeType<'t>,
     ) -> Result<()> {
         let context = function_name!();
         trace!("{}", self.trace_item_stack(context));
-        let scoped_identifier = pop_item!(self, scoped_identifier, ScopedIdentifier, context);
-        let with_generic_argument_item_0_built = WithGenericArgumentItemScopedIdentifier {
-            scoped_identifier: Box::new(scoped_identifier),
+        let expression_identifier =
+            pop_item!(self, expression_identifier, ExpressionIdentifier, context);
+        let with_generic_argument_item_0_built = WithGenericArgumentItemExpressionIdentifier {
+            expression_identifier: Box::new(expression_identifier),
         };
         let with_generic_argument_item_0_built =
-            WithGenericArgumentItem::ScopedIdentifier(with_generic_argument_item_0_built);
+            WithGenericArgumentItem::ExpressionIdentifier(with_generic_argument_item_0_built);
         // Calling user action here
         self.user_grammar
             .with_generic_argument_item(&with_generic_argument_item_0_built)?;

--- a/crates/parser/src/generated/veryl_parser.rs
+++ b/crates/parser/src/generated/veryl_parser.rs
@@ -22768,7 +22768,7 @@ pub const LOOKAHEAD_AUTOMATA: &[LookaheadDFA; 750] = &[
             Trans(23, 26, 33, -1),
             Trans(23, 27, 33, -1),
             Trans(23, 31, 60, -1),
-            Trans(23, 32, 61, -1),
+            Trans(23, 32, 71, -1),
             Trans(23, 33, 36, -1),
             Trans(23, 34, 36, -1),
             Trans(23, 35, 34, -1),
@@ -22779,7 +22779,7 @@ pub const LOOKAHEAD_AUTOMATA: &[LookaheadDFA; 750] = &[
             Trans(23, 42, 145, -1),
             Trans(23, 43, 36, -1),
             Trans(23, 44, 72, -1),
-            Trans(23, 45, 62, -1),
+            Trans(23, 45, 73, -1),
             Trans(23, 46, 146, -1),
             Trans(23, 47, 64, -1),
             Trans(23, 48, 65, -1),
@@ -31493,11 +31493,17 @@ pub const LOOKAHEAD_AUTOMATA: &[LookaheadDFA; 750] = &[
             Trans(4, 5, 3, 858),
             Trans(4, 30, 3, 858),
             Trans(4, 32, 3, 858),
+            Trans(4, 35, 3, 858),
+            Trans(4, 38, 3, 858),
+            Trans(4, 43, 3, 858),
             Trans(4, 45, 3, 858),
             Trans(5, 5, 3, 858),
             Trans(5, 29, 3, 858),
             Trans(5, 30, 3, 858),
             Trans(5, 32, 3, 858),
+            Trans(5, 35, 3, 858),
+            Trans(5, 38, 3, 858),
+            Trans(5, 43, 3, 858),
             Trans(5, 45, 3, 858),
             Trans(6, 7, 3, 858),
             Trans(6, 8, 3, 858),
@@ -37330,10 +37336,10 @@ pub const PRODUCTIONS: &[Production; 1096] = &[
         lhs: 731,
         production: &[],
     },
-    // 862 - WithGenericArgumentItem: ScopedIdentifier;
+    // 862 - WithGenericArgumentItem: ExpressionIdentifier;
     Production {
         lhs: 728,
-        production: &[ParseType::N(613)],
+        production: &[ParseType::N(219)],
     },
     // 863 - WithGenericArgumentItem: FixedType;
     Production {

--- a/crates/parser/src/token_range.rs
+++ b/crates/parser/src/token_range.rs
@@ -1125,7 +1125,7 @@ impl_token_range!(WithGenericArgument, colon_colon_l_angle, r_angle);
 impl_token_range_list!(WithGenericArgumentList, WithGenericArgumentItem);
 impl_token_range_enum!(
     WithGenericArgumentItem,
-    scoped_identifier,
+    expression_identifier,
     fixed_type,
     number,
     boolean_literal

--- a/crates/parser/src/veryl_walker.rs
+++ b/crates/parser/src/veryl_walker.rs
@@ -2663,8 +2663,8 @@ pub trait VerylWalker {
     fn with_generic_argument_item(&mut self, arg: &WithGenericArgumentItem) {
         before!(self, with_generic_argument_item, arg);
         match arg {
-            WithGenericArgumentItem::ScopedIdentifier(x) => {
-                self.scoped_identifier(&x.scoped_identifier);
+            WithGenericArgumentItem::ExpressionIdentifier(x) => {
+                self.expression_identifier(&x.expression_identifier);
             }
             WithGenericArgumentItem::FixedType(x) => {
                 self.fixed_type(&x.fixed_type);

--- a/crates/parser/veryl.par
+++ b/crates/parser/veryl.par
@@ -795,7 +795,7 @@ WithGenericArgument: ColonColonLAngle %push(Generic) [ WithGenericArgumentList ]
 
 WithGenericArgumentList: WithGenericArgumentItem { Comma WithGenericArgumentItem } [ Comma ];
 
-WithGenericArgumentItem: ScopedIdentifier
+WithGenericArgumentItem: ExpressionIdentifier
                        | FixedType
                        | Number
                        | BooleanLiteral


### PR DESCRIPTION
fix #1609
fix #1613 

Currently, type checker for generic args has following restrictoins.

* Not check the definition location of the given type for type generic parameters
* Can't use parameters not defined in packages for proto generic parameters
* Can't use struct/union values for proto generic parameters
* Can't use member variables as generic args
    * #1609

This PR is to clear the above restrictions.