### PR TITLE
Fix issue that cyclic dependency in generic reference may not be detected

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -544,6 +544,38 @@ fn cyclic_type_dependency() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package PkgA::<V: u32> {
+        const A: u32 = V;
+    }
+    package PkgB {
+        const B: u32 = 32;
+        const A: u32 = PkgA::<B>::A;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::CyclicTypeDependency { .. }
+    ));
+
+    let code = r#"
+    package PkgA::<V: u32> {
+        const A: u32 = V;
+    }
+    package PkgB {
+        const B: u32 = 32;
+        alias package PKG = PkgA::<B>;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::CyclicTypeDependency { .. }
+    ));
 }
 
 #[test]

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -5956,7 +5956,7 @@ pub fn resolve_generic_path(
 
     for (i, symbol) in &path_symbols {
         for arg in &mut path.paths[*i].arguments {
-            arg.append_project_path(namespace, &symbol.namespace);
+            arg.append_namespace_path(namespace, &symbol.namespace);
         }
     }
 


### PR DESCRIPTION
fix veryl-lang/veryl#2073

```systemverilog
package PkgA::<V: u32> {
    const A: u32 = V;
}
package PkgB {
    const B: u32 = 32;
    const A: u32 = PkgA::<B>::A;
}
```

For the above example, `PkgA` depends on `PkgB::B` and `PkgB` depends on `PkgA` so these packages are depended cyclicly.
`B` is not visible from `PkgA` because `B` has no package prefix. Due to this, cyclic dependency between these is not tested.
https://github.com/veryl-lang/veryl/blob/8c6a0e17c1a3ca2f0be377b00adeb1e053c8d73f/crates/analyzer/src/type_dag.rs#L219

To fix this error, we need to add the package prefix to `B` to make `B` visible from `PkgA`.
Then dependency check between `PkgA` and `B` will be tested.