### PR TITLE
Fix `unknown_member` error caused by package alias

### DIFF
--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -132,16 +132,23 @@ impl AnalyzerPass3 {
                 ));
             }
         }
-        let mut assignable_list: Vec<_> = assignable_list.iter().map(|x| (x, vec![])).collect();
+        let mut assignable_list: Vec<_> = assignable_list
+            .iter()
+            .map(|x| (x, x.proto_path(), vec![]))
+            .collect();
         for assign in &assign_list {
+            let assign_proto_path = assign.path.proto_path();
             for assignable in &mut assignable_list {
-                if assignable.0.included(&assign.path) {
-                    assignable.1.push((assign.position.clone(), assign.partial));
+                if assignable.0.included(&assign.path)
+                    || assignable.1.included(&assign.path)
+                    || assignable.0.included(&assign_proto_path)
+                {
+                    assignable.2.push((assign.position.clone(), assign.partial));
                 }
             }
         }
 
-        for (path, positions) in &assignable_list {
+        for (path, _, positions) in &assignable_list {
             if positions.is_empty() {
                 let full_path = path.full_path();
                 let symbol = symbol_table::get(*full_path.first().unwrap()).unwrap();

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -154,7 +154,7 @@ impl SymbolTable {
 
             let mut path = x.path.clone();
             path.resolve_imported(&context.namespace, None);
-
+            path.unalias();
             let symbol = self.resolve(
                 &path.generic_path(),
                 &path.generic_arguments(),
@@ -674,6 +674,7 @@ impl SymbolTable {
                             SymbolKind::Instance(x) => {
                                 let mut type_name = x.type_name.clone();
                                 type_name.resolve_imported(&context.namespace, None);
+                                type_name.unalias();
                                 context = self.trace_type_path(context, &type_name)?;
                             }
                             SymbolKind::GenericInstance(_) => {


### PR DESCRIPTION
fix veryl-lang/veryl#2081

For the added test code, `unknown_member` error is reported during resolving type of `_b.b` and `_c.c`.
* https://github.com/taichi-ishitani/veryl/blob/fe14e91ca05d8c7b9c7b595808f5e724a50f2ad5/crates/analyzer/src/tests.rs#L5021
* https://github.com/taichi-ishitani/veryl/blob/fe14e91ca05d8c7b9c7b595808f5e724a50f2ad5/crates/analyzer/src/tests.rs#L5023

These variables are typed by a type imported from package alias `A_PKG` so symbol paths to these types include pacakge alias given as generic arg.
To resove such type, **unalias** is needed but it is not executed.
As a result, resolving such symbol path is faield and `unknown_member` error is reported.

After inserting `unalias`, `unassigned_variable` error is reported for `_b.b.a`.
The type resolved from its declaration is `a_struct` defined in the proto package `a_proto_pkg`. On the other hand, the type resolved from its reference is `a_struct` defined in the package `a_pkg`.
Therefore, paths generated from the declaration and the refrence are treated as diffrent paths becuase two symbols are diffrent.
* https://github.com/veryl-lang/veryl/blob/c6eb363b6213cf151b9c7968d3962ca2430dd33f/crates/analyzer/src/var_ref.rs#L316
* https://github.com/veryl-lang/veryl/blob/c6eb363b6213cf151b9c7968d3962ca2430dd33f/crates/analyzer/src/analyzer.rs#L138
As a result, `unassigned_variable` error is reported.
To resolve this issue, we need to trace a symbol defined in a proto component from a symbol defined in its implementation.