### PR TITLE
Place include files into the `sim_build` directory for cocotb runner

### DIFF
--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -137,20 +137,14 @@ impl Runner for Cocotb {
                 fs::create_dir_all(&sim_build_path)
                     .into_diagnostic()
                     .with_context(|| {
-                        format!(
-                            "Failed to create `sim_build` directory at {:?}",
-                            sim_build_path
-                        )
+                        format!("Failed to create `sim_build` directory at {sim_build_path:?}")
                     })?;
 
                 let target_path = sim_build_path.join(file_name);
                 fs::copy(include_file, &target_path)
                     .into_diagnostic()
                     .with_context(|| {
-                        format!(
-                            "Failed to copy include {:?} to {:?}",
-                            include_file, target_path
-                        )
+                        format!("Failed to copy include {include_file:?} to {target_path:?}")
                     })?;
             } else {
                 miette::bail!("Failed to get include file name {:?}", include_file);

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -137,7 +137,10 @@ impl Runner for Cocotb {
                 fs::create_dir_all(&sim_build_path)
                     .into_diagnostic()
                     .with_context(|| {
-                        format!("Failed to create `sim_build` directory at {:?}", sim_build_path)
+                        format!(
+                            "Failed to create `sim_build` directory at {:?}",
+                            sim_build_path
+                        )
                     })?;
 
                 let target_path = sim_build_path.join(file_name);


### PR DESCRIPTION
Trying to use the feature added in #1729, I realized there is a bug where the `sim_build` directory doesn't exist when trying to copy the files over. Instead, create the directory before trying to copy the files.

This also has the advantage of placing the included files in the same directory as the testbench python file.