### PR TITLE
Fix `invalid_reset_non_elaborative` error for generic parameter used for reset value

### DIFF
--- a/crates/analyzer/src/evaluator.rs
+++ b/crates/analyzer/src/evaluator.rs
@@ -1542,6 +1542,8 @@ impl Evaluator {
                     tmp = self.do_concatenation(tmp, e.clone());
                 }
                 tmp
+            } else if c.is_known_static() {
+                Evaluated::create_unknown_static()
             } else {
                 Evaluated::create_unknown()
             }

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -302,6 +302,17 @@ impl Symbol {
                     }
                 }
                 SymbolKind::Genvar => Evaluated::create_unknown_static(),
+                SymbolKind::GenericParameter(x) => {
+                    if x.bound
+                        .resolve_proto_bound(&self.namespace)
+                        .map(|x| x.is_variable_type())
+                        .unwrap_or(false)
+                    {
+                        Evaluated::create_unknown_static()
+                    } else {
+                        self.create_evaluated_with_error()
+                    }
+                }
                 SymbolKind::Module(_)
                 | SymbolKind::ProtoModule(_)
                 | SymbolKind::Interface(_)

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5530,6 +5530,40 @@ fn reset_value_non_elaborative() {
         errors[0],
         AnalyzerError::InvalidResetNonElaborative { .. }
     ));
+
+    let code = r#"
+    module ModuleA::<A: u32> (
+        i_clk: input clock,
+        i_rst: input reset,
+    ) {
+        var _a: logic;
+        always_ff {
+            if_reset {
+                _a = A;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA::<A: u32> (
+        i_clk: input clock,
+        i_rst: input reset,
+    ) {
+        var _a: logic<A>;
+        always_ff {
+            if_reset {
+                _a = {1'b0 repeat A};
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1872

An evaluation result of a generic parameter should be `unknown static` but currently not.
This causes #1872.