### PR TITLE
Support proto package functions in IR conversion

### DIFF
--- a/crates/analyzer/src/conv/statement.rs
+++ b/crates/analyzer/src/conv/statement.rs
@@ -274,8 +274,9 @@ impl Conv<&IdentifierStatement> for ir::StatementBlock {
                     ir::Arguments::Null
                 };
 
-                let symbol = symbol_table::resolve(value.expression_identifier.as_ref())
-                    .map_err(|_| ir_error!(token))?;
+                let resolved_path =
+                    context.resolve_path(value.expression_identifier.as_ref().into());
+                let symbol = symbol_table::resolve(&resolved_path).map_err(|_| ir_error!(token))?;
 
                 match &symbol.found.kind {
                     SymbolKind::SystemFunction(_) => {

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1107,8 +1107,8 @@ pub fn eval_function_call(
             ir::Arguments::Null
         };
 
-        let symbol = symbol_table::resolve(value.expression_identifier.as_ref())
-            .map_err(|_| ir_error!(token))?;
+        let resolved_path = context.resolve_path(value.expression_identifier.as_ref().into());
+        let symbol = symbol_table::resolve(&resolved_path).map_err(|_| ir_error!(token))?;
 
         match &symbol.found.kind {
             SymbolKind::SystemFunction(_) => {

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -66,6 +66,14 @@ impl Signature {
                 }
                 symbol.found
             }
+            SymbolKind::ProtoFunction(_) => {
+                let resolved = context.resolve_path(path.clone());
+                let symbol = symbol_table::resolve(&resolved).ok()?;
+                match &symbol.found.kind {
+                    SymbolKind::Function(_) => symbol.found,
+                    _ => return None,
+                }
+            }
             SymbolKind::ProtoAliasModule(x) => {
                 let symbol = symbol_table::resolve(&x.target).ok()?;
                 return Some(Signature::new(symbol.found.id));

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -1857,3 +1857,73 @@ fn concat() {
 "#;
     check_ir(code, exp);
 }
+
+#[test]
+fn proto_function() {
+    let code = r#"
+    proto package Element {
+        type data;
+        function gt(a: input data, b: input data) -> logic;
+    }
+    package IntElement for Element {
+        type data = logic<8>;
+        function gt(a: input data, b: input data) -> logic {
+            return a >: b;
+        }
+    }
+    module ModuleA::<E: Element> (
+        a: input  E::data,
+        b: input  E::data,
+        r: output logic,
+    ) {
+        always_comb {
+            r = E::gt(a, b);
+        }
+    }
+    module Top (
+        a: input  logic<8>,
+        b: input  logic<8>,
+        r: output logic,
+    ) {
+        inst inner: ModuleA::<IntElement> (a, b, r);
+    }
+    "#;
+    let exp = r#"module ModuleA {
+  input var0(a): unknown = 1'hx;
+  input var1(b): unknown = 1'hx;
+  output var2(r): logic = 1'hx;
+
+  comb {
+    var2 = unknown;
+  }
+}
+module Top {
+  input var0(a): logic<8> = 8'hxx;
+  input var1(b): logic<8> = 8'hxx;
+  output var2(r): logic = 1'hx;
+
+  inst inner (
+    var0 <- var0;
+    var1 <- var1;
+    var2 -> var2;
+  ) {
+    module ModuleA {
+      input var0(a): logic<8> = 8'hxx;
+      input var1(b): logic<8> = 8'hxx;
+      output var2(r): logic = 1'hx;
+      var var4(E.gt.return): logic = 1'hx;
+      input var5(E.gt.a): logic<8> = 8'hxx;
+      input var6(E.gt.b): logic<8> = 8'hxx;
+      func var3(E.gt) -> var4 {
+        var4 = (var5 >: var6);
+      }
+
+      comb {
+        var2 = var3(a: var0, b: var1);
+      }
+    }
+  }
+}
+"#;
+    check_ir(code, exp);
+}


### PR DESCRIPTION
Resolve symbol paths through context generic maps before symbol table lookup in `eval_function_call`, `IdentifierStatement`, and `Signature::from_path`, so that proto symbols (e.g. `E::gt`) resolve to their concrete implementations (e.g. `IntElement::gt`) during IR  conversion.
```diff
-      var2 = unknown;
+      var var4(E.gt.return): logic = 1'hx;
+      input var5(E.gt.a): logic<8> = 8'hxx;
+      input var6(E.gt.b): logic<8> = 8'hxx;
+      func var3(E.gt) -> var4 {
+        var4 = (var5 >: var6);
+      }
+      var2 = var3(a: var0, b: var1);
```