### PR TITLE
Add components referenced only as alias target to filelist

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -421,7 +421,9 @@ mod filelist {
             "09_module_f.veryl",
             "10_package_g.veryl",
             "11_package_h.veryl",
+            "12_alias_i.veryl",
             "ram.veryl",
+            "axi_pkg.veryl",
         ];
         check_list(&paths, all);
 
@@ -432,5 +434,6 @@ mod filelist {
         check_order(&paths, "07_module_d.veryl", "09_module_f.veryl");
         check_order(&paths, "09_module_f.veryl", "08_module_e.veryl");
         check_order(&paths, "10_package_g.veryl", "11_package_h.veryl");
+        check_order(&paths, "axi_pkg.veryl", "12_alias_i.veryl");
     }
 }

--- a/testcases/filelist/src/12_alias_i.veryl
+++ b/testcases/filelist/src/12_alias_i.veryl
@@ -1,0 +1,1 @@
+alias package AliasI = $std::axi4_pkg::<32, 4, 8, 1, 1, 1, 1, 1>;


### PR DESCRIPTION
close veryl-lang/veryl#1748

Currenlty, components referenced only as alias target are not included in the filelist.
https://github.com/veryl-lang/veryl/issues/1748#issuecomment-3019602691

This PR is to add such component to the filelist.