### PR TITLE
Fix wrong filelist order

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -419,6 +419,8 @@ mod filelist {
             "07_module_d.veryl",
             "08_module_e.veryl",
             "09_module_f.veryl",
+            "10_package_g.veryl",
+            "11_package_h.veryl",
             "ram.veryl",
         ];
         check_list(&paths, all);
@@ -429,5 +431,6 @@ mod filelist {
         check_order(&paths, "06_package_c.veryl", "07_module_d.veryl");
         check_order(&paths, "07_module_d.veryl", "09_module_f.veryl");
         check_order(&paths, "09_module_f.veryl", "08_module_e.veryl");
+        check_order(&paths, "10_package_g.veryl", "11_package_h.veryl");
     }
 }

--- a/testcases/filelist/src/10_package_g.veryl
+++ b/testcases/filelist/src/10_package_g.veryl
@@ -1,0 +1,3 @@
+package PackageG {
+  type G = logic<2>;
+}

--- a/testcases/filelist/src/11_package_h.veryl
+++ b/testcases/filelist/src/11_package_h.veryl
@@ -1,0 +1,5 @@
+package PackageH {
+  struct StructH {
+    H: PackageG::G,
+  }
+}


### PR DESCRIPTION
fix veryl-lang/veryl#1716

To fix #1716, need to insert dag between two packages for dag for package items defined in each other packages.