### PR TITLE
Treat generic arg defined in namespace same with the namespace of generic reference as unresolvable generic arg

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -7321,6 +7321,22 @@ fn unresolvable_generic_argument() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package PkgA::<V: u32> {
+        const A: u32 = V;
+    }
+    package PkgB {
+        const B: u32 = 32;
+        const A: u32 = PkgA::<B>::A;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::UnresolvableGenericArgument { .. }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2073

```systemverilog
package PkgA::<V: u32> {
    const A: u32 = V;
}
package PkgB {
    const B: u32 = 32;
    const A: u32 = PkgA::<B>::A;
}
```

For the above example, `PkgA` depends on `PkgB::B` and `PkgB` depends on `PkgA` so these packages are depended cyclicly.
However, no errors are reported.

This PR is to make generic arg `B` to be treated unresolved generic arg.