### PR TITLE
Fix `invalid_cast` error for clock/reset variable referenced via modport

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5947,6 +5947,26 @@ fn invalid_cast() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InvalidCast { .. }));
+
+    let code = r#"
+    interface FooIF {
+        var clk: clock;
+        var rst: reset;
+        modport mp {
+            clk: input,
+            rst: input,
+        }
+    }
+    module BarModule (
+        foo_if: modport FooIF::mp,
+    ) {
+        let _clk: clock = foo_if.clk as clock;
+        let _rst: reset = foo_if.rst as reset;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1873

Currently, evaluation result of `modport member variable` is `unknown` value.
This causes #1873.

To fix this, I implemented evaluation for `modport member variable`.