### PR TITLE
Fix panic happened during executing `resolve_user_defined`

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -390,16 +390,28 @@ impl Symbol {
     }
 
     pub fn generic_table(&self, arguments: &[GenericSymbolPath]) -> GenericTable {
-        let generic_parameters = self.generic_parameters();
+        let params = self.generic_parameters();
+        let n_args = arguments.len();
         let mut ret = HashMap::default();
 
+        let match_arity = if params.len() > n_args {
+            params[n_args].1.default_value.is_some()
+        } else {
+            params.len() == n_args
+        };
+        if !match_arity {
+            // Too many or too few generic args are given.
+            // Return empty generic table.
+            return ret;
+        }
+
         for (i, arg) in arguments.iter().enumerate() {
-            if let Some((p, _)) = generic_parameters.get(i) {
+            if let Some((p, _)) = params.get(i) {
                 ret.insert(*p, arg.clone());
             }
         }
 
-        for param in generic_parameters.iter().skip(arguments.len()) {
+        for param in params.iter().skip(n_args) {
             ret.insert(param.0, param.1.default_value.as_ref().unwrap().clone());
         }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1378,6 +1378,24 @@ fn mismatch_generics_arity() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    interface a_if::<W: u32> {
+        var a: logic<W>;
+        modport mp {
+            a: input
+        }
+    }
+    module b_module (
+        aif: modport a_if::mp,
+    ){}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::MismatchGenericsArity { .. }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#1980

Veryl compiler will panic during creating a generic table if less generic args are given.
Due to this, Veryl compiler is paniced before checking arity of generic args.
https://github.com/veryl-lang/veryl/blob/580947b5fb380605dfefa3dd52e74b72f19cd651/crates/analyzer/src/symbol.rs#L403

To avoid this issue, an empty generic table will be returned if arity of generic args is mismatched.
