### PR TITLE
Fix unexpected modport mismatch error

### DIFF
--- a/crates/analyzer/src/handlers/check_expression.rs
+++ b/crates/analyzer/src/handlers/check_expression.rs
@@ -142,7 +142,7 @@ impl CheckExpression {
                     let dst_interface = symbol_table::get(dst.interface).unwrap();
                     if let EvaluatedType::UserDefined(src) = &src.r#type {
                         let src_symbol = symbol_table::get(src.symbol).unwrap();
-                        if dst.interface != src.symbol {
+                        if !Self::match_interface(&dst_interface, &src_symbol) {
                             self.errors.push(AnalyzerError::mismatch_assignment(
                                 &format!("instance of {}", src_symbol.token),
                                 &format!("modport of {}", dst_interface.token),
@@ -165,6 +165,14 @@ impl CheckExpression {
         }
 
         src
+    }
+
+    fn match_interface(dst: &Symbol, src: &Symbol) -> bool {
+        if matches!(dst.kind, SymbolKind::ProtoInterface(_)) {
+            src.proto().map(|x| x.id == dst.id).unwrap_or(false)
+        } else {
+            src.id == dst.id
+        }
     }
 
     fn check_inst(&mut self, arg: &ComponentInstantiation) {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3390,6 +3390,58 @@ fn mismatch_assignment() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto interface ProtoA {
+        const WIDTH: u32;
+
+        var ready: logic       ;
+        var valid: logic       ;
+        var data : logic<WIDTH>;
+
+        function ack() -> logic ;
+
+        modport master {
+            ready: input ,
+            valid: output,
+            data : output,
+            ack  : import,
+        }
+    }
+    interface InterfaceA::<W: u32> for ProtoA {
+        const WIDTH: u32 = W;
+
+        var ready: logic       ;
+        var valid: logic       ;
+        var data : logic<WIDTH>;
+
+        function ack () -> logic {
+            return ready && valid;
+        }
+
+        modport master {
+            ready: input ,
+            valid: output,
+            data : output,
+            ack  : import,
+        }
+    }
+    module ModuleA::<BUS_IF: ProtoA> (
+        bus_if: modport BUS_IF::master,
+    ) {
+        connect bus_if <> 0;
+    }
+    module ModuleB {
+        inst bus_if: InterfaceA::<8>;
+
+        inst u: ModuleA::<InterfaceA::<8>> (
+            bus_if: bus_if,
+        );
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2053

Before merging #2045, connections between interface instance and modport in generic module instance declaration were not checked because the result of the symbol resolution below is generic instance.
After #2045, the above symbol resolution returns `module` and then #2053 is appered.

