### PR TITLE
Fix panic on emitting `bind` declaration

### DIFF
--- a/crates/analyzer/src/namespace.rs
+++ b/crates/analyzer/src/namespace.rs
@@ -1,7 +1,9 @@
 use crate::attribute::Attribute;
 use crate::attribute_table;
 use crate::namespace_table;
+use crate::symbol::Symbol;
 use crate::symbol_path::SymbolPath;
+use crate::symbol_table;
 use crate::{HashMap, SVec, svec};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -146,6 +148,20 @@ impl Namespace {
             }
         }
         self.paths = paths;
+    }
+
+    pub fn get_symbol(&self) -> Option<Symbol> {
+        let mut namespace = self.clone();
+        if let Some(path) = namespace.pop()
+            && namespace.depth() >= 1
+        {
+            let path = SymbolPath::new(&[path]);
+            symbol_table::resolve((&path, &namespace))
+                .map(|x| x.found)
+                .ok()
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -156,17 +156,7 @@ impl Symbol {
     }
 
     pub fn get_parent(&self) -> Option<Symbol> {
-        let mut namespace = self.namespace.clone();
-        if let Some(path) = namespace.pop()
-            && namespace.depth() >= 1
-        {
-            let path = SymbolPath::new(&[path]);
-            if let Ok(symbol) = symbol_table::resolve((&path, &namespace)) {
-                return Some(symbol.found);
-            }
-        }
-
-        None
+        self.namespace.get_symbol()
     }
 
     pub fn get_parent_package(&self) -> Option<Symbol> {

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -368,6 +368,19 @@ impl GenericSymbolPath {
         SymbolPath::new(&path)
     }
 
+    pub fn slice(&self, i: usize) -> GenericSymbolPath {
+        let paths: Vec<_> = self.paths.clone().drain(0..=i).collect();
+        let range = TokenRange {
+            beg: paths.first().map(|x| x.base).unwrap(),
+            end: paths.last().map(|x| x.base).unwrap(),
+        };
+        GenericSymbolPath {
+            paths,
+            kind: self.kind,
+            range,
+        }
+    }
+
     pub fn mangled_path(&self) -> SymbolPath {
         let path: Vec<_> = self.paths.iter().map(|x| x.mangled()).collect();
         SymbolPath::new(&path)

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2180,3 +2180,58 @@ endmodule
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
 }
+
+#[test]
+fn bind_declaration() {
+    let code = r#"
+proto package ProtoPkg {
+}
+
+package Pkg::<A_VALUE: u32> for ProtoPkg {
+}
+
+module ModuleA::<PKG: ProtoPkg> {}
+
+module ModuleB::<PKG: ProtoPkg> {}
+
+alias module mod = ModuleC::<32>;
+
+module ModuleC::<A_VALUE: u32> {
+  alias package pkg = Pkg::<A_VALUE>;
+
+  bind ModuleA::<pkg> <- u: ModuleB::<pkg>;
+}
+"#;
+
+    let expect = r#"
+
+package prj___Pkg__32;
+endpackage
+
+module prj___ModuleA____Pkg__32;
+endmodule
+
+module prj___ModuleB____Pkg__32;
+endmodule
+
+
+module prj___ModuleC__32;
+
+
+    bind prj___ModuleA____Pkg__32 prj___ModuleB____Pkg__32 u ();
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata: Metadata =
+        toml::from_str(&Metadata::create_default_toml("prj").unwrap()).unwrap();
+
+    let ret = if cfg!(windows) {
+        emit(&metadata, code).replace("\r\n", "\n")
+    } else {
+        emit(&metadata, code)
+    };
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
+}


### PR DESCRIPTION
fix veryl-lang/veryl#1915

`generic_reference` includes original paths only but not unaliased paths.
https://github.com/veryl-lang/veryl/blob/474134043c9c010960d937ee79dc125460a0da0b/crates/analyzer/src/handlers/create_symbol_table.rs#L704

For the case of #1915, `ModuleA::<pkg>` and `ModuleB::<pkg>` are included but `ModuleA::<Pkg::<32>>` and `ModuleB::<Pkg::<32>>` are not.

Due to this, generic instance created from such unaliased path are not created and #1915 is happened.

To fix this error, unaliased paths should also be added to `generic_reference`.
https://github.com/taichi-ishitani/veryl/blob/32837a5c0fe055baf978edc0cde1a11f9f102725/crates/analyzer/src/reference_table.rs#L309