### PR TITLE
Fix unexpected `unknown_member` error

### DIFF
--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -751,6 +751,12 @@ impl SymbolTable {
         }
 
         let mut namespace = namespace.clone();
+
+        // Remove anonymous blocks
+        namespace
+            .paths
+            .retain(|x| x.to_string().find('@').is_none());
+
         let path = namespace.pop().map(|x| SymbolPath::new(&[x]))?;
         let context = ResolveContext::new(&namespace);
         let params = self

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4762,6 +4762,37 @@ fn unknown_member() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package foo_proto_pkg {
+        const WIDTH: u32;
+        struct foo_struct {
+        foo: logic<WIDTH>,
+        }
+    }
+    package foo_pkg::<W: u32> for foo_proto_pkg {
+        const WIDTH: u32 = W;
+        struct foo_struct {
+        foo: logic<WIDTH>,
+        }
+    }
+    interface foo_if::<PKG: foo_proto_pkg> {
+        var foo: PKG::foo_struct;
+        modport mp {
+            foo: input,
+        }
+    }
+    module foo_module::<PKG: foo_proto_pkg> {
+        inst foo: foo_if::<PKG>;
+        var _foo: logic;
+        always_comb {
+            _foo = foo.foo.foo;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2009

Namespace associated with an identifier referenced in a `always_comb` block includes anonymous block names.
For the sample code of the issue, namespace associated with `foo.foo.foo` is `foo_module@1`.

However, namespace associated with generic map does not include them. 
https://github.com/veryl-lang/veryl/blob/de9d71addc85110cd259148b18f0d3e178edf1bb/crates/analyzer/src/symbol_table.rs#L748
This differnece causes #2009.

To fix this issue, remove anonymous block names from the namespace given to the above function.