### PR TITLE
Change name of VSCode extension

### DIFF
--- a/support/vscode/CHANGELOG.md
+++ b/support/vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "vscode-veryl" extension will be documented in this file.
+All notable changes to the "veryl-vscode" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/support/vscode/README.md
+++ b/support/vscode/README.md
@@ -1,10 +1,10 @@
 # [Veryl](https://veryl-lang.org) extension for Visual Studio Code
 
-![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/veryl-lang.vscode-veryl)
-![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/veryl-lang.vscode-veryl)
-![Visual Studio Marketplace Release Date](https://img.shields.io/visual-studio-marketplace/release-date/veryl-lang.vscode-veryl)
+![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/veryl-lang.veryl-vscode)
+![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/veryl-lang.veryl-vscode)
+![Visual Studio Marketplace Release Date](https://img.shields.io/visual-studio-marketplace/release-date/veryl-lang.veryl-vscode)
 
-[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=veryl-lang.vscode-veryl)
+[Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=veryl-lang.veryl-vscode)
 
 This extension adds language support for Veryl to Visual Studio Code.
 It supports:

--- a/support/vscode/package-lock.json
+++ b/support/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vscode-veryl",
-  "version": "0.16.4",
+  "name": "veryl-vscode",
+  "version": "0.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-veryl",
-      "version": "0.16.4",
+      "name": "veryl-vscode",
+      "version": "0.16.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/support/vscode/package.json
+++ b/support/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-veryl",
+  "name": "veryl-vscode",
   "displayName": "Veryl",
   "description": "Veryl extension for Visual Studio Code",
   "version": "0.16.5",
@@ -28,9 +28,9 @@
   "contributes": {
     "commands": [
       {
-        "command": "vscode-veryl.restartServer",
+        "command": "veryl-vscode.restartServer",
         "title": "Restart language server",
-        "category": "vscode-veryl"
+        "category": "veryl-vscode"
       },
       {
         "command": "waveformRender.start",
@@ -67,7 +67,7 @@
       {
         "title": "Veryl Language Server",
         "properties": {
-          "vscode-veryl.verylLsBinary.path": {
+          "veryl-vscode.verylLsBinary.path": {
             "scope": "window",
             "type": [
               "string",

--- a/support/vscode/src/extension.ts
+++ b/support/vscode/src/extension.ts
@@ -20,7 +20,7 @@ let client: LanguageClient;
 function startServer(context: vscode.ExtensionContext) {
 	let verylLsIntegrated = context.asAbsolutePath(path.join('bin', 'veryl-ls'));
 
-	let verylLsBinaryPath: string | undefined = workspace.getConfiguration("vscode-veryl").get("verylLsBinary.path");
+	let verylLsBinaryPath: string | undefined = workspace.getConfiguration("veryl-vscode").get("verylLsBinary.path");
 	if (typeof verylLsBinaryPath === "undefined") {
 		verylLsBinaryPath = verylLsIntegrated;
 	} else if (verylLsBinaryPath === null) {
@@ -65,10 +65,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "vscode-veryl" is now active!');
+	console.log('Congratulations, your extension "veryl-vscode" is now active!');
 
 	context.subscriptions.push(
-		commands.registerCommand("vscode-veryl.restartServer", () => {
+		commands.registerCommand("veryl-vscode.restartServer", () => {
 			stopServer().then(function () {startServer(context);}, startServer);
 		})
 	);


### PR DESCRIPTION
Ref #1966 

VSCode extension which has the same name of the existing extension is not allowed.
https://github.com/microsoft/vsmarketplace/issues/504