### PR TITLE
Exclude $std from check mode of build

### DIFF
--- a/crates/veryl/src/cmd_build.rs
+++ b/crates/veryl/src/cmd_build.rs
@@ -134,7 +134,9 @@ impl CmdBuild {
                     std::fs::create_dir_all(dst.parent().unwrap()).into_diagnostic()?;
                 }
 
-                if self.opt.check {
+                let exclude_check = context.path.prj == "$std";
+
+                if self.opt.check && !exclude_check {
                     let output = fs::read_to_string(&dst).unwrap_or(String::new());
                     if output != emitter.as_str() {
                         if !quiet {


### PR DESCRIPTION
`veryl build --check` checks build artifact's differences, but std library changes cause unexpected large differences.
This PR exclude std library from the check mode.