### PR TITLE
Fix wrong `unassign_variable` warning

### DIFF
--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -94,6 +94,7 @@ impl Analyzer {
 
         symbol_table::apply_import();
         symbol_table::resolve_user_defined();
+        symbol_table::resolve_function();
         ret.append(&mut symbol_table::resolve_enum());
         ret.append(&mut symbol_table::apply_bind());
         ret.append(&mut symbol_table::apply_msb());

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -801,6 +801,7 @@ impl Conv<&FunctionDeclaration> for () {
         if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
             && let SymbolKind::Function(x) = symbol.found.kind
         {
+            let constantable = x.constantable.unwrap();
             let ret_type = if let Some(x) = &x.ret {
                 let mut r#type = x.to_ir_type(context, TypePosition::Variable)?;
                 if r#type.is_struct() {
@@ -942,6 +943,7 @@ impl Conv<&FunctionDeclaration> for () {
                 path,
                 r#type,
                 array: Shape::default(),
+                constantable,
                 functions: vec![body?],
             };
 

--- a/crates/analyzer/src/handlers/create_symbol_table.rs
+++ b/crates/analyzer/src/handlers/create_symbol_table.rs
@@ -83,6 +83,7 @@ pub struct CreateSymbolTable {
     port_connects: HashMap<Token, ConnectTarget>,
     parameters: Vec<Vec<Parameter>>,
     ports: Vec<Vec<Port>>,
+    reference_paths: Vec<Vec<GenericSymbolPath>>,
     needs_default_generic_argument: bool,
     generic_context: GenericContext,
     default_clock: Option<SymbolId>,
@@ -686,6 +687,11 @@ impl VerylGrammarTrait for CreateSymbolTable {
                 if let Some(x) = self.type_dag_candidates.last_mut() {
                     x.push(cand);
                 }
+            }
+
+            if let Some(paths) = self.reference_paths.last_mut() {
+                let path: GenericSymbolPath = arg.into();
+                paths.push(path);
             }
         }
         Ok(())
@@ -1715,6 +1721,7 @@ impl VerylGrammarTrait for CreateSymbolTable {
                     self.generic_context.push();
                 }
                 self.ports.push(Vec::new());
+                self.reference_paths.push(Vec::new());
                 self.affiliation.push(Affiliation::Function);
                 self.push_type_dag_cand();
             }
@@ -1728,6 +1735,7 @@ impl VerylGrammarTrait for CreateSymbolTable {
                     vec![]
                 };
                 let ports: Vec<_> = self.ports.pop().unwrap();
+                let reference_paths: Vec<_> = self.reference_paths.pop().unwrap();
 
                 let ret = arg
                     .function_declaration_opt1
@@ -1755,6 +1763,8 @@ impl VerylGrammarTrait for CreateSymbolTable {
                     generic_references: vec![],
                     ports,
                     ret,
+                    reference_paths,
+                    constantable: None,
                     definition: Some(definition),
                 };
 
@@ -2314,6 +2324,8 @@ impl VerylGrammarTrait for CreateSymbolTable {
                     generic_references: vec![],
                     ports,
                     ret,
+                    reference_paths: vec![],
+                    constantable: None,
                     definition: None,
                 };
 

--- a/crates/analyzer/src/ir/function.rs
+++ b/crates/analyzer/src/ir/function.rs
@@ -75,6 +75,7 @@ pub struct Function {
     pub path: FuncPath,
     pub r#type: Option<Type>,
     pub array: Shape,
+    pub constantable: bool,
     pub functions: Vec<FunctionBody>,
 }
 
@@ -195,7 +196,11 @@ impl FunctionCall {
             ValueVariant::Unknown
         };
 
-        let mut is_const = true;
+        let mut is_const = context
+            .functions
+            .get(&self.id)
+            .map(|func| func.constantable)
+            .unwrap_or(true);
         for expr in self.inputs.values_mut() {
             is_const &= expr.eval_comptime(context, None).is_const;
         }

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -2081,6 +2081,8 @@ pub struct FunctionProperty {
     pub generic_references: Vec<GenericSymbolPath>,
     pub ports: Vec<Port>,
     pub ret: Option<Type>,
+    pub reference_paths: Vec<GenericSymbolPath>,
+    pub constantable: Option<bool>,
     pub definition: Option<DefinitionId>,
 }
 

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -1,5 +1,6 @@
 mod connect;
 mod r#enum;
+mod function;
 mod msb;
 
 use crate::namespace::Namespace;
@@ -1162,6 +1163,19 @@ impl SymbolTable {
         }
     }
 
+    pub fn get_function_symbols(&self) -> Vec<Symbol> {
+        self.symbol_table
+            .values()
+            .filter_map(|symbol| {
+                if matches!(symbol.kind, SymbolKind::Function(_)) {
+                    Some(symbol.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     pub fn get_enum_symbols(&self) -> Vec<Symbol> {
         self.symbol_table
             .values()
@@ -1668,6 +1682,11 @@ pub fn resolve_user_defined() {
     SYMBOL_CACHE.with(|f| f.borrow_mut().clear());
     let resolved = SYMBOL_TABLE.with(|f| f.borrow().resolve_user_defined());
     SYMBOL_TABLE.with(|f| f.borrow_mut().set_user_defined(resolved));
+}
+
+pub fn resolve_function() {
+    let list = SYMBOL_TABLE.with(|f| f.borrow().get_function_symbols());
+    function::resolve_function(&list);
 }
 
 pub fn resolve_enum() -> Vec<AnalyzerError> {

--- a/crates/analyzer/src/symbol_table/function.rs
+++ b/crates/analyzer/src/symbol_table/function.rs
@@ -1,0 +1,77 @@
+use crate::namespace::Namespace;
+use crate::symbol::{Direction, FunctionProperty, Symbol, SymbolId, SymbolKind};
+use crate::symbol_table;
+
+pub fn resolve_function(list: &[Symbol]) {
+    for symbol in list {
+        resolve_constantable(symbol);
+    }
+}
+
+fn resolve_constantable(symbol: &Symbol) -> bool {
+    if let SymbolKind::Function(func) = &symbol.kind
+        && let Some(constantable) = func.constantable
+    {
+        return constantable;
+    }
+
+    let mut symbol = symbol.clone();
+    let namespace = symbol.inner_namespace();
+    let SymbolKind::Function(mut func) = symbol.kind else {
+        unreachable!();
+    };
+
+    let constantable = is_constantable_function(&func, symbol.id, &namespace);
+    func.constantable = Some(constantable);
+    func.reference_paths.clear();
+
+    symbol.kind = SymbolKind::Function(func);
+    symbol_table::update(symbol);
+
+    constantable
+}
+
+fn is_constantable_function(func: &FunctionProperty, id: SymbolId, namespace: &Namespace) -> bool {
+    if func.ret.is_none() {
+        // constant function should have a return value.
+        return false;
+    }
+
+    for port in &func.ports {
+        let SymbolKind::Port(port) = symbol_table::get(port.symbol).unwrap().kind else {
+            unreachable!();
+        };
+
+        // constant function has only input ports
+        if !matches!(port.direction, Direction::Input) {
+            return false;
+        }
+    }
+
+    for path in &func.reference_paths {
+        let Ok(symbol) = symbol_table::resolve(path) else {
+            continue;
+        };
+        if symbol.found.id == id {
+            continue;
+        }
+
+        match &symbol.found.kind {
+            SymbolKind::Port(_) | SymbolKind::Variable(_) => {
+                // port and variable should be defined in the given function
+                if !symbol.found.namespace.included(namespace) {
+                    return false;
+                }
+            }
+            SymbolKind::Function(_) => {
+                if !resolve_constantable(&symbol.found) {
+                    return false;
+                }
+            }
+            SymbolKind::Instance(_) => return false,
+            _ => {}
+        }
+    }
+
+    true
+}

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -7001,6 +7001,54 @@ fn unassign_variable() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::UnassignVariable { .. }));
+
+    let code = r#"
+    module ModuleA (
+        i_clk: input  clock,
+        i_rst: input  reset,
+    ) {
+        let a: logic = 1;
+        var b: logic;
+
+        function f() -> logic {
+            return a;
+        }
+
+        always_ff {
+            if f() {
+                b = 1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    interface IfA {
+        var a: logic;
+        function get_a() -> logic {
+            return a;
+        }
+    }
+    module ModuleA (
+        i_clk: input clock,
+    ) {
+        inst if_a: IfA;
+        assign if_a.a = '1;
+
+        var d: logic;
+        always_ff {
+            if if_a.get_a() {
+                d = '1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2203

Wrong `unassign_variable` warning is reported for a variable assigned in `if` statement whose condition is given by a function call with no args.
The root cuase of this issue is that result of such function call is treated as a `const` even though the function references external variables.
https://github.com/veryl-lang/veryl/blob/f04ec292c2bc948dccc09833a5143f0efb5e5bf4/crates/analyzer/src/ir/function.rs#L198-L206

To resolve this, a new field named `constantable` is added to Symbol and IR of `function`.
It shows if following conditions are met and the given function can be constant function.

* Have a return value
* Have input ports only
* Have no references to external variable/port/instance

