### PR TITLE
Fix reference error related to pacakge alias defined in package

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -311,9 +311,7 @@ impl ReferenceTable {
                     }
 
                     for arg in args.iter_mut() {
-                        if let Some(unaliased_arg) = arg.unaliased_path() {
-                            *arg = unaliased_arg;
-                        }
+                        arg.unalias();
                         arg.append_project_path(namespace, &target_namespace);
                     }
 

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -419,9 +419,10 @@ impl SymbolTable {
             _ => false,
         };
         let via_pacakge = match &last_found.kind {
-            SymbolKind::Package(_) | SymbolKind::ProtoPackage(_) | SymbolKind::AliasPackage(_) => {
-                true
-            }
+            SymbolKind::Package(_)
+            | SymbolKind::ProtoPackage(_)
+            | SymbolKind::AliasPackage(_)
+            | SymbolKind::ProtoAliasPackage(_) => true,
             SymbolKind::GenericInstance(_) => {
                 matches!(last_found_type, Some(SymbolKind::Package(_)))
             }
@@ -860,7 +861,6 @@ impl SymbolTable {
         let project_path = GenericSymbol {
             base: project_symbol.token,
             arguments: vec![],
-            is_member_reference: false,
         };
 
         let mut path = path.clone();

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4072,6 +4072,27 @@ fn invisible_identifier() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package a_proto_pkg {
+        const A_TYPE: type;
+    }
+    package a_pkg::<a_type: type> for a_proto_pkg {
+        const A_TYPE: type = a_type;
+    }
+    proto package b_proto_pkg {
+        alias package A_PKG: a_proto_pkg;
+    }
+    package b_pkg::<a_type: type> for b_proto_pkg {
+        alias package A_PKG = a_pkg::<a_type>;
+    }
+    module c_module::<B_PKG: b_proto_pkg> {
+        let _c: B_PKG::A_PKG::A_TYPE = 0;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -5922,7 +5922,12 @@ pub fn resolve_generic_path(
     generic_maps: Option<&Vec<GenericMap>>,
 ) -> (Result<ResolveResult, ResolveError>, GenericSymbolPath) {
     let mut path = path.clone();
+
     path.resolve_imported(namespace, generic_maps);
+    if let Some(maps) = generic_maps {
+        path.apply_map(maps);
+    }
+    path.unalias();
 
     let path_symbols: Vec<_> = (0..path.len())
         .filter_map(|i| {
@@ -5938,15 +5943,9 @@ pub fn resolve_generic_path(
             let n_args = path.paths[*i].arguments.len();
 
             for param in params.iter().skip(n_args) {
-                path.paths[*i]
-                    .arguments
-                    .push(param.1.default_value.as_ref().unwrap().clone());
-            }
-
-            for arg in &mut path.paths[*i].arguments {
-                if let Some(unaliased_arg) = arg.unaliased_path() {
-                    *arg = unaliased_arg;
-                }
+                let mut arg = param.1.default_value.as_ref().unwrap().clone();
+                arg.unalias();
+                path.paths[*i].arguments.push(arg);
             }
         }
     }


### PR DESCRIPTION
fix veryl-lang/veryl#2070

For the 1st issue.
In the current implementation, proto package alias is not treated as package when checking visiblity. Due to this, wrong `invisible_identifier` error is reported when resolving symbol path including proto package alias in the middle.

For the 2nd issue.
In the current implmementation, symbol path whose head symbol is proto pacakge alias imported from proto package is not unaliased.
(Example: `PROTO_PKG_ALIAS::A_CONST`)
In addition, `resolve_imported` for the such symbol path is failed because the current implementation checks if the given symbol path is imported by using result of symbol resolution with the whole given path.
Due to these, such path is not unaliaed and emitter is paniced during emitting it.

To fix this issue:

* not unalias generic arg only but also whole the given path
    * https://github.com/taichi-ishitani/veryl/blob/4a12fa04d8d079dbca6e666b33c506200844d4d6/crates/emitter/src/emitter.rs#L5930
* change target symbol path of `resolve_imported` to head symbol only
    * https://github.com/taichi-ishitani/veryl/blob/4a12fa04d8d079dbca6e666b33c506200844d4d6/crates/analyzer/src/symbol_path.rs#L710
