### PR TITLE
Fix `bool` migration doesn't work

### DIFF
--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -3,6 +3,9 @@ use crate::veryl_token::{Token, VerylToken};
 use crate::veryl_walker::VerylWalker;
 use veryl_metadata::Metadata;
 use veryl_parser::resource_table;
+use veryl_parser::veryl_grammar_trait::Identifier as NewIdentifier;
+use veryl_parser::veryl_grammar_trait::Veryl as NewVeryl;
+use veryl_parser::veryl_walker::VerylWalker as NewVerylWalker;
 
 #[cfg(target_os = "windows")]
 const NEWLINE: &str = "\r\n";
@@ -78,6 +81,26 @@ impl Migrator {
         for x in &x.comments {
             self.push_token(x);
         }
+    }
+
+    /// Check whether the valid syntax tree should be migrated
+    pub fn migratable(veryl: &NewVeryl) -> bool {
+        struct BoolChecker {
+            bool_exist: bool,
+        }
+
+        impl NewVerylWalker for BoolChecker {
+            fn identifier(&mut self, arg: &NewIdentifier) {
+                if arg.text().to_string() == "bool" {
+                    self.bool_exist = true;
+                }
+            }
+        }
+
+        let mut checker = BoolChecker { bool_exist: false };
+        checker.veryl(veryl);
+
+        checker.bool_exist
     }
 }
 

--- a/crates/veryl/src/cmd_migrate.rs
+++ b/crates/veryl/src/cmd_migrate.rs
@@ -34,7 +34,13 @@ impl CmdMigrate {
             // Check whether new parser is passed
             let parser = Parser::parse(&input, &path.src);
 
-            if parser.is_err() {
+            let migrate = if let Ok(veryl) = parser {
+                Migrator::migratable(&veryl.veryl)
+            } else {
+                true
+            };
+
+            if migrate {
                 let parser = OldParser::parse(&input, &path.src)?;
                 let mut migrator = Migrator::new(metadata);
                 migrator.migrate(&parser.veryl);


### PR DESCRIPTION
`bool` syntax change doesn't cause syntax error because it is identified as user defined type in the new syntax.
`veryl migrate` doesn't work fine because it is triggered by syntax error.

To resolve this issue, this PR introduce an explicit `migratable` function.