### PR TITLE
Insert type dag edge between base and actual generic arg

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -415,6 +415,10 @@ mod filelist {
             "03_module_a.veryl",
             "04_module_b.veryl",
             "05_module_c.veryl",
+            "06_package_c.veryl",
+            "07_module_d.veryl",
+            "08_module_e.veryl",
+            "09_module_f.veryl",
             "ram.veryl",
         ];
         check_list(&paths, all);
@@ -422,5 +426,8 @@ mod filelist {
         check_order(&paths, "01_package_a.veryl", "03_module_a.veryl");
         check_order(&paths, "02_package_b.veryl", "04_module_b.veryl");
         check_order(&paths, "ram.veryl", "05_module_c.veryl");
+        check_order(&paths, "06_package_c.veryl", "07_module_d.veryl");
+        check_order(&paths, "07_module_d.veryl", "09_module_f.veryl");
+        check_order(&paths, "09_module_f.veryl", "08_module_e.veryl");
     }
 }

--- a/testcases/filelist/src/06_package_c.veryl
+++ b/testcases/filelist/src/06_package_c.veryl
@@ -1,0 +1,7 @@
+proto package ProtoPackageC {
+    const WIDTH: u32;
+}
+
+package PackageC::<W: u32> for ProtoPackageC {
+    const WIDTH: u32 = W;
+}

--- a/testcases/filelist/src/07_module_d.veryl
+++ b/testcases/filelist/src/07_module_d.veryl
@@ -1,0 +1,3 @@
+module ModuleD::<PKG: ProtoPackageC> {
+  let _a: logic<PKG::WIDTH> = 0;
+}

--- a/testcases/filelist/src/08_module_e.veryl
+++ b/testcases/filelist/src/08_module_e.veryl
@@ -1,0 +1,3 @@
+module ModuleE {
+  inst u: ModuleF::<PackageC::<8>>;
+}

--- a/testcases/filelist/src/09_module_f.veryl
+++ b/testcases/filelist/src/09_module_f.veryl
@@ -1,0 +1,3 @@
+module ModuleF::<PKG: ProtoPackageC> {
+  inst u: ModuleD::<PKG>;
+}


### PR DESCRIPTION
fix veryl-lang/veryl#1657

Currently, no dag edge between base symbol and actual arg symbol is inserted if the given path includes references to generic paramters.
This causes #1657.

To fix this case, we need to replace references to generic parameters with actual generic arguments and resolve the path.
