### PR TITLE
Support backward function definition

### DIFF
--- a/crates/analyzer/src/conv/statement.rs
+++ b/crates/analyzer/src/conv/statement.rs
@@ -292,7 +292,7 @@ impl Conv<&IdentifierStatement> for ir::StatementBlock {
                         )]))
                     }
                     SymbolKind::Function(x) => {
-                        let ret = function_call(
+                        let id = function_call(
                             context,
                             value.expression_identifier.as_ref(),
                             args,
@@ -306,14 +306,12 @@ impl Conv<&IdentifierStatement> for ir::StatementBlock {
                             ));
                         }
 
-                        Ok(ir::StatementBlock(vec![ir::Statement::FunctionCall(
-                            Box::new(ret),
-                        )]))
+                        Ok(ir::StatementBlock(vec![ir::Statement::FunctionCall(id)]))
                     }
                     SymbolKind::ModportFunctionMember(x) => {
                         let symbol = symbol_table::get(x.function).unwrap();
                         if let SymbolKind::Function(x) = &symbol.kind {
-                            let ret = function_call(
+                            let id = function_call(
                                 context,
                                 value.expression_identifier.as_ref(),
                                 args,
@@ -327,9 +325,7 @@ impl Conv<&IdentifierStatement> for ir::StatementBlock {
                                 ));
                             }
 
-                            Ok(ir::StatementBlock(vec![ir::Statement::FunctionCall(
-                                Box::new(ret),
-                            )]))
+                            Ok(ir::StatementBlock(vec![ir::Statement::FunctionCall(id)]))
                         } else {
                             unreachable!();
                         }

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -6,8 +6,8 @@ use crate::conv::instance::InstanceHistoryError;
 use crate::conv::{Context, Conv};
 use crate::definition_table::{self, Definition};
 use crate::ir::{
-    self, Arguments, Comptime, FuncPath, FuncProto, IrResult, Op, PartSelectPath, Shape, ShapeRef,
-    Signature, ValueVariant, VarIndex, VarKind, VarPath, VarPathSelect, VarSelect, Variable,
+    self, Arguments, Comptime, FuncPath, IrResult, Op, PartSelectPath, Shape, ShapeRef, Signature,
+    ValueVariant, VarId, VarIndex, VarKind, VarPath, VarPathSelect, VarSelect, Variable,
 };
 use crate::symbol::{
     self, Affiliation, ClockDomain, EnumMemberValue, GenericBoundKind, ProtoBound, SymbolKind,
@@ -16,7 +16,7 @@ use crate::symbol::{
 use crate::symbol_path::GenericSymbolPath;
 use crate::symbol_table::{self, ResolveResult};
 use crate::value::Value;
-use crate::{HashMap, ir_error};
+use crate::{HashMap, ir_error, namespace_table};
 use veryl_parser::resource_table::{self, StrId};
 use veryl_parser::token_range::TokenRange;
 use veryl_parser::veryl_grammar_trait::*;
@@ -562,7 +562,7 @@ pub fn eval_struct_member(
                     member_path.add_prelude(&path.0);
                     for x in r#type.expand_struct_union(&path, &[], None) {
                         if x.path == member_path {
-                            let comptime = expr.eval_comptime(context, None);
+                            let comptime = Box::new(expr.eval_comptime(context, None));
                             // TODO range select from PartSelect
                             return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(
                                 comptime, token,
@@ -580,6 +580,8 @@ pub fn eval_struct_member(
                     if x.path == member_path {
                         let mut comptime = Comptime::from_type(r#type, ClockDomain::None, token);
                         comptime.is_const = true;
+
+                        let comptime = Box::new(comptime);
                         return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(
                             comptime, token,
                         ))));
@@ -591,6 +593,8 @@ pub fn eval_struct_member(
                 GenericBoundKind::Type => {
                     let mut comptime = Comptime::create_unknown(ClockDomain::None, token);
                     comptime.is_const = true;
+
+                    let comptime = Box::new(comptime);
                     Ok(ir::Expression::Term(Box::new(ir::Factor::Value(
                         comptime, token,
                     ))))
@@ -599,6 +603,8 @@ pub fn eval_struct_member(
                     let r#type = x.to_ir_type(context, TypePosition::Variable)?;
                     let mut comptime = Comptime::from_type(r#type, ClockDomain::None, token);
                     comptime.is_const = true;
+
+                    let comptime = Box::new(comptime);
                     Ok(ir::Expression::Term(Box::new(ir::Factor::Value(
                         comptime, token,
                     ))))
@@ -1068,6 +1074,8 @@ pub fn eval_function_call(
                 let mut x = Comptime::create_unknown(ClockDomain::None, token);
                 x.is_const = true;
                 context.insert_ir_error::<()>(&Err(ir_error!(token)));
+
+                let x = Box::new(x);
                 Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))))
             }
             SymbolKind::ProtoFunction(_) => Err(ir_error!(token)),
@@ -1081,6 +1089,60 @@ pub fn eval_function_call(
     } else {
         unreachable!();
     }
+}
+
+pub fn insert_generic_function_insts(
+    context: &mut Context,
+    value: &FunctionDeclaration,
+) -> IrResult<()> {
+    let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref()) else {
+        return Ok(());
+    };
+
+    let func_paths: Vec<_> = context
+        .func_paths
+        .iter()
+        .filter_map(|(path, id)| {
+            if path.sig.is_generic()
+                && path.sig.symbol == symbol.found.id
+                && !context.functions.contains_key(id)
+            {
+                Some((path.clone(), *id))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut func_ids = Vec::new();
+    for (path, id) in &func_paths {
+        context.push_generic_map(path.sig.to_generic_map());
+        let ret: IrResult<()> = Conv::conv(context, (value, Some(path)));
+        context.pop_generic_map();
+        ret?;
+        func_ids.push(*id);
+    }
+
+    let func_call_ids: Vec<_> = context
+        .function_calls
+        .iter()
+        .filter_map(|(id, func_call)| {
+            if func_ids.contains(&func_call.id) {
+                Some(*id)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for id in &func_call_ids {
+        context.update_func_call(*id, |c, func_call| {
+            func_call.apply_ret(c);
+            func_call.apply_args(c)
+        })?;
+    }
+
+    Ok(())
 }
 
 pub fn eval_struct_constructor(
@@ -1158,6 +1220,7 @@ pub fn eval_external_symbol(
                     comptime.value.expand_value(width);
                 }
 
+                let comptime = Box::new(comptime);
                 return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(
                     comptime, token,
                 ))));
@@ -1194,6 +1257,7 @@ pub fn eval_external_symbol(
                     x.is_global = true;
                     x.r#type = r#type;
 
+                    let x = Box::new(x);
                     return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
                 }
             } else if matches!(x.bound, GenericBoundKind::Type) {
@@ -1208,6 +1272,7 @@ pub fn eval_external_symbol(
                 x.is_global = true;
                 x.r#type.kind = ir::TypeKind::Type;
 
+                let x = Box::new(x);
                 return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
             } else {
                 context.insert_error(AnalyzerError::invalid_factor(
@@ -1225,6 +1290,7 @@ pub fn eval_external_symbol(
             x.is_const = true;
             x.is_global = true;
 
+            let x = Box::new(x);
             return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
         }
         SymbolKind::ProtoTypeDef(_) => {
@@ -1233,6 +1299,7 @@ pub fn eval_external_symbol(
             x.is_const = true;
             x.is_global = true;
 
+            let x = Box::new(x);
             return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
         }
         SymbolKind::EnumMember(x) => {
@@ -1250,6 +1317,7 @@ pub fn eval_external_symbol(
                 }
                 EnumMemberValue::ExplicitValue(x, _) => {
                     let (x, _) = eval_expr(context, None, x, false)?;
+                    let x = Box::new(x);
                     return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
                 }
                 EnumMemberValue::UnevaluableValue => (),
@@ -1284,6 +1352,7 @@ pub fn eval_external_symbol(
             x.is_const = true;
             x.is_global = true;
 
+            let x = Box::new(x);
             return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
         }
         SymbolKind::Function(_) | SymbolKind::Module(_) | SymbolKind::SystemFunction(_) => {
@@ -1311,7 +1380,7 @@ pub fn eval_external_symbol(
             }
 
             let r#type = x.r#type.to_ir_type(context, TypePosition::Variable)?;
-            let x = Comptime::from_type(r#type, x.clock_domain, token);
+            let x = Box::new(Comptime::from_type(r#type, x.clock_domain, token));
 
             return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
         }
@@ -1338,6 +1407,7 @@ pub fn eval_external_symbol(
                 ..Default::default()
             };
 
+            let x = Box::new(x);
             return Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x, token))));
         }
         _ => (),
@@ -1693,7 +1763,7 @@ pub fn get_port_connects(
                         var_id,
                         VarIndex::default(),
                         VarSelect::default(),
-                        comptime,
+                        Box::new(comptime),
                         token,
                     )))
                 } else {
@@ -1743,7 +1813,7 @@ pub fn get_port_connects(
             var_id,
             VarIndex::default(),
             VarSelect::default(),
-            comptime,
+            Box::new(comptime),
             token,
         )));
         let dst = vec![VarPathSelect(
@@ -1887,7 +1957,7 @@ pub fn expand_connect_const(
         for lhs in lhs_members {
             if lhs.1.is_output() {
                 let dst = VarPathSelect(lhs.0, lhs_select.clone(), lhs_token);
-                let src = ir::Factor::Value(comptime.clone(), token);
+                let src = ir::Factor::Value(Box::new(comptime.clone()), token);
                 let src = ir::Expression::Term(Box::new(src));
 
                 if let Some(dst) = dst.to_assign_destination(context, false) {
@@ -1926,52 +1996,96 @@ pub fn var_path_to_assign_destination(
         .collect()
 }
 
-fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> IrResult<FuncProto> {
-    if let Some(x) = context.func_paths.get(path) {
-        Ok(x.clone())
+fn get_function(
+    context: &mut Context,
+    path: &FuncPath,
+    is_local_func: bool,
+    token: TokenRange,
+) -> IrResult<VarId> {
+    if let Some(id) = context.func_paths.get(path) {
+        Ok(*id)
+    } else if is_local_func {
+        get_local_function(context, path, token)
     } else {
+        get_external_function(context, path, token)
+    }
+}
+
+fn get_local_function(
+    context: &mut Context,
+    path: &FuncPath,
+    token: TokenRange,
+) -> IrResult<VarId> {
+    if context.func_paths.contains_key(&path.base()) {
+        // insert instanced generic function
+        let func_def = get_func_definition(path, token)?;
+        let _: () = Conv::conv(context, (&func_def, Some(path)))?;
+        context
+            .func_paths
+            .get(path)
+            .cloned()
+            .ok_or_else(|| ir_error!(token))
+    } else {
+        // insert function path
+        let id = context.insert_func_path(path.clone());
+        Ok(id)
+    }
+}
+
+fn get_external_function(
+    context: &mut Context,
+    path: &FuncPath,
+    token: TokenRange,
+) -> IrResult<VarId> {
+    let func_def = get_func_definition(path, token)?;
+
+    let array = if let Some((_, comptime)) = context.find_path(&path.path) {
+        comptime.r#type.array
+    } else {
+        Shape::default()
+    };
+
+    let mut local_context = Context::default();
+    local_context.var_id = context.var_id;
+    local_context.inherit(context);
+    local_context.extract_var_paths(context, &path.path, &array);
+
+    let ret: IrResult<()> = Conv::conv(&mut local_context, (&func_def, Some(path)));
+
+    context.extract_function(&mut local_context, &path.path, &array);
+    context.inherit(&mut local_context);
+    context.var_id = local_context.var_id;
+
+    ret?;
+
+    context
+        .func_paths
+        .get(path)
+        .cloned()
+        .ok_or_else(|| ir_error!(token))
+}
+
+fn get_func_definition(path: &FuncPath, token: TokenRange) -> IrResult<FunctionDeclaration> {
+    let id = {
         let symbol = symbol_table::get(path.sig.symbol).unwrap();
-        let definition = match &symbol.kind {
+        match &symbol.kind {
             SymbolKind::Function(x) => x.definition.unwrap(),
             SymbolKind::ModportFunctionMember(x) => {
                 let symbol = symbol_table::get(x.function).unwrap();
-                let SymbolKind::Function(x) = symbol.kind else {
+                let SymbolKind::Function(x) = &symbol.kind else {
                     unreachable!();
                 };
                 x.definition.unwrap()
             }
             _ => return Err(ir_error!(token)),
-        };
+        }
+    };
 
-        let definition = definition_table::get(definition).unwrap();
-        let Definition::Function(definition) = definition else {
-            unreachable!()
-        };
-
-        let array = if let Some((_, comptime)) = context.find_path(&path.path) {
-            comptime.r#type.array
-        } else {
-            Shape::default()
-        };
-
-        let mut local_context = Context::default();
-        local_context.var_id = context.var_id;
-        local_context.inherit(context);
-        local_context.extract_var_paths(context, &path.path, &array);
-
-        let ret: IrResult<()> = Conv::conv(&mut local_context, &definition);
-
-        context.extract_function(&mut local_context, &path.path, &array);
-        context.inherit(&mut local_context);
-        context.var_id = local_context.var_id;
-
-        ret?;
-
-        context
-            .func_paths
-            .get(&path.base())
-            .cloned()
-            .ok_or_else(|| ir_error!(token))
+    let definition = definition_table::get(id).unwrap();
+    if let Definition::Function(x) = definition {
+        Ok(x)
+    } else {
+        unreachable!()
     }
 }
 
@@ -1980,7 +2094,7 @@ pub fn function_call(
     path: &ExpressionIdentifier,
     args: Arguments,
     token: TokenRange,
-) -> IrResult<ir::FunctionCall> {
+) -> IrResult<ir::VarId> {
     let generic_path: GenericSymbolPath = path.into();
 
     check_generic_args(context, &generic_path);
@@ -1988,6 +2102,12 @@ pub fn function_call(
     let mut parent_path = generic_path.clone();
     parent_path.paths.pop();
     let sig = Signature::from_path(context, generic_path).ok_or_else(|| ir_error!(token))?;
+
+    let is_local_func = {
+        let namespace = namespace_table::get(path.identifier().token.id).unwrap();
+        let symbol = symbol_table::get(sig.symbol).unwrap();
+        namespace.included(&symbol.namespace)
+    };
 
     let path: VarPathSelect = Conv::conv(context, path)?;
     let (mut base_path, select, _) = path.into();
@@ -2026,21 +2146,30 @@ pub fn function_call(
 
     context.push_generic_map(map);
 
-    let ret = context.block(|c| {
-        let proto = get_function(c, &path, token)?;
-        let (inputs, outputs) = args.to_function_args(c, &proto, token)?;
-        Ok(ir::FunctionCall {
-            id: proto.id,
+    let func_call = context.block(|c| {
+        let id = get_function(c, &path, is_local_func, token)?;
+        let mut func_call = ir::FunctionCall {
+            id,
             index,
-            ret: proto.ret,
-            inputs,
-            outputs,
+            ret: None,
+            args,
+            inputs: HashMap::default(),
+            outputs: HashMap::default(),
             token,
-        })
+        };
+
+        if c.functions.contains_key(&id) {
+            func_call.apply_args(c)?;
+            func_call.apply_ret(c);
+        }
+
+        Ok(func_call)
     });
 
     context.pop_generic_map();
-    ret
+
+    let id = context.insert_func_call(func_call?);
+    Ok(id)
 }
 
 pub fn check_compatibility(

--- a/crates/analyzer/src/ir.rs
+++ b/crates/analyzer/src/ir.rs
@@ -23,7 +23,7 @@ pub use declaration::{
     FinalDeclaration, InitialDeclaration, InstDeclaration, InstInput, InstOutput,
 };
 pub use expression::{ArrayLiteralItem, Expression, Factor};
-pub use function::{Arguments, FuncArg, FuncPath, FuncProto, Function, FunctionBody, FunctionCall};
+pub use function::{Arguments, FuncArg, FuncPath, Function, FunctionBody, FunctionCall};
 pub use interface::Interface;
 pub use ir::{Component, Ir, IrError, IrResult, SystemVerilog};
 pub use module::Module;

--- a/crates/analyzer/src/ir/interface.rs
+++ b/crates/analyzer/src/ir/interface.rs
@@ -1,15 +1,14 @@
-use crate::HashMap;
-use crate::ir::{Comptime, FuncPath, FuncProto, Function, VarId, VarPath, Variable};
+use crate::ir::{Comptime, FuncPath, Function, VarId, VarPath, Variable};
 use crate::symbol::Direction;
+use crate::{Context, HashMap};
 use indent::indent_all_by;
-use std::fmt;
 use veryl_parser::resource_table::StrId;
 
 #[derive(Clone)]
 pub struct Interface {
     pub name: StrId,
     pub var_paths: HashMap<VarPath, (VarId, Comptime)>,
-    pub func_paths: HashMap<FuncPath, FuncProto>,
+    pub func_paths: HashMap<FuncPath, VarId>,
     pub variables: HashMap<VarId, Variable>,
     pub functions: HashMap<VarId, Function>,
     pub modports: HashMap<StrId, Vec<(StrId, Direction)>>,
@@ -25,10 +24,8 @@ impl Interface {
         }
         ret
     }
-}
 
-impl fmt::Display for Interface {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn to_string(&self, context: &Context) -> String {
         let mut ret = format!("interface {} {{\n", self.name);
 
         let mut variables: Vec<_> = self.variables.iter().collect();
@@ -43,11 +40,11 @@ impl fmt::Display for Interface {
         }
 
         for (_, x) in functions {
-            let text = format!("{}\n", x);
+            let text = format!("{}\n", x.to_string(context));
             ret.push_str(&indent_all_by(2, text));
         }
 
         ret.push('}');
-        ret.fmt(f)
+        ret
     }
 }

--- a/crates/analyzer/src/ir/ir.rs
+++ b/crates/analyzer/src/ir/ir.rs
@@ -1,6 +1,5 @@
 use crate::conv::Context;
 use crate::ir::{AssignDestination, Interface, Module};
-use std::fmt;
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
 
@@ -19,15 +18,13 @@ impl Ir {
             x.eval_assign(context);
         }
     }
-}
 
-impl fmt::Display for Ir {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn to_string(&self, context: &Context) -> String {
         let mut ret = String::new();
         for x in &self.components {
-            ret.push_str(&format!("{}\n", x));
+            ret.push_str(&format!("{}\n", x.to_string(context)));
         }
-        ret.fmt(f)
+        ret
     }
 }
 
@@ -64,14 +61,12 @@ impl Component {
             Component::SystemVerilog(_) => (),
         }
     }
-}
 
-impl fmt::Display for Component {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn to_string(&self, context: &Context) -> String {
         match self {
-            Component::Module(x) => x.fmt(f),
-            Component::Interface(x) => x.fmt(f),
-            Component::SystemVerilog(_) => "".fmt(f),
+            Component::Module(x) => x.to_string(context),
+            Component::Interface(x) => x.to_string(context),
+            Component::SystemVerilog(_) => "".to_string(),
         }
     }
 }

--- a/crates/analyzer/src/ir/module.rs
+++ b/crates/analyzer/src/ir/module.rs
@@ -6,7 +6,6 @@ use crate::ir::assign_table::AssignTable;
 use crate::ir::{Declaration, Function, Type, VarId, VarIndex, VarPath, Variable};
 use crate::symbol::ClockDomain;
 use indent::indent_all_by;
-use std::fmt;
 use veryl_parser::resource_table::StrId;
 
 #[derive(Clone)]
@@ -70,7 +69,7 @@ impl Module {
                     ) {
                         let index = VarIndex::from_index(*index, &variable.r#type.array);
                         context.insert_error(crate::AnalyzerError::unassign_variable(
-                            &format!("{}{index}", variable.path),
+                            &format!("{}{}", variable.path, index.to_string(context)),
                             &variable.token,
                         ));
                     }
@@ -78,10 +77,8 @@ impl Module {
             }
         }
     }
-}
 
-impl fmt::Display for Module {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn to_string(&self, context: &Context) -> String {
         let mut ret = format!("module {} {{\n", self.name);
 
         let mut variables: Vec<_> = self.variables.iter().collect();
@@ -96,18 +93,18 @@ impl fmt::Display for Module {
         }
 
         for (_, x) in functions {
-            let text = format!("{}\n", x);
+            let text = format!("{}\n", x.to_string(context));
             ret.push_str(&indent_all_by(2, text));
         }
 
         ret.push('\n');
 
         for x in &self.declarations {
-            let text = format!("{}\n", x);
+            let text = format!("{}\n", x.to_string(context));
             ret.push_str(&indent_all_by(2, text));
         }
 
         ret.push('}');
-        ret.fmt(f)
+        ret
     }
 }

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -168,6 +168,10 @@ impl Signature {
         }
         vec![ret]
     }
+
+    pub fn is_generic(&self) -> bool {
+        !self.generic_parameters.is_empty()
+    }
 }
 
 impl fmt::Display for Signature {

--- a/crates/analyzer/src/ir/system_function.rs
+++ b/crates/analyzer/src/ir/system_function.rs
@@ -7,37 +7,36 @@ use crate::ir::{
 use crate::symbol::ClockDomain;
 use crate::value::Value;
 use crate::{AnalyzerError, BigUint, ir_error};
-use std::fmt;
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
 
 #[derive(Clone, Debug)]
 pub struct Input(Expression);
 
-impl fmt::Display for Input {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+impl Input {
+    pub fn to_string(&self, context: &Context) -> String {
+        self.0.to_string(context)
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct Output(Vec<AssignDestination>);
 
-impl fmt::Display for Output {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Output {
+    pub fn to_string(&self, context: &Context) -> String {
         let mut ret = String::new();
 
         if self.0.len() == 1 {
-            ret.push_str(&format!("{}", self.0[0]));
+            ret.push_str(&self.0[0].to_string(context));
         } else if !self.0.is_empty() {
-            ret.push_str(&format!("{{{}", self.0[0]));
+            ret.push_str(&format!("{{{}", self.0[0].to_string(context)));
             for d in &self.0[1..] {
-                ret.push_str(&format!(", {}", d));
+                ret.push_str(&format!(", {}", d.to_string(context)));
             }
             ret.push_str("}}");
         }
 
-        ret.fmt(f)
+        ret
     }
 }
 
@@ -281,16 +280,18 @@ impl SystemFunctionCall {
             }
         }
     }
-}
 
-impl fmt::Display for SystemFunctionCall {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn to_string(&self, context: &Context) -> String {
         match &self.kind {
-            SystemFunctionKind::Bits(x) => format!("$bits({x})").fmt(f),
-            SystemFunctionKind::Size(x) => format!("$size({x})").fmt(f),
-            SystemFunctionKind::Clog2(x) => format!("$clog2({x})").fmt(f),
-            SystemFunctionKind::Onehot(x) => format!("$onehot({x})").fmt(f),
-            SystemFunctionKind::Readmemh(x, y) => format!("$readmemh({x}, {y})").fmt(f),
+            SystemFunctionKind::Bits(x) => format!("$bits({})", x.to_string(context)),
+            SystemFunctionKind::Size(x) => format!("$size({})", x.to_string(context)),
+            SystemFunctionKind::Clog2(x) => format!("$clog2({})", x.to_string(context)),
+            SystemFunctionKind::Onehot(x) => format!("$onehot({})", x.to_string(context)),
+            SystemFunctionKind::Readmemh(x, y) => format!(
+                "$readmemh({}, {})",
+                x.to_string(context),
+                y.to_string(context)
+            ),
         }
     }
 }

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -934,8 +934,12 @@ impl From<&syntax_tree::GenericArgIdentifier> for GenericSymbolPath {
 impl fmt::Display for GenericSymbolPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut text = String::new();
-        for path in &self.paths {
-            text.push_str(&format!("{} ", path.mangled()));
+        for (i, path) in self.paths.iter().enumerate() {
+            if i == 0 {
+                text.push_str(&format!("{}", path.mangled()));
+            } else {
+                text.push_str(&format!(" {}", path.mangled()));
+            }
         }
         text.fmt(f)
     }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1651,9 +1651,9 @@ fn mismatch_function_arity() {
         ) -> logic {
             return 0;
         }
-    
+
         inst u: $sv::IF;
-    
+
         always_comb {
             u.a = func(1'b1);
         }
@@ -5380,6 +5380,30 @@ fn referring_before_definition() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA (
+        i_clk: input clock,
+    ) {
+        var a: logic<4>;
+        always_ff {
+            if get_b() {
+                a = get_c::<4>();
+            }
+        }
+        let b: logic = '1;
+        function get_b() -> logic {
+            return b;
+        }
+        let c: logic = '1;
+        function get_c::<W: u32>() -> logic<W> {
+            return c as W;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]
@@ -7042,6 +7066,25 @@ fn unassign_variable() {
         always_ff {
             if if_a.get_a() {
                 d = '1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA #(
+        param N: u32 = 4,
+    ) {
+        always_comb {
+            f();
+        }
+        function f() {
+            var a: u32;
+            for _i: u32 in 0..N {
+                a = 0;
             }
         }
     }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2140,25 +2140,25 @@ module ModuleA {
 "#;
 
     let expect = r#"// __PkgA__0__1__2__3
-package prj___PkgA__3894375d1deadabb;
+package prj___PkgA__97b1a4fc9479185f;
     localparam int unsigned V = 0 + 1 + 2 + 3;
 endpackage
 // __PkgA__4__5__6__7
-package prj___PkgA__c10f54f86dbec958;
+package prj___PkgA__a23a9e5c80a698c2;
     localparam int unsigned V = 4 + 5 + 6 + 7;
 endpackage
 module prj_ModuleA;
     // __FuncA____PkgA__0__1__2__3_V
-    function automatic int unsigned __FuncA__830b4abf8aba07ce() ;
-        return prj___PkgA__3894375d1deadabb::V;
+    function automatic int unsigned __FuncA__1625729981fddf71() ;
+        return prj___PkgA__97b1a4fc9479185f::V;
     endfunction
     // __FuncA____PkgA__4__5__6__7_V
-    function automatic int unsigned __FuncA__e5a0d24d19f5a43d() ;
-        return prj___PkgA__c10f54f86dbec958::V;
+    function automatic int unsigned __FuncA__1c60de7541878b99() ;
+        return prj___PkgA__a23a9e5c80a698c2::V;
     endfunction
-    int unsigned _a; always_comb _a = __FuncA__830b4abf8aba07ce();
-    int unsigned _b; always_comb _b = __FuncA__830b4abf8aba07ce();
-    int unsigned _c; always_comb _c = __FuncA__e5a0d24d19f5a43d();
+    int unsigned _a; always_comb _a = __FuncA__1625729981fddf71();
+    int unsigned _b; always_comb _b = __FuncA__1625729981fddf71();
+    int unsigned _c; always_comb _c = __FuncA__1c60de7541878b99();
 endmodule
 //# sourceMappingURL=test.sv.map
 "#;
@@ -2196,17 +2196,17 @@ alias module mod = c_module::<pkg>;
     let expect = r#"
 // __a_pkg__32
 
-package prj___a_pkg__805a71dc85438e33;
+package prj___a_pkg__cd2bef6d30dada19;
     localparam int unsigned A = 32;
 endpackage
 // __b_module____a_pkg__32
-module prj___b_module__dc41fc063ac19318;
-    import prj___a_pkg__805a71dc85438e33::*;
+module prj___b_module__c0fb5ed5baf172ab;
+    import prj___a_pkg__cd2bef6d30dada19::*;
 
 endmodule
 // __c_module____a_pkg__32
-module prj___c_module__dc41fc063ac19318;
-    prj___b_module__dc41fc063ac19318 u ();
+module prj___c_module__c0fb5ed5baf172ab;
+    prj___b_module__c0fb5ed5baf172ab u ();
 endmodule
 
 

--- a/crates/tests/src/snapshots/unresolvable_generic_argument.snap
+++ b/crates/tests/src/snapshots/unresolvable_generic_argument.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 unresolvable_generic_argument (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#unresolvable_generic_argument)
 
-  × "X " can't be resolved from the definition of generics
+  × "X" can't be resolved from the definition of generics
    ╭─[../../testcases/error/unresolvable_generic_argument.veryl:3:46]
  2 │     const X: u32 = 1;
  3 │     inst u: unresolvable_generic_argument2::<X>;

--- a/crates/veryl/src/cmd_dump.rs
+++ b/crates/veryl/src/cmd_dump.rs
@@ -84,7 +84,7 @@ impl CmdDump {
         }
 
         if self.opt.ir {
-            println!("{}", ir);
+            println!("{}", ir.to_string(&analyzer_context));
 
             let check_error = CheckError::new(metadata.build.error_count_limit);
             check_error.append(&mut ir_error).check_err()?;


### PR DESCRIPTION
close veryl-lang/veryl#2210
close veryl-lang/veryl#2205

Currently, wrong IR is generated for functions that are referenced before defining them because the variables referenced from such functions have not beend added to the context.

To resolve this, IR for functions and instances for generic functions should be generated when they are being defined.
IR for function call has information extracted from function definition (`inputs`, `outputs` and `ret`) so these fields need to be extracted lazily too.
To do this, the `function_calls` field is added to the `context` struct.