### PR TITLE
Add support for including additional files for tests

### DIFF
--- a/crates/metadata/src/test.rs
+++ b/crates/metadata/src/test.rs
@@ -16,6 +16,8 @@ pub struct Test {
     pub waveform_target: WaveFormTarget,
     #[serde(default)]
     pub waveform_format: WaveFormFormat,
+    #[serde(default)]
+    pub include_files: Vec<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -1,6 +1,6 @@
 use crate::runner::{Runner, copy_wave};
 use futures::prelude::*;
-use log::{error, info};
+use log::{error, info, warn};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -128,6 +128,11 @@ impl Runner for Cocotb {
         info!("Executing test ({})", test);
 
         let src_path = temp_dir.path().join(format!("{}.py", test));
+
+        // in this case, the global includes may be irrelevant
+        if !metadata.test.include_files.is_empty() {
+            warn!("Including files is unimplemented for this backend!");
+        }
 
         match self.source {
             CocotbSource::Embed(x) => {

--- a/crates/veryl/src/runner/vcs.rs
+++ b/crates/veryl/src/runner/vcs.rs
@@ -130,6 +130,11 @@ impl Runner for Vcs {
 
         let temp_dir = tempfile::tempdir().into_diagnostic()?;
 
+        // in this case, the global includes may be irrelevant
+        if !metadata.test.include_files.is_empty() {
+            warn!("Including files is unimplemented for this backend!");
+        }
+
         info!("Compiling test ({})", test);
 
         let mut defines = vec![format!(


### PR DESCRIPTION
Hi!

This is a PoC implementation of something like what @jbeaurivage mentioned in Discord.

"  From what I understand, veryl test runs the simulations from a temp directory which is cleaned up after the run (at least for verilator, not sure about other simulation frameworks). Seems like there is no mechanism to include extra files to the temp directory so that they can be referenced in the simulation, is that correct? "

This adds additional option in Veryl.toml

```
[test.verilator]
include_files = [string]
```

The provided files will be copied into the temp directory created for the test bench. My personal use case for this is `$readmemh()` based memory population, which requires a source `.mem` file.

Current implementation is limited to an array of file paths, and to Verilator (the way you want to do this for vcd or Vivado may differ, and i'm not familiar enough with those to do it), one could also think of allowing the inclusion of entire directories.

I've not used `miette` before, so i'm unsure of the idiomatic way of creating errors, i've used miette::bail!(), with a hopefully helpful message, let me know if this needs changing. 