### PR TITLE
Fix syntax error on `bool` keyword in generic param list

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3118,6 +3118,17 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package FooPkg::<A: bool = true, B: bool = false> {
+    }
+    module BarModule {
+        import FooPkg::<false, true>::*;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/parser/src/generated/veryl-exp.par
+++ b/crates/parser/src/generated/veryl-exp.par
@@ -94,7 +94,7 @@
 /*   56 */ AsTerm: 'as' : Token;
 /*   57 */ BindTerm: 'bind' : Token;
 /*   58 */ BitTerm: 'bit' : Token;
-/*   59 */ BoolTerm: 'bool' : Token;
+/*   59 */ BoolTerm: <INITIAL, Generic>'bool' : Token;
 /*   60 */ CaseTerm: 'case' : Token;
 /*   61 */ ClockTerm: 'clock' : Token;
 /*   62 */ ClockPosedgeTerm: 'clock_posedge' : Token;

--- a/crates/parser/src/generated/veryl_grammar_trait.rs
+++ b/crates/parser/src/generated/veryl_grammar_trait.rs
@@ -15660,7 +15660,7 @@ impl<'t, 'u> VerylGrammarAuto<'t, 'u> {
 
     /// Semantic action for production 59:
     ///
-    /// `BoolTerm: 'bool' : Token;`
+    /// `BoolTerm: <INITIAL, Generic>'bool' : Token;`
     ///
     #[parol_runtime::function_name::named]
     fn bool_term(&mut self, bool_term: &ParseTreeType<'t>) -> Result<()> {

--- a/crates/parser/src/generated/veryl_parser.rs
+++ b/crates/parser/src/generated/veryl_parser.rs
@@ -343,6 +343,7 @@ scanner! {
             token r"\." => 36; // "DotTerm"
             token r"=" => 37; // "EquTerm"
             token r">" => 49; // "RAngleTerm"
+            token r"bool" => 64; // "BoolTerm"
             token r"f32" => 76; // "F32Term"
             token r"f64" => 77; // "F64Term"
             token r"false" => 78; // "FalseTerm"

--- a/crates/parser/veryl.par
+++ b/crates/parser/veryl.par
@@ -112,7 +112,7 @@ AssignTerm            : <INITIAL                                                
 AsTerm                : <INITIAL                                                      >'as'                                                                                  : Token; // Keyword: Statement
 BindTerm              : <INITIAL                                                      >'bind'                                                                                : Token; // Keyword: Statement
 BitTerm               : <INITIAL                                                      >'bit'                                                                                 : Token; // Keyword: Type
-BoolTerm              : <INITIAL                                                      >'bool'                                                                                : Token; // Keyword: Type
+BoolTerm              : <INITIAL, Generic                                             >'bool'                                                                                : Token; // Keyword: Type
 CaseTerm              : <INITIAL                                                      >'case'                                                                                : Token; // Keyword: Conditional
 ClockTerm             : <INITIAL                                                      >'clock'                                                                               : Token; // Keyword: Type
 ClockPosedgeTerm      : <INITIAL                                                      >'clock_posedge'                                                                       : Token; // Keyword: Type


### PR DESCRIPTION
Due to #1957, `bool` keyword can't be used in generic param list.

```
Error:   × veryl check failed

Error: undefined_identifier (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#undefined_identifier)

  × bool is undefined
    ╭─[/home/ishitani/workspace/pzdma/hw/rtl/pzbcm/pzbcm/rtl/pzcorebus_common/pzcorebus_pkg.veryl:75:25]
 74 │   DATA_WIDTH          : u16                                    ,
 75 │   USE_BYTE_ENABLE     : bool                                   ,
    ·                         ──┬─
    ·                           ╰── Error location
 76 │   MAX_LENGTH          : u16                                    ,
    ╰────
  help:
```

This PR fixes this syntax error.