### PR TITLE
Report `ReferringBeforeDefinition` for function called before definition

### DIFF
--- a/crates/analyzer/src/conv/ir.rs
+++ b/crates/analyzer/src/conv/ir.rs
@@ -334,23 +334,9 @@ impl Conv<&PackageDeclaration> for () {
                         context.insert_ir_error(&ret);
                     }
                     PackageItem::FunctionDeclaration(x) => {
-                        // ignore IrError of generic function
-                        let use_ir = context.config.use_ir;
-                        if x.function_declaration.function_declaration_opt.is_some() {
-                            context.config.use_ir = false;
-                            context.ignore_var_func = true;
-                        }
-
                         let ret: IrResult<()> =
                             Conv::conv(&mut context, x.function_declaration.as_ref());
-
-                        if x.function_declaration.function_declaration_opt.is_some() {
-                            context.config.use_ir = use_ir;
-                            context.ignore_var_func = false;
-                        } else {
-                            // check IrError for non-generic function
-                            context.insert_ir_error(&ret);
-                        }
+                        context.insert_ir_error(&ret);
                     }
                     _ => (),
                 }

--- a/crates/analyzer/src/ir/function.rs
+++ b/crates/analyzer/src/ir/function.rs
@@ -2,7 +2,7 @@ use crate::conv::Context;
 use crate::conv::utils::check_compatibility;
 use crate::ir::assign_table::{AssignContext, AssignTable};
 use crate::ir::{
-    AssignDestination, Comptime, Expression, FfTable, IrResult, Shape, Signature, Statement, Type,
+    AssignDestination, Comptime, Expression, FfTable, IrResult, Shape, Signature, Statement,
     ValueVariant, VarId, VarIndex, VarPath, VarPathSelect, VarSelect,
 };
 use crate::symbol::{ClockDomain, Direction, Symbol, SymbolId, SymbolKind};
@@ -53,16 +53,6 @@ impl fmt::Display for FuncPath {
 }
 
 #[derive(Clone)]
