### PR TITLE
Fix filelist order

### DIFF
--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -447,6 +447,11 @@ mod filelist {
             "14_package_j.veryl",
             "15_module_k.veryl",
             "16_package_l.veryl",
+            "17_package_m.veryl",
+            "18_package_n.veryl",
+            "19_package_o.veryl",
+            "20_module_p.veryl",
+            "21_alias_q.veryl",
             "ram.veryl",
             "axi_pkg.veryl",
         ];
@@ -463,5 +468,9 @@ mod filelist {
         check_order(&paths, "axi_pkg.veryl", "13_embed.veryl");
         check_order(&paths, "14_package_j.veryl", "16_package_l.veryl");
         check_order(&paths, "16_package_l.veryl", "15_module_k.veryl");
+        check_order(&paths, "17_package_m.veryl", "18_package_n.veryl");
+        check_order(&paths, "18_package_n.veryl", "19_package_o.veryl");
+        check_order(&paths, "19_package_o.veryl", "20_module_p.veryl");
+        check_order(&paths, "20_module_p.veryl", "21_alias_q.veryl");
     }
 }

--- a/testcases/filelist/src/17_package_m.veryl
+++ b/testcases/filelist/src/17_package_m.veryl
@@ -1,0 +1,5 @@
+package PackageM {
+  enum enum_m: u32 {
+    M,
+  }
+}

--- a/testcases/filelist/src/18_package_n.veryl
+++ b/testcases/filelist/src/18_package_n.veryl
@@ -1,0 +1,10 @@
+proto package ProtoPackageN {
+    function func_n() -> u32;
+}
+
+package PackageN::<V: u32> for ProtoPackageN {
+    function func_n() -> u32 {
+        let m: u32 = PackageM::enum_m::M;
+        return V + m;
+    }
+}

--- a/testcases/filelist/src/19_package_o.veryl
+++ b/testcases/filelist/src/19_package_o.veryl
@@ -1,0 +1,5 @@
+package PackageO::<N_PKG: ProtoPackageN> {
+    function func_o() -> u32 {
+        return N_PKG::func_n();
+    }
+}

--- a/testcases/filelist/src/20_module_p.veryl
+++ b/testcases/filelist/src/20_module_p.veryl
@@ -1,0 +1,6 @@
+module ModuleP::<N_PKG: ProtoPackageN> {
+    function func_p() -> u32 {
+        return PackageO::<N_PKG>::func_o();
+    }
+    let _p: u32 = func_p();
+}

--- a/testcases/filelist/src/21_alias_q.veryl
+++ b/testcases/filelist/src/21_alias_q.veryl
@@ -1,0 +1,2 @@
+alias package N = PackageN::<1>;
+alias module  P = ModuleP::<N>;


### PR DESCRIPTION
fix veryl-lang/veryl#1971

For the above example, type dag between `c_pkd` and `d_module` is like below.
<img width="208" height="151" alt="image" src="https://github.com/user-attachments/assets/9c0419d1-8006-4efa-90dc-31c2fa29ae02" />
Therefore, there is no edge bteween them. This caues #1971.

To resolve this issue, need to insert edge between `c_pkg` and `d_module` instead of `d_module::D` like #1628.