### PR TITLE
Fix generic argument resolution performed during generic path resolution

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4122,6 +4122,29 @@ fn unknown_member() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package ProtoPkg {
+        struct Foo {
+            foo: logic,
+        }
+    }
+    interface InterfaceA::<Pkg: ProtoPkg> {
+        var foo: Pkg::Foo;
+        modport mp {
+            foo: input,
+        }
+    }
+    module ModuleB::<Pkg: ProtoPkg> (
+        if_a: modport InterfaceA::<Pkg>::mp,
+    ) {
+        var _foo: logic;
+        assign _foo = if_a.foo.foo;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1714

The givne generic arguments will be resolved in the inner namespace of the generic base component.
Therefore, resolution of the generic parameter given as a generic argument will be failed because it is not defined in the namespace.

To resolve this situation, generic parameters given as generic arguments should be replaced with their types.