### PR TITLE
Fix issue where unnecessary generic function instances are emitted

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -2358,6 +2358,7 @@ pub struct GenericParameterProperty {
 pub struct GenericInstanceProperty {
     pub base: SymbolId,
     pub arguments: Vec<GenericSymbolPath>,
+    pub affiliation_symbol: Option<SymbolId>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -347,13 +347,23 @@ impl GenericSymbol {
         }
     }
 
-    pub fn get_generic_instance(&self, base: &Symbol) -> Option<(Token, Symbol)> {
+    pub fn get_generic_instance(
+        &self,
+        base: &Symbol,
+        affiliation_symbol: Option<&Symbol>,
+    ) -> Option<(Token, Symbol)> {
         if self.arguments.is_empty() {
             None
         } else {
+            let affiliation_id = if let Some(symbol) = affiliation_symbol {
+                Some(symbol.id)
+            } else {
+                base.get_parent().map(|parent| parent.id)
+            };
             let property = GenericInstanceProperty {
                 base: base.id,
                 arguments: self.arguments.clone(),
+                affiliation_symbol: affiliation_id,
             };
             let kind = SymbolKind::GenericInstance(property);
             let token = &self.base;

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -2021,13 +2021,12 @@ impl Emitter {
             .filter(|x| {
                 if let Some(id) = x.id {
                     let symbol = symbol_table::get(id).unwrap();
-                    let parent = symbol.get_parent().unwrap();
-                    if matches!(parent.kind, SymbolKind::GenericInstance(_)) {
-                        parent_id == parent.id
+                    if let SymbolKind::GenericInstance(x) = symbol.kind
+                        && let Some(affiliation_symbol) = x.affiliation_symbol
+                    {
+                        affiliation_symbol == parent_id
                     } else {
-                        // If the symbol is a generic instance and used in the definition scope
-                        // it belongs to the base object of the parent even if the parent is a generic object.
-                        true
+                        unreachable!()
                     }
                 } else {
                     true

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2445,15 +2445,27 @@ module ModuleA::<PKG: ProtoPkgA> {
     let _w: u32 = func::<A>();
 }
 module ModuleB {
-    inst u_a: ModuleA::<PkgA::<32>>;
+    inst u_a: ModuleA::<PkgA::<16>>;
+    inst u_b: ModuleA::<PkgA::<32>>;
 }
 "#;
 
     let expect = r#"
 
+package prj___PkgA__16;
+    typedef logic [16-1:0] A;
+endpackage
 package prj___PkgA__32;
     typedef logic [32-1:0] A;
 endpackage
+module prj___ModuleA____PkgA__16;
+    import prj___PkgA__16::*;
+
+    function automatic int unsigned __func____PkgA__16_A() ;
+        return $bits(prj___PkgA__16::A);
+    endfunction
+    int unsigned _w; always_comb _w = __func____PkgA__16_A();
+endmodule
 module prj___ModuleA____PkgA__32;
     import prj___PkgA__32::*;
 
@@ -2463,7 +2475,8 @@ module prj___ModuleA____PkgA__32;
     int unsigned _w; always_comb _w = __func____PkgA__32_A();
 endmodule
 module prj_ModuleB;
-    prj___ModuleA____PkgA__32 u_a ();
+    prj___ModuleA____PkgA__16 u_a ();
+    prj___ModuleA____PkgA__32 u_b ();
 endmodule
 //# sourceMappingURL=test.sv.map
 "#;


### PR DESCRIPTION
fix veryl-lang/veryl#2161

Currently, generic functions used in the component where they are defined are linked to base component of the component even if the component is generic.
In the example showed in #2161, `func` is linked with the base of `b_if`.

Due to this and the code below,
https://github.com/veryl-lang/veryl/blob/f63dc84c1790739ed271c34c557c5f4b0f8a37fc/crates/emitter/src/emitter.rs#L2027-L2029
all instnaces of the such functions are emitted into all instnace of such components.

To fix this issue, generic instance should be linked with the symbol where it is instanceated in.