### PR TITLE
Allow to specify multiple source directories

### DIFF
--- a/Veryl.toml
+++ b/Veryl.toml
@@ -11,7 +11,7 @@ clock_type       = "posedge"
 reset_type       = "async_low"
 reset_low_suffix = "_n"
 filelist_type    = "absolute"
-source           = "testcases/veryl"
+sources          = ["testcases/veryl"]
 target           = {type = "directory", path = "testcases/sv"}
 sourcemap_target = {type = "directory", path = "testcases/map"}
 

--- a/crates/metadata/src/build.rs
+++ b/crates/metadata/src/build.rs
@@ -20,6 +20,8 @@ pub struct Build {
     pub filelist_type: FilelistType,
     #[serde(default = "default_source")]
     pub source: PathBuf,
+    #[serde(default = "default_sources")]
+    pub sources: Vec<PathBuf>,
     #[serde(default)]
     pub target: Target,
     #[serde(default)]
@@ -48,6 +50,10 @@ pub struct Build {
 
 fn default_source() -> PathBuf {
     PathBuf::new()
+}
+
+fn default_sources() -> Vec<PathBuf> {
+    vec![PathBuf::new()]
 }
 
 fn default_instance_depth_limit() -> usize {

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -192,7 +192,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("");
+        metadata.build.sources = vec![PathBuf::from("")];
         metadata.build.target = Target::Source;
         metadata.build.sourcemap_target = SourceMapTarget::Target;
 
@@ -209,7 +209,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("");
+        metadata.build.sources = vec![PathBuf::from("")];
         metadata.build.target = Target::Source;
         metadata.build.sourcemap_target = SourceMapTarget::Directory {
             path: "testcases/map".into(),
@@ -228,7 +228,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("");
+        metadata.build.sources = vec![PathBuf::from("")];
         metadata.build.target = Target::Directory {
             path: "testcases/sv".into(),
         };
@@ -247,7 +247,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("");
+        metadata.build.sources = vec![PathBuf::from("")];
         metadata.build.target = Target::Directory {
             path: "testcases/sv".into(),
         };
@@ -268,7 +268,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("testcases/veryl/");
+        metadata.build.sources = vec![PathBuf::from("testcases/veryl/")];
         metadata.build.target = Target::Source;
         metadata.build.sourcemap_target = SourceMapTarget::Target;
 
@@ -285,7 +285,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("testcases/veryl/");
+        metadata.build.sources = vec![PathBuf::from("testcases/veryl/")];
         metadata.build.target = Target::Source;
         metadata.build.sourcemap_target = SourceMapTarget::Directory {
             path: "testcases/map".into(),
@@ -304,7 +304,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("testcases/veryl/");
+        metadata.build.sources = vec![PathBuf::from("testcases/veryl/")];
         metadata.build.target = Target::Directory {
             path: "testcases/sv".into(),
         };
@@ -323,7 +323,7 @@ mod path {
         let metadata_path = Metadata::search_from_current().unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 
-        metadata.build.source = PathBuf::from("testcases/veryl/");
+        metadata.build.sources = vec![PathBuf::from("testcases/veryl/")];
         metadata.build.target = Target::Directory {
             path: "testcases/sv".into(),
         };


### PR DESCRIPTION
close veryl-lang/veryl#1746

The warning message blow is displayed if the `source` field is set.
![image](https://github.com/user-attachments/assets/b4f1fd11-6799-4202-83a2-9b27e52559d0)

