### PR TITLE
fix unexpected `mismatch_generics_arity` error

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -7,7 +7,7 @@ use crate::evaluator::{
 use crate::namespace::Namespace;
 use crate::namespace_table;
 use crate::symbol_path::{GenericSymbolPath, SymbolPath};
-use crate::symbol_table;
+use crate::symbol_table::{self, Import};
 use std::cell::RefCell;
 use std::fmt;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -123,7 +123,7 @@ pub struct Symbol {
     pub namespace: Namespace,
     pub references: Vec<Token>,
     pub generic_instances: Vec<SymbolId>,
-    pub imported: Vec<(GenericSymbolPath, Namespace)>,
+    pub imported: Vec<Import>,
     pub evaluated: RefCell<Option<Evaluated>>,
     pub overrides: Vec<Evaluated>,
     pub allow_unused: bool,

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1362,6 +1362,22 @@ fn mismatch_generics_arity() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package PkgA::<V: u32> {
+        const A: u32 = V;
+    }
+    module ModuleA {
+        import PkgA::<32>::*;
+        function get_v::<V: u32> -> u32 {
+            return V;
+        }
+        let _a: u32 = get_v::<A>();
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -5657,7 +5657,7 @@ pub fn symbol_string(
         | SymbolKind::TypeDef(_)
         | SymbolKind::Enum(_) => {
             let visible = namespace.included(&symbol.namespace)
-                || symbol.imported.iter().any(|(_, x)| *x == namespace);
+                || symbol.imported.iter().any(|x| x.namespace == namespace);
             if visible & !context.in_import {
                 ret.push_str(&token_text);
             } else {
@@ -5700,7 +5700,7 @@ pub fn symbol_string(
         SymbolKind::GenericInstance(x) => {
             let base = symbol_table::get(x.base).unwrap();
             let visible = namespace.included(&base.namespace)
-                || base.imported.iter().any(|(_, x)| *x == namespace);
+                || base.imported.iter().any(|x| x.namespace == namespace);
             let top_level = matches!(
                 base.kind,
                 SymbolKind::Module(_) | SymbolKind::Interface(_) | SymbolKind::Package(_)


### PR DESCRIPTION
fix veryl-lang/veryl#1898
fix veryl-lang/veryl#1900

This error is reported when resolving generic arg imorted from generic package.

Path to an imported symbol is appended with the package where the symbol belongs to. However, expanded path does not include generic args even if the parent package is a generic package.
https://github.com/veryl-lang/veryl/blob/d55b0f4003decf3fdc91497cccc15c9e234f2e2f/crates/analyzer/src/symbol_path.rs#L565

Due to this, unexpected `mismatch_generics_arity` error is reported.

