### PR TITLE
Fix panic on resolving generic instance with enum member generic arg

### DIFF
--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -476,9 +476,14 @@ impl GenericSymbolPath {
                 // see:
                 // https://github.com/veryl-lang/veryl/issues/1721#issuecomment-2986758880
                 let member_path = self.paths.pop().unwrap();
-                let mut namespace = namespace.clone();
-                namespace.pop();
-                self.resolve_imported(&namespace, generic_maps);
+                if namespace.matched(&symbol.found.namespace) {
+                    // For case that the given namespace is matched with the enum declaration
+                    let mut namespace = namespace.clone();
+                    namespace.pop();
+                    self.resolve_imported(&namespace, generic_maps);
+                } else {
+                    self.resolve_imported(namespace, generic_maps);
+                }
                 self.paths.push(member_path);
             } else if symbol.imported {
                 let self_namespace = namespace_table::get(self.range.beg.id).unwrap();

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -2766,6 +2766,20 @@ fn mismatch_type() {
     assert!(errors.is_empty());
 
     let code = r#"
+    package PkgA {
+        enum Foo {
+            FOO
+        }
+    }
+    package PkgB::<FOO: PkgA::Foo> {
+    }
+    alias package PkgC = PkgB::<PkgA::Foo::FOO>;
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
     module ModuleA {}
     alias package Pkg = ModuleA;
     "#;


### PR DESCRIPTION
fix veryl-lang/veryl#1828

This error is symbol resolution for generic instance with enum member generic arg called from here.
https://github.com/veryl-lang/veryl/blob/1466d33db42ee817317c1d7fd9301d66e6150697/crates/analyzer/src/symbol_path.rs#L481

The given namespace is popped without conditions. Due to this, the propagated namespace can be empty and this error is happened.

To fix this error, the given namesapce should be popped only when it is matched with the enum declaration.