### PR TITLE
Simplify generic reference resolution

### DIFF
--- a/crates/analyzer/src/namespace.rs
+++ b/crates/analyzer/src/namespace.rs
@@ -150,6 +150,10 @@ impl Namespace {
         self.paths = paths;
     }
 
+    pub fn strip_anonymous_path(&mut self) {
+        self.paths.retain(|x| x.to_string().find('@').is_none());
+    }
+
     pub fn get_symbol(&self) -> Option<Symbol> {
         let mut namespace = self.clone();
         if let Some(path) = namespace.pop()

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -488,6 +488,22 @@ impl Symbol {
         }
     }
 
+    pub fn has_generic_paramters(&self) -> bool {
+        match &self.kind {
+            SymbolKind::Function(x) => !x.generic_parameters.is_empty(),
+            SymbolKind::Module(x) => !x.generic_parameters.is_empty(),
+            SymbolKind::Interface(x) => !x.generic_parameters.is_empty(),
+            SymbolKind::Package(x) => !x.generic_parameters.is_empty(),
+            SymbolKind::Struct(x) => !x.generic_parameters.is_empty(),
+            SymbolKind::Union(x) => !x.generic_parameters.is_empty(),
+            SymbolKind::GenericInstance(x) => {
+                let symbol = symbol_table::get(x.base).unwrap();
+                symbol.has_generic_paramters()
+            }
+            _ => false,
+        }
+    }
+
     pub fn generic_references(&self) -> Vec<GenericSymbolPath> {
         let references = match &self.kind {
             SymbolKind::Function(x) => &x.generic_references,

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -754,11 +754,7 @@ impl SymbolTable {
         }
 
         let mut namespace = namespace.clone();
-
-        // Remove anonymous blocks
-        namespace
-            .paths
-            .retain(|x| x.to_string().find('@').is_none());
+        namespace.strip_anonymous_path();
 
         let path = namespace.pop().map(|x| SymbolPath::new(&[x]))?;
         let context = ResolveContext::new(&namespace);
@@ -864,6 +860,7 @@ impl SymbolTable {
         let project_path = GenericSymbol {
             base: project_symbol.token,
             arguments: vec![],
+            is_member_reference: false,
         };
 
         let mut path = path.clone();


### PR DESCRIPTION
fix #2056 

Currenlty, generic referecnes are resolved when all generic args are applied.
However, generic parameters are typed by `proto` type so symbol resulutions can be done with generic parameters before appplying generic args.

This PR is to simplify generic reference resolution:

* Resolving symbol path even if it includes unresolived generic parameters
    * symbol path resolution is done with `proto` boundary
* Split resolving symbol path and inserting generic instance
    * generic instance is inserted recursibly when all generic args are applied

Changes in this PR also fixes #2056.