### PR TITLE
Use `sources` instead of `source` in default TOML

### DIFF
--- a/crates/metadata/src/metadata.rs
+++ b/crates/metadata/src/metadata.rs
@@ -377,7 +377,7 @@ impl Metadata {
 name = "{name}"
 version = "0.1.0"
 [build]
-source = "src"
+sources = ["src"]
 target = {{type = "directory", path = "target"}}"###
         ))
     }


### PR DESCRIPTION
The deprecated `source` entry is used for the default TOML generated by `veryl init` and `veryl new`.
This PR changes it to `sources`.

Ref: https://github.com/veryl-lang/veryl/issues/1746 