### PR TITLE
Fix emitting member reference of const struct

### DIFF
--- a/crates/emitter/src/expaneded_modport.rs
+++ b/crates/emitter/src/expaneded_modport.rs
@@ -344,6 +344,7 @@ impl ExpandedModportPortTable {
                 let text = symbol_string(
                     namespace_token,
                     &interface_symbol,
+                    &interface_symbol.namespace,
                     &interface_path,
                     &interface_tables,
                     context,


### PR DESCRIPTION
fix veryl-lang/veryl#1937

Currenty, the emitter emits each path element, except for namespace and package, to emit struct member reference given as generic arg.
https://github.com/veryl-lang/veryl/blob/d0977734859953bdce2b1717b42ea3ac28f591e5/crates/emitter/src/emitter.rs#L5794-L5811

However,

* generic package instnace is not filtered
* inner namespace of generic package instnace should be emitted but namespace of generic package is actualy emitted
    * for case of #1937, `project_a_pkg`

Due to these, wrong package prefix is added to member reference of const struct.

To fix this issue, namespace of parent symbol of struct member should be replaced with inner namespace of generic package instnace.