### PR TITLE
Fix `unevaluatable_value` error reported for width cast

### DIFF
--- a/crates/analyzer/src/conv/var.rs
+++ b/crates/analyzer/src/conv/var.rs
@@ -57,6 +57,14 @@ fn check_select_type(context: &mut Context, expr: &mut ir::Expression, value: &E
     }
 }
 
+impl Conv<&ScopedIdentifier> for VarPathSelect {
+    fn conv(context: &mut Context, value: &ScopedIdentifier) -> IrResult<Self> {
+        let var_path: VarPath = Conv::conv(context, value)?;
+        let token: TokenRange = value.into();
+        Ok(VarPathSelect(var_path, VarSelect::default(), token))
+    }
+}
+
 impl Conv<&ExpressionIdentifier> for VarPathSelect {
     fn conv(context: &mut Context, value: &ExpressionIdentifier) -> IrResult<Self> {
         check_separator(context, value);

--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -330,7 +330,15 @@ impl Expression {
                     | Op::NeWildcard
                     | Op::LogicAnd
                     | Op::LogicOr => Some(1),
-                    Op::As => Some(0),
+                    Op::As => {
+                        if let ValueVariant::Numeric(y) = &y.value
+                            && let Some(y) = y.to_usize()
+                        {
+                            Some(y)
+                        } else {
+                            Some(0)
+                        }
+                    }
                     _ => unreachable!(),
                 };
                 ret.r#type.width = Shape::new(vec![width]);
@@ -386,7 +394,12 @@ impl Expression {
                         }
                     }
                     Op::As => {
-                        if let ValueVariant::Type(y) = y.value {
+                        if let ValueVariant::Numeric(y) = &y.value
+                            && let Some(_width) = y.to_usize()
+                        {
+                            // TODO
+                            // Check width range
+                        } else if let ValueVariant::Type(y) = y.value {
                             let invalid_clock_cast = y.is_clock() && !x.r#type.is_clock();
                             let invalid_reset_cast = y.is_reset() && x.r#type.is_clock();
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -7879,6 +7879,29 @@ fn unevaluable_value_reset_value() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package Pkg {
+        const W: u32 = 8;
+    }
+    module ModuleA (
+        i_clk: input clock,
+        i_rst: input reset,
+    ) {
+        import Pkg::*;
+        var _d: logic<W>;
+        always_ff {
+            if_reset {
+                _d = 0 as W;
+            } else {
+                _d = 1 as W;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2259

Currently, IR conversion for cast operation whose RHS is factor defined in other component is treated as error. This causes #2259.

To fix #2259, I implemented the above case.