### PR TITLE
Fix analyzer panic during converting binary op b/w large width variable and `'0` literal

### DIFF
--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -1839,7 +1839,7 @@ fn concat() {
     o: output logic<16>,
     o2: output logic<16>,
 ) {
-    assign o = {8'hff + 8'h1}; 
+    assign o = {8'hff + 8'h1};
     assign o2 = {8'hf0, 8'hff + 8'h1};
 }
     "#;
@@ -1925,5 +1925,31 @@ module Top {
   }
 }
 "#;
+    check_ir(code, exp);
+}
+
+#[test]
+fn binary_operation_with_large_width_variable() {
+    let code = r#"
+module Top (
+  a: input  logic<65>,
+  b: output logic    ,
+) {
+  always_comb {
+    b = a == '0;
+  }
+}
+"#;
+
+    let exp = r#"module Top {
+  input var0(a): logic<65> = 65'hxxxxxxxxxxxxxxxxx;
+  output var1(b): logic = 1'hx;
+
+  comb {
+    var1 = (var0 == '0);
+  }
+}
+"#;
+
     check_ir(code, exp);
 }

--- a/crates/analyzer/src/value.rs
+++ b/crates/analyzer/src/value.rs
@@ -752,7 +752,7 @@ impl Value {
     }
 
     pub fn expand(&self, width: usize, use_sign: bool) -> Cow<'_, Self> {
-        if self.width() == 0 || self.width() >= width {
+        if (self.width() == 0 && width <= 64) || self.width() >= width {
             Cow::Borrowed(self)
         } else if width > 64 {
             let ret = match self {


### PR DESCRIPTION
fix veryl-lang/veryl#2275

Bit expantion of `'0` literal is not performed because it is treated as `U64` value with 0 width.
https://github.com/veryl-lang/veryl/blob/536ba379c83403855b60dfb6cf8b16ba48049430/crates/analyzer/src/value.rs#L755
This cuases #2275.

To fix this issue, change the above condition to perform bit expansion forcely when the given width > 64.