### PR TITLE
Fix emitting identifier with duplicated project prefix

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -5748,7 +5748,8 @@ pub fn symbol_string(
                 base.kind,
                 SymbolKind::Module(_) | SymbolKind::Interface(_) | SymbolKind::Package(_)
             );
-            if (scope_depth >= 2) | !visible | top_level {
+            let add_namespace = (scope_depth >= 2) | !visible | top_level;
+            if add_namespace {
                 ret.push_str(&namespace_string(
                     &symbol.namespace,
                     generic_tables,
@@ -5759,7 +5760,7 @@ pub fn symbol_string(
                 let name = symbol
                     .generic_maps()
                     .first()
-                    .map(|x| x.name(true, true))
+                    .map(|x| x.name(!add_namespace, true))
                     .unwrap();
                 ret.push_str(&name);
             } else {


### PR DESCRIPTION
fix veryl-lang/veryl#1935

`GenericMap::name` method is used to generate mangled name of a generic instance.
This method has a parameter used to specified whether or not generated name includes the project prefix.

When `hashed_mangled_name` is enabled, this method is used but wrong value: true is given to the above parameter although the project prefix is added manually.
The above parameter should be set to true only when the project prefix is not added.