### PR TITLE
Fix `unknown_member` error for struct type referenced via typedef

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -1176,6 +1176,13 @@ impl Type {
                 SymbolKind::TypeDef(x) => {
                     return x.r#type.trace_user_defined(&symbol.found.namespace);
                 }
+                SymbolKind::ProtoTypeDef(ref x) => {
+                    if let Some(r#type) = &x.r#type {
+                        return r#type.trace_user_defined(&symbol.found.namespace);
+                    } else {
+                        return Some((self.clone(), Some(symbol.found)));
+                    }
+                }
                 SymbolKind::Module(_)
                 | SymbolKind::ProtoModule(_)
                 | SymbolKind::Interface(_)

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4281,6 +4281,40 @@ fn unknown_member() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package FooPkg {
+        struct Foo {
+            foo: logic,
+        }
+    }
+    package BarPkg {
+        type Foo = FooPkg::Foo;
+    }
+    module ModuleA {
+        let _foo: BarPkg::Foo = BarPkg::Foo'{ foo: 0 };
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    package FooPkg {
+        struct Foo {
+            foo: logic,
+        }
+    }
+    proto package BarProtoPkg {
+        type Foo = FooPkg::Foo;
+    }
+    module ModuleA::<PKG: BarProtoPkg> {
+        let _foo: PKG::Foo = PKG::Foo'{ foo: 0 };
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1771