### PR TITLE
Do `unassign_variable` with 1st assignment only

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5344,6 +5344,19 @@ fn unassign_variable() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::UnassignVariable { .. }));
+
+    let code = r#"
+    module ModuleA {
+        var a: logic;
+        always_comb {
+            a = 0;
+            a = a + 1;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1939

`unassign_variable` checks if there are any visible variable reference from an asssignment.
If there ara multiple assignments, the checker should check the 1st assignment only but, currently, checks all assingments.
Due to this, this is the cause of #1939.
