### PR TITLE
Fix insertion of dag edge between generic arg and base symbol

### DIFF
--- a/crates/analyzer/src/handlers/create_symbol_table.rs
+++ b/crates/analyzer/src/handlers/create_symbol_table.rs
@@ -611,6 +611,7 @@ impl CreateSymbolTable {
             let cand = TypeDagCandidate::Symbol {
                 id: symbol.0,
                 context: symbol.1,
+                project_namespace: self.project_namespace.clone(),
                 parent: None,
                 import,
             };

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -6704,16 +6704,21 @@ fn unresolvable_generic_argument() {
         struct Bar {
             bar: Baz
         }
-        function Func::<baz: Baz> {}
     }
     package PkgB {
         import PkgA::*;
         const FOO: Bar = Bar'{ bar: Baz'{ baz: 1 } };
     }
+    package PkgC {
+        import PkgA::*;
+        function Func::<baz: Baz> -> logic {
+            return baz.baz;
+        }
+    }
     module ModuleA {
         import PkgB::*;
         always_comb {
-            PkgA::Func::<PkgB::FOO.bar>();
+            PkgC::Func::<PkgB::FOO.bar>();
         }
     }
     "#;

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -444,6 +444,9 @@ mod filelist {
             "11_package_h.veryl",
             "12_alias_i.veryl",
             "13_embed.veryl",
+            "14_package_j.veryl",
+            "15_module_k.veryl",
+            "16_package_l.veryl",
             "ram.veryl",
             "axi_pkg.veryl",
         ];
@@ -458,5 +461,7 @@ mod filelist {
         check_order(&paths, "10_package_g.veryl", "11_package_h.veryl");
         check_order(&paths, "axi_pkg.veryl", "12_alias_i.veryl");
         check_order(&paths, "axi_pkg.veryl", "13_embed.veryl");
+        check_order(&paths, "14_package_j.veryl", "16_package_l.veryl");
+        check_order(&paths, "16_package_l.veryl", "15_module_k.veryl");
     }
 }

--- a/testcases/filelist/src/14_package_j.veryl
+++ b/testcases/filelist/src/14_package_j.veryl
@@ -1,0 +1,7 @@
+proto package ProtoPackageJ {
+  const J: u32;
+}
+
+package PackageJ::<V: u32> for ProtoPackageJ {
+  const J: u32 = V;
+}

--- a/testcases/filelist/src/15_module_k.veryl
+++ b/testcases/filelist/src/15_module_k.veryl
@@ -1,0 +1,6 @@
+module ModuleK::<PKG: ProtoPackageJ> {
+  const K: u32 = PackageL::<PKG>::L;
+}
+
+alias package J = PackageJ::<32>;
+alias module K = ModuleK::<J>;

--- a/testcases/filelist/src/16_package_l.veryl
+++ b/testcases/filelist/src/16_package_l.veryl
@@ -1,0 +1,3 @@
+package PackageL::<PKG: ProtoPackageJ> {
+  const L: u32 = PKG::J;
+}


### PR DESCRIPTION
fix veryl-lang/veryl#1954

DAG edges between generic arguments and base symbols may not be inserted.

Such dag edges will be inserted when processing symbol paths.
https://github.com/veryl-lang/veryl/blob/e69787d74f4823ce6b8e630626dd0ae904774c65/crates/analyzer/src/type_dag.rs#L230-L239
However, in the above code, generic map is gotten from the parent of type dag but not parent scope.
For example, the code below is from example code of #1954. Used generic map when processing `c_pkg::<A_PKG>::C` is empty becuase its dag parent is `const B` but not `b_module`. Due to this, type dag between c_pkg and a_pkg is not inserted.

```
module b_module::<A_PKG: a_proto_pkg> {
    const B: u32 = c_pkg::<A_PKG>::C;
}
```

Relashionship between generic args and base symbol have already been created and we can get them by using `Symbol::generic_maps` method.
By using result of this method, we can insert correct dag edges between generic arg and base symbol.
https://github.com/taichi-ishitani/veryl/blob/9470c8660b9cb9f71e208c6a2ac199e1c9e44c01/crates/analyzer/src/type_dag.rs#L149-L159