### PR TITLE
Change visibility of `fifo_contoller` to `public`

### DIFF
--- a/crates/std/veryl/src/fifo/fifo_controller.veryl
+++ b/crates/std/veryl/src/fifo/fifo_controller.veryl
@@ -1,4 +1,4 @@
-module fifo_controller #(
+pub module fifo_controller #(
     param TYPE             : type = logic                                    ,
     param DEPTH            : u32  = 8                                        ,
     param THRESHOLD        : u32  = DEPTH                                    ,


### PR DESCRIPTION
This module is required to re-write [pzbcm_sram_fifo](https://github.com/pezy-computing/pzbcm/blob/774f8a5df860c2ba572ac472d8eb3606e645bd69/pzbcm_sram_fifo/pzbcm_sram_fifo.sv#L560) in Veryl.
