### PR TITLE
Fix the issue that filelist does not include SV files containing `embed` declaration only

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -753,6 +753,7 @@ pub enum SymbolKind {
     GenericInstance(GenericInstanceProperty),
     ClockDomain,
     Test(TestProperty),
+    Embed,
 }
 
 impl SymbolKind {
@@ -807,6 +808,7 @@ impl SymbolKind {
             SymbolKind::GenericInstance(_) => "generic instance".to_string(),
             SymbolKind::ClockDomain => "clock domain".to_string(),
             SymbolKind::Test(_) => "test".to_string(),
+            SymbolKind::Embed => "embed".to_string(),
         }
     }
 
@@ -1064,6 +1066,7 @@ impl fmt::Display for SymbolKind {
             SymbolKind::GenericInstance(_) => "generic instance".to_string(),
             SymbolKind::ClockDomain => "clock domain".to_string(),
             SymbolKind::Test(_) => "test".to_string(),
+            SymbolKind::Embed => "embed".to_string(),
         };
         text.fmt(f)
     }

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -692,7 +692,8 @@ impl SymbolTable {
                             | SymbolKind::SystemFunction(_)
                             | SymbolKind::Genvar
                             | SymbolKind::ClockDomain
-                            | SymbolKind::Test(_) => (),
+                            | SymbolKind::Test(_)
+                            | SymbolKind::Embed => (),
                         }
                     }
                 } else {

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -80,6 +80,7 @@ pub enum Context {
     Package,
     Modport,
     GenericInstance,
+    Embed,
 }
 
 #[derive(Debug, Clone)]
@@ -271,7 +272,9 @@ impl TypeDag {
             | SymbolKind::TypeDef(_)
             | SymbolKind::Struct(_)
             | SymbolKind::Union(_)
-            | SymbolKind::Function(_) => true,
+            | SymbolKind::Function(_)
+            | SymbolKind::Test(_)
+            | SymbolKind::Embed => true,
             SymbolKind::Parameter(ref x) => matches!(x.kind, ParameterKind::Const),
             _ => false,
         };

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -5795,7 +5795,8 @@ pub fn symbol_string(
         | SymbolKind::ProtoConst(_)
         | SymbolKind::ProtoTypeDef(_)
         | SymbolKind::ProtoFunction(_)
-        | SymbolKind::Test(_) => {
+        | SymbolKind::Test(_)
+        | SymbolKind::Embed => {
             unreachable!()
         }
     }

--- a/crates/languageserver/src/server.rs
+++ b/crates/languageserver/src/server.rs
@@ -438,6 +438,7 @@ impl Server {
                     VerylSymbolKind::GenericInstance(_) => SymbolKind::MODULE,
                     VerylSymbolKind::ClockDomain => SymbolKind::TYPE_PARAMETER,
                     VerylSymbolKind::Test(_) => SymbolKind::MODULE,
+                    VerylSymbolKind::Embed => SymbolKind::NAMESPACE,
                 };
                 let location = to_location(&symbol.token);
                 #[allow(deprecated)]

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -428,6 +428,7 @@ mod filelist {
             "10_package_g.veryl",
             "11_package_h.veryl",
             "12_alias_i.veryl",
+            "13_embed.veryl",
             "ram.veryl",
             "axi_pkg.veryl",
         ];
@@ -441,5 +442,6 @@ mod filelist {
         check_order(&paths, "09_module_f.veryl", "08_module_e.veryl");
         check_order(&paths, "10_package_g.veryl", "11_package_h.veryl");
         check_order(&paths, "axi_pkg.veryl", "12_alias_i.veryl");
+        check_order(&paths, "axi_pkg.veryl", "13_embed.veryl");
     }
 }

--- a/testcases/filelist/src/13_embed.veryl
+++ b/testcases/filelist/src/13_embed.veryl
@@ -1,0 +1,3 @@
+embed (inline) sv {{{
+    `define AXI_PKG \{ $std::axi4_pkg::<32, 4, 8, 1, 1, 1, 1, 1> \}
+}}}


### PR DESCRIPTION
fix veryl-lang/veryl#1918

Filelist is generated based on `symbol_table`.
If a file has no inserted symbols then filelist does not include such file.
This causes #1918.

To fix this, symbol showing `embed` declaration need to be inserted.