### PR TITLE
Fix visibility of indirectly dependent projects

### DIFF
--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -290,13 +290,13 @@ pub struct AnalyzerPass3Info {
     var_refs: HashMap<VarRefAffiliation, Vec<VarRef>>,
 }
 
-fn new_namespace(name: &str) -> (Token, Symbol) {
+fn new_namespace(name: &str, public: bool) -> (Token, Symbol) {
     let token = Token::new(name, 0, 0, 0, 0, TokenSource::External);
     let symbol = Symbol::new(
         &token,
         SymbolKind::Namespace,
         &Namespace::new(),
-        false,
+        public,
         DocComment::default(),
     );
     (token, symbol)
@@ -307,7 +307,7 @@ impl Analyzer {
         for locks in metadata.lockfile.lock_table.values() {
             for lock in locks {
                 let prj = resource_table::insert_str(&lock.name);
-                let (token, symbol) = new_namespace(&lock.name);
+                let (token, symbol) = new_namespace(&lock.name, lock.visible);
                 symbol_table::insert(&token, symbol);
                 for lock_dep in &lock.dependencies {
                     let from = resource_table::insert_str(&lock_dep.name);
@@ -318,7 +318,7 @@ impl Analyzer {
                         .unwrap();
                     let to = to.iter().find(|x| x.source == lock_dep.source).unwrap();
 
-                    let (token, symbol) = new_namespace(&to.name);
+                    let (token, symbol) = new_namespace(&to.name, to.visible);
                     symbol_table::insert(&token, symbol);
 
                     let to = resource_table::insert_str(&to.name);

--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -1069,6 +1069,16 @@ pub enum AnalyzerError {
         error_location: SourceSpan,
     },
 
+    #[diagnostic(severity(Error), code(private_namespace), help(""), url(""))]
+    #[error("\"{name}\" is private namespace")]
+    PrivateNamespace {
+        name: String,
+        #[source_code]
+        input: MultiSources,
+        #[label("Error location")]
+        error_location: SourceSpan,
+    },
+
     #[diagnostic(
         severity(Error),
         code(unknown_msb),
@@ -1940,6 +1950,14 @@ impl AnalyzerError {
 
     pub fn private_member(name: &str, token: &TokenRange) -> Self {
         AnalyzerError::PrivateMember {
+            name: name.to_string(),
+            input: source(token),
+            error_location: token.into(),
+        }
+    }
+
+    pub fn private_namespace(name: &str, token: &TokenRange) -> Self {
+        AnalyzerError::PrivateNamespace {
             name: name.to_string(),
             input: source(token),
             error_location: token.into(),

--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -144,8 +144,13 @@ impl ReferenceTable {
                     }
                 }
                 ResolveErrorCause::Private => {
-                    self.errors
-                        .push(AnalyzerError::private_member(&name, token));
+                    if matches!(last_found.kind, SymbolKind::Namespace) {
+                        self.errors
+                            .push(AnalyzerError::private_namespace(&name, token));
+                    } else {
+                        self.errors
+                            .push(AnalyzerError::private_member(&name, token));
+                    }
                 }
                 ResolveErrorCause::Invisible => {
                     self.errors

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -76,7 +76,7 @@ impl SymbolTable {
                 &token,
                 SymbolKind::Namespace,
                 &namespace,
-                false,
+                true,
                 DocComment::default(),
             );
             let _ = ret.insert(&token, symbol);
@@ -359,6 +359,7 @@ impl SymbolTable {
             | SymbolKind::Package(_)
             | SymbolKind::ProtoPackage(_)
             | SymbolKind::AliasPackage(_) => !context.other_prj || found.public,
+            SymbolKind::Namespace => context.other_prj || found.public,
             _ => true,
         }
     }


### PR DESCRIPTION
fix veryl-lang/veryl#1795

Visibility of indirectly dependent projects should be invisible but currently such projects are visible from the main project.
This PR is to fix it.