### PR TITLE
Fix spurious `unassign variable` error

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4685,6 +4685,97 @@ fn unassign_variable() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::UnassignVariable { .. }));
+
+    let code = r#"
+    module Foo (
+        bar: output logic,
+        baz: output logic,
+    ) {
+        always_comb {
+            if true {
+                bar = 0;
+                baz = bar;
+            } else {
+                bar = 1;
+                baz = 0;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module Foo (
+        bar: output logic,
+        baz: output logic,
+    ) {
+        always_comb {
+            if true {
+                if true {
+                    baz = bar;
+                } else {
+                    baz = 0;
+                }
+                if true {
+                    bar = 0;
+                } else {
+                    bar = 1;
+                }
+            } else {
+                bar = 1;
+                baz = 0;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::UnassignVariable { .. }));
+
+    let code = r#"
+    module Foo (
+        bar: output logic,
+        baz: output logic,
+    ) {
+        always_comb {
+            if true {
+                baz = bar;
+            } else {
+                baz = 0;
+            }
+            bar = 0;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::UnassignVariable { .. }));
+
+    let code = r#"
+    module Foo (
+        bar: output logic,
+        baz: output logic,
+    ) {
+        always_comb {
+            if true {
+                baz = bar;
+            } else {
+                baz = 0;
+            }
+
+            if true {
+                bar = 0;
+            } else {
+                bar = 1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::UnassignVariable { .. }));
 }
 
 #[test]
@@ -4811,6 +4902,27 @@ fn uncovered_branch() {
         always_comb {
             if x {
                 a = 1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::UncoveredBranch { .. }));
+
+    let code = r#"
+    module ModuleC {
+        var a: logic;
+        let x: logic = 1;
+        let y: logic = 1;
+
+        always_comb {
+            if x {
+                if y {
+                    a = 1;
+                }
+            } else {
+                a = 0;
             }
         }
     }

--- a/crates/analyzer/src/var_ref.rs
+++ b/crates/analyzer/src/var_ref.rs
@@ -16,6 +16,30 @@ pub struct VarRef {
     pub r#type: VarRefType,
     pub affiliation: VarRefAffiliation,
     pub path: VarRefPath,
+    // `branch group` and `branch index` are used to distinguish two statements.
+    // two `VarRef` are visible from each other if either of following conditions is met.
+    // * two `VarRef` belong to different branch group
+    //      * two `branch group` share no elements
+    // * two `VarRef` belong to the same branch
+    //      * two `branch group` share elements but `branch index` are different
+    //
+    //  if {        branch group [0]    branch index [0]
+    //      if {    branch group [0, 1] branch index [0, 0]
+    //      }
+    //  } else {    branch group [0]    branch index [1]
+    //      if {    branch group [0, 2] branch index [1, 0]
+    //      }
+    //  }
+    //
+    //  if {        branch group [3]    branch index [0]
+    //      if {    branch group [3, 4] branch index [0, 0]
+    //      }
+    //  } else {    branch group [3]    branch index [1]
+    //      if {    branch group [3, 5] branch index [1, 0]
+    //      }
+    //  }
+    pub branch_group: Vec<usize>,
+    pub branch_index: Vec<usize>,
 }
 
 impl VarRef {


### PR DESCRIPTION
fix veryl-lang/veryl#1707

The checker does not distinguish two variable references which belong to other conditonal branches.
Due to this, #1707 is happened.