### PR TITLE
Used line.contains(...) instead of line.starts_with(...)

### DIFF
--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -46,46 +46,28 @@ impl Cocotb {
     }
 
     fn parse_line(&mut self, line: &str, force_error: bool) {
-        self.debug(line);
-
         if force_error {
             self.error(line);
         } else {
-            if !line.starts_with("                ") {
+            // Set the log level for each line
+            if line.contains("DEBUG") {
+                self.debug(line);
+                self.state = State::Info; // which state should it be ?
+            } else if line.contains("INFO") {
+                self.info(line);
+                self.state = State::Info;
+            } else if line.contains("WARNING") {
+                self.warning(line);
+                self.state = State::Warning;
+            } else if line.contains("ERROR") {
+                self.error(line);
+                self.state = State::Error;
+            } else if line.contains("CRTITICAL") {
+                self.fatal(line);
+                self.state = State::Fatal;
+            } else {
+                self.info(line);
                 self.state = State::Idle;
-            }
-
-            match self.state {
-                State::Idle => {
-                    if line.ends_with("failed") {
-                        self.error(line);
-                        self.state = State::Error;
-                    } else if line.starts_with("     0.00ns INFO") {
-                        self.info(line);
-                        self.state = State::Info;
-                    } else if line.starts_with("     0.00ns WARNING") {
-                        self.warning(line);
-                        self.state = State::Warning;
-                    } else if line.starts_with("     0.00ns ERROR") {
-                        self.error(line);
-                        self.state = State::Error;
-                    } else if line.starts_with("     0.00ns CRITICAL") {
-                        self.fatal(line);
-                        self.state = State::Fatal;
-                    }
-                }
-                State::Info => {
-                    self.info(line);
-                }
-                State::Warning => {
-                    self.warning(line);
-                }
-                State::Error => {
-                    self.error(line);
-                }
-                State::Fatal => {
-                    self.fatal(line);
-                }
             }
         }
     }

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -47,28 +47,28 @@ impl Cocotb {
     }
 
     fn parse_line(&mut self, line: &str, force_error: bool) {
-        self.debug(line);   // Show all lines in debug mode by default
+        self.debug(line); // Show all lines in debug mode by default
 
         // Check for keyword presence to set line's state
         if force_error {
             self.state = State::Error;
         } else {
-            if line.contains("DEBUG") {     
+            if line.contains("DEBUG") {
                 self.state = State::Debug;
             } else if line.contains("INFO") {
                 self.state = State::Info;
             } else if line.contains("WARNING") {
                 self.state = State::Warning;
-            } else if line.contains("ERROR"){
+            } else if line.contains("ERROR") {
                 self.state = State::Error;
             } else if line.contains("CRTITICAL") {
                 self.state = State::Fatal;
-            } 
+            }
         }
 
-        // Display the line 
+        // Display the line
         match self.state {
-            State::Debug => self.debug(line), 
+            State::Debug => self.debug(line),
             State::Idle => self.info(line),
             State::Info => self.info(line),
             State::Warning => self.warning(line),

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -15,6 +15,7 @@ use veryl_parser::veryl_grammar_trait::{self as syntax_tree};
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum State {
     Idle,
+    Debug,
     Info,
     Warning,
     Error,
@@ -46,29 +47,33 @@ impl Cocotb {
     }
 
     fn parse_line(&mut self, line: &str, force_error: bool) {
+        self.debug(line);   // Show all lines in debug mode by default
+
+        // Check for keyword presence to set line's state
         if force_error {
-            self.error(line);
+            self.state = State::Error;
         } else {
-            // Set the log level for each line
-            if line.contains("DEBUG") {
-                self.debug(line);
-                self.state = State::Info; // which state should it be ?
+            if line.contains("DEBUG") {     
+                self.state = State::Debug;
             } else if line.contains("INFO") {
-                self.info(line);
                 self.state = State::Info;
             } else if line.contains("WARNING") {
-                self.warning(line);
                 self.state = State::Warning;
-            } else if line.contains("ERROR") {
-                self.error(line);
+            } else if line.contains("ERROR"){
                 self.state = State::Error;
             } else if line.contains("CRTITICAL") {
-                self.fatal(line);
                 self.state = State::Fatal;
-            } else {
-                self.info(line);
-                self.state = State::Idle;
-            }
+            } 
+        }
+
+        // Display the line 
+        match self.state {
+            State::Debug => self.debug(line), 
+            State::Idle => self.info(line),
+            State::Info => self.info(line),
+            State::Warning => self.warning(line),
+            State::Error => self.error(line),
+            State::Fatal => self.fatal(line),
         }
     }
 


### PR DESCRIPTION
Cocotb uses Python logging library with the following formatting:
>     100.00ns INFO     cocotb                             Running tests
But Veryl's cocotb runner only checked that a line starts with 0.00ns and a log level, this would only allow 0.00ns logs to be displayed in non-debug mode.

Should close: #2279 

So I replaced all the `line.starts_with(...)` by `line.contains(...)`  and touched a lot of things around it.

This is a draft PR because I didn't get the goal of the State enum in the runner, it doesn't seem to be used for now so I copied behavior from dsim.rs.

It seems like it is used to mark a whole Veryl test as error once one is detected but it's not clear whether the bool success is enough or not. 
Could you point me in the right direction ? 

Python logging library gives us the log level, and has a debug log level, the user can control the log level in the testbench, I will look if we can force the log level from the python runner : https://docs.cocotb.org/en/stable/library_reference.html#logging.

This is my first time writing Rust so feel free to emit critics if I'm not doing something right.