### PR TITLE
Fix the issue that modport default members may not be linked

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5125,6 +5125,31 @@ fn unknown_member() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    interface a_if {
+        var a: u32;
+        function f() -> u32 {
+            var a: u32;
+            a = 0;
+            return a;
+        }
+        modport master {
+            a: output,
+        }
+        modport slave {
+            ..converse(master)
+        }
+    }
+    module b_module (
+        aif: modport a_if::slave,
+    ) {
+        let _b: u32 = aif.a;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2101

Default modport members are expaned according to `variables_ids`.
https://github.com/veryl-lang/veryl/blob/a516eafc53d87495d300934b1e8bdb5b7c253d4e/crates/analyzer/src/handlers/create_symbol_table.rs#L501-L514

Therefore, `variable_ids` should only contain variable symbols defined directly under the interface declaration but contains also symbols defined under other locations.
This causes #2101.
