### PR TITLE
Fixes incorrect constant folding for 64-bit arithmetic right shift (>>>).

### DIFF
--- a/crates/analyzer/src/value.rs
+++ b/crates/analyzer/src/value.rs
@@ -90,7 +90,11 @@ impl ValueU64 {
     }
 
     pub fn gen_mask(width: usize) -> u64 {
-        if width >= 64 { 0 } else { (1u64 << width) - 1 }
+        if width >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << width) - 1
+        }
     }
 
     pub fn gen_mask_range(beg: usize, end: usize) -> u64 {


### PR DESCRIPTION
Fixed `gen_mask(64)` to correctly return `u64::MAX`. Previously, the branch handling `width >= 64` incorrectly returned `0`, which caused 64-bit values to be improperly handled throughout the Analyzer.

This fix ensures that 64-bit signed/unsigned values are correctly processed in the Analyzer IR, resolving several issues:
- Arithmetic Right Shifts: Correctly preserves the sign bit for 64-bit signed logic.
- Variable Initialization: 64-bit logic variables now correctly default to the `'X'` state instead of 0.

For example, given the following Veryl source:
```
module Top (
    o: output signed logic<64>,
    o2: output signed logic<64>,
    o3: output logic<64>
) {
    assign o = 64'shc000_0000_0000_0000 >>> 1;
    assign o2 = 64'hc000_0000_0000_0000 >>> 1;
    assign o3 = 64'shc000_0000_0000_0000 >>> 1;
}
```
# Actual
The constant folding results in `7fffffffffffffff `for signed shifts, indicating that the sign bit is not properly extended.
```
module Top {
  output var0(o): signed logic<64> = 64'sh0000000000000000;
  output var1(o2): signed logic<64> = 64'sh0000000000000000;
  output var2(o3): logic<64> = 64'h0000000000000000;
  comb {
    var0 = 64'sh7fffffffffffffff; // Incorrect
  }
  comb {
    var1 = 64'h6000000000000000;
  }
  comb {
    var2 = 64'sh7fffffffffffffff; // Incorrect
  }
}
```
# Expected
The sign bit should be correctly extended:
```
module Top {
  output var0(o): signed logic<64> = 64'shxxxxxxxxxxxxxxxx;
  output var1(o2): signed logic<64> = 64'shxxxxxxxxxxxxxxxx;
  output var2(o3): logic<64> = 64'hxxxxxxxxxxxxxxxx;
  comb {
    var0 = 64'she000000000000000; // Correct sign extension
  }
  comb {
    var1 = 64'h6000000000000000;
  }
  comb {
    var2 = 64'she000000000000000; // Correct sign extension
  }
}
```