### PR TITLE
Fix `unresolvable_generic_argument` and `mismatch_type` errors for expression identifier used as generic arg

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -221,11 +221,12 @@ impl ReferenceTable {
         generics_token: Option<Token>,
         generic_maps: Option<&Vec<GenericMap>>,
     ) {
-        let orig_len = path.len();
         let mut path = path.clone();
         if let Some(maps) = generic_maps {
             path.apply_map(maps);
         }
+
+        let orig_len = path.len();
         path.resolve_imported(namespace, generic_maps);
 
         if path.is_generic_reference() {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3019,6 +3019,24 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package PkgA::<V: u32> {
+        struct Foo {
+            foo: u32,
+        }
+        const FOO: Foo = Foo'{ foo: V };
+    }
+    package PkgB::<V: u32> {
+        const BAR: u32 = V;
+    }
+    module ModuleA {
+        import PkgB::<PkgA::<32>::FOO.foo>::*;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1838