-pub struct FuncProto {
-    pub name: StrId,
-    pub id: VarId,
-    pub ret: Option<Comptime>,
-    pub arity: usize,
-    pub args: Vec<FuncArg>,
-    pub token: TokenRange,
-}
-
-#[derive(Clone)]
 pub struct FuncArg {
     pub name: StrId,
     pub comptime: Comptime,
@@ -71,12 +61,16 @@ pub struct FuncArg {
 
 #[derive(Clone)]
 pub struct Function {
+    pub name: StrId,
     pub id: VarId,
     pub path: FuncPath,
-    pub r#type: Option<Type>,
+    pub r#type: Option<Comptime>,
     pub array: Shape,
+    pub arity: usize,
+    pub args: Vec<FuncArg>,
     pub constantable: bool,
     pub functions: Vec<FunctionBody>,
+    pub token: TokenRange,
 }
 
 impl Function {
@@ -96,6 +90,27 @@ impl Function {
         let index = self.array.calc_index(index)?;
         self.functions.get(index).cloned()
     }
+
+    pub fn to_proto(&self) -> FuncProto {
+        FuncProto {
+            name: self.name,
+            id: self.id,
+            r#type: self.r#type.clone(),
+            arity: self.arity,
+            args: self.args.clone(),
+            token: self.token,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FuncProto {
+    pub name: StrId,
+    pub id: VarId,
+    pub r#type: Option<Comptime>,
+    pub arity: usize,
+    pub args: Vec<FuncArg>,
+    pub token: TokenRange,
 }
 
 #[derive(Clone)]

--- a/crates/analyzer/src/ir/interface.rs
+++ b/crates/analyzer/src/ir/interface.rs
@@ -1,5 +1,5 @@
 use crate::HashMap;
-use crate::ir::{Comptime, FuncPath, FuncProto, Function, VarId, VarPath, Variable};
+use crate::ir::{Comptime, FuncPath, Function, VarId, VarPath, Variable};
 use crate::symbol::Direction;
 use indent::indent_all_by;
 use std::fmt;
@@ -9,7 +9,7 @@ use veryl_parser::resource_table::StrId;
 pub struct Interface {
     pub name: StrId,
     pub var_paths: HashMap<VarPath, (VarId, Comptime)>,
-    pub func_paths: HashMap<FuncPath, FuncProto>,
+    pub func_paths: HashMap<FuncPath, VarId>,
     pub variables: HashMap<VarId, Variable>,
     pub functions: HashMap<VarId, Function>,
     pub modports: HashMap<StrId, Vec<(StrId, Direction)>>,

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -934,8 +934,12 @@ impl From<&syntax_tree::GenericArgIdentifier> for GenericSymbolPath {
 impl fmt::Display for GenericSymbolPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut text = String::new();
-        for path in &self.paths {
-            text.push_str(&format!("{} ", path.mangled()));
+        for (i, path) in self.paths.iter().enumerate() {
+            if i == 0 {
+                text.push_str(&format!("{}", path.mangled()));
+            } else {
+                text.push_str(&format!(" {}", path.mangled()));
+            }
         }
         text.fmt(f)
     }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2140,25 +2140,25 @@ module ModuleA {
 "#;
 
     let expect = r#"// __PkgA__0__1__2__3
-package prj___PkgA__3894375d1deadabb;
+package prj___PkgA__97b1a4fc9479185f;
     localparam int unsigned V = 0 + 1 + 2 + 3;
 endpackage
 // __PkgA__4__5__6__7
-package prj___PkgA__c10f54f86dbec958;
+package prj___PkgA__a23a9e5c80a698c2;
     localparam int unsigned V = 4 + 5 + 6 + 7;
 endpackage
 module prj_ModuleA;
     // __FuncA____PkgA__0__1__2__3_V
-    function automatic int unsigned __FuncA__830b4abf8aba07ce() ;
-        return prj___PkgA__3894375d1deadabb::V;
+    function automatic int unsigned __FuncA__1625729981fddf71() ;
+        return prj___PkgA__97b1a4fc9479185f::V;
     endfunction
     // __FuncA____PkgA__4__5__6__7_V
-    function automatic int unsigned __FuncA__e5a0d24d19f5a43d() ;
-        return prj___PkgA__c10f54f86dbec958::V;
+    function automatic int unsigned __FuncA__1c60de7541878b99() ;
+        return prj___PkgA__a23a9e5c80a698c2::V;
     endfunction
-    int unsigned _a; always_comb _a = __FuncA__830b4abf8aba07ce();
-    int unsigned _b; always_comb _b = __FuncA__830b4abf8aba07ce();
-    int unsigned _c; always_comb _c = __FuncA__e5a0d24d19f5a43d();
+    int unsigned _a; always_comb _a = __FuncA__1625729981fddf71();
+    int unsigned _b; always_comb _b = __FuncA__1625729981fddf71();
+    int unsigned _c; always_comb _c = __FuncA__1c60de7541878b99();
 endmodule
 //# sourceMappingURL=test.sv.map
 "#;
@@ -2196,17 +2196,17 @@ alias module mod = c_module::<pkg>;
     let expect = r#"
 // __a_pkg__32
 
-package prj___a_pkg__805a71dc85438e33;
+package prj___a_pkg__cd2bef6d30dada19;
     localparam int unsigned A = 32;
 endpackage
 // __b_module____a_pkg__32
-module prj___b_module__dc41fc063ac19318;
-    import prj___a_pkg__805a71dc85438e33::*;
+module prj___b_module__c0fb5ed5baf172ab;
+    import prj___a_pkg__cd2bef6d30dada19::*;
 
 endmodule
 // __c_module____a_pkg__32
-module prj___c_module__dc41fc063ac19318;
-    prj___b_module__dc41fc063ac19318 u ();
+module prj___c_module__c0fb5ed5baf172ab;
+    prj___b_module__c0fb5ed5baf172ab u ();
 endmodule
 
 

--- a/crates/std/veryl/src/counter/counter.veryl
+++ b/crates/std/veryl/src/counter/counter.veryl
@@ -34,48 +34,10 @@ pub module counter #(
     /// Indicator for wrap around
     o_wrap_around: output logic,
 ) {
-    var count     : COUNT;
-    var count_next: COUNT;
-
-    assign o_count      = count;
-    assign o_count_next = count_next;
-
-    assign count_next = get_count_next(i_clear, i_set, i_set_value, i_up, i_down, count);
-    always_ff (i_clk, i_rst) {
-        if_reset {
-            count = INITIAL_COUNT;
-        } else {
-            count = count_next;
-        }
-    }
-
-    if (WRAP_AROUND) :g {
-        assign o_wrap_around = get_wrap_around_flag(i_clear, i_set, i_up, i_down, count);
-    } else {
-        assign o_wrap_around = '0;
-    }
-
-    function get_count_next (
-        clear        : input logic,
-        set          : input logic,
-        set_value    : input COUNT,
-        up           : input logic,
-        down         : input logic,
-        current_count: input COUNT,
-    ) -> COUNT {
-        switch {
-            clear          : return INITIAL_COUNT;
-            set            : return set_value;
-            (up && (!down)): return count_up(current_count);
-            (down && (!up)): return count_down(current_count);
-            default        : return current_count;
-        }
-    }
-
     function count_up (
         current_count: input COUNT,
     ) -> COUNT {
-        if count == MAX_COUNT {
+        if current_count == MAX_COUNT {
             if WRAP_AROUND {
                 return MIN_COUNT;
             } else {
@@ -89,7 +51,7 @@ pub module counter #(
     function count_down (
         current_count: input COUNT,
     ) -> COUNT {
-        if count == MIN_COUNT {
+        if current_count == MIN_COUNT {
             if WRAP_AROUND {
                 return MAX_COUNT;
             } else {
@@ -118,5 +80,43 @@ pub module counter #(
         } else {
             return '0;
         }
+    }
+
+    function get_count_next (
+        clear        : input logic,
+        set          : input logic,
+        set_value    : input COUNT,
+        up           : input logic,
+        down         : input logic,
+        current_count: input COUNT,
+    ) -> COUNT {
+        switch {
+            clear          : return INITIAL_COUNT;
+            set            : return set_value;
+            (up && (!down)): return count_up(current_count);
+            (down && (!up)): return count_down(current_count);
+            default        : return current_count;
+        }
+    }
+
+    var count     : COUNT;
+    var count_next: COUNT;
+
+    assign o_count      = count;
+    assign o_count_next = count_next;
+
+    assign count_next = get_count_next(i_clear, i_set, i_set_value, i_up, i_down, count);
+    always_ff (i_clk, i_rst) {
+        if_reset {
+            count = INITIAL_COUNT;
+        } else {
+            count = count_next;
+        }
+    }
+
+    if (WRAP_AROUND) :g {
+        assign o_wrap_around = get_wrap_around_flag(i_clear, i_set, i_up, i_down, count);
+    } else {
+        assign o_wrap_around = '0;
     }
 }

--- a/crates/std/veryl/src/fifo/fifo_controller.veryl
+++ b/crates/std/veryl/src/fifo/fifo_controller.veryl
@@ -71,6 +71,25 @@ pub module fifo_controller #(
     //--------------------------------------------------------------
     //  word counter
     //--------------------------------------------------------------
+    function get_word_counter_next (
+        push        : input logic     ,
+        pop         : input logic     ,
+        clear       : input logic  <2>,
+        word_counter: input COUNTER   ,
+    ) -> COUNTER {
+        var up  : logic;
+        var down: logic;
+        up   = push && (!pop);
+        down = (!push) && pop;
+        switch {
+            clear[0]: return 0 as COUNTER;
+            clear[1]: return 1 as COUNTER;
+            up      : return word_counter + 1 as COUNTER;
+            down    : return word_counter - 1 as COUNTER;
+            default : return word_counter;
+        }
+    }
+
     always_comb {
         o_word_count = word_counter;
     }
@@ -93,28 +112,19 @@ pub module fifo_controller #(
         }
     }
 
-    function get_word_counter_next (
-        push        : input logic     ,
-        pop         : input logic     ,
-        clear       : input logic  <2>,
-        word_counter: input COUNTER   ,
-    ) -> COUNTER {
-        var up  : logic;
-        var down: logic;
-        up   = push && (!pop);
-        down = (!push) && pop;
-        switch {
-            clear[0]: return 0 as COUNTER;
-            clear[1]: return 1 as COUNTER;
-            up      : return word_counter + 1 as COUNTER;
-            down    : return word_counter - 1 as COUNTER;
-            default : return word_counter;
-        }
-    }
-
     //--------------------------------------------------------------
     //  status flag
     //--------------------------------------------------------------
+    function get_status_flag (
+        word_count: input COUNTER,
+    ) -> s_status_flag {
+        var flag            : s_status_flag;
+        flag.empty       = word_count == 0;
+        flag.almost_full = word_count >= THRESHOLD;
+        flag.full        = word_count >= DEPTH;
+        return flag;
+    }
+
     always_comb {
         o_empty       = status_flag.empty;
         o_almost_full = status_flag.almost_full;
@@ -135,16 +145,6 @@ pub module fifo_controller #(
         always_comb {
             status_flag = get_status_flag(word_counter);
         }
-    }
-
-    function get_status_flag (
-        word_count: input COUNTER,
-    ) -> s_status_flag {
-        var flag            : s_status_flag;
-        flag.empty       = word_count == 0;
-        flag.almost_full = word_count >= THRESHOLD;
-        flag.full        = word_count >= DEPTH;
-        return flag;
     }
 
     //--------------------------------------------------------------

--- a/crates/tests/src/snapshots/unresolvable_generic_argument.snap
+++ b/crates/tests/src/snapshots/unresolvable_generic_argument.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 unresolvable_generic_argument (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#unresolvable_generic_argument)
 
-  × "X " can't be resolved from the definition of generics
+  × "X" can't be resolved from the definition of generics
    ╭─[../../testcases/error/unresolvable_generic_argument.veryl:3:46]
  2 │     const X: u32 = 1;
  3 │     inst u: unresolvable_generic_argument2::<X>;


### PR DESCRIPTION
Currently, wrong IR is generated for function reference before definition.
This causes #2205.

For ease to know the root cause and concistency with variable reference, report `ReferringBeforeDefinition` error for such function reference.