### PR TITLE
Allow to reference function before definition

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -5,6 +5,7 @@ use crate::ir::{
     IrResult, ShapeRef, Signature, Type, VarId, VarIndex, VarKind, VarPath, VarSelect, Variable,
     VariableInfo,
 };
+use crate::namespace::Namespace;
 use crate::namespace_table;
 use crate::symbol::{Affiliation, ClockDomain, Direction, GenericMap, SymbolId};
 use crate::symbol_path::GenericSymbolPath;
@@ -52,6 +53,7 @@ pub struct Context {
     pub select_paths: Vec<(VarPath, GenericSymbolPath)>,
     pub select_dims: Vec<usize>,
     pub ignore_var_func: bool,
+    pub namespaces: Vec<Namespace>,
     pub in_generic: bool,
     pub in_if_reset: bool,
     pub current_clock: Option<Comptime>,
@@ -72,6 +74,7 @@ impl Context {
         std::mem::swap(&mut self.generic_maps, &mut tgt.generic_maps);
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
+        std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);
         self.func_call_depth = tgt.func_call_depth;
         self.in_generic = tgt.in_generic;
         self.config = tgt.config.clone();
@@ -480,6 +483,18 @@ impl Context {
 
     pub fn get_affiliation(&self) -> Affiliation {
         self.affiliation.last().copied().unwrap()
+    }
+
+    pub fn push_namespace(&mut self, namespace: Namespace) {
+        self.namespaces.push(namespace);
+    }
+
+    pub fn pop_namespace(&mut self) {
+        self.namespaces.pop();
+    }
+
+    pub fn currnet_namespace(&self) -> Option<Namespace> {
+        self.namespaces.last().cloned()
     }
 
     pub fn find_path(&self, path: &VarPath) -> Option<(VarId, Comptime)> {

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -816,7 +816,7 @@ impl Conv<(&FunctionDeclaration, Option<&FuncPath>)> for () {
         }
 
         if let Ok(symbol) = symbol_table::resolve(func_def.identifier.as_ref())
-            && let SymbolKind::Function(x) = symbol.found.kind
+            && let SymbolKind::Function(x) = &symbol.found.kind
         {
             let constantable = x.constantable.unwrap();
             let ret_type = if let Some(x) = &x.ret {
@@ -848,11 +848,18 @@ impl Conv<(&FunctionDeclaration, Option<&FuncPath>)> for () {
                 let path = FuncPath::new(symbol.found.id);
                 (path, name)
             };
+
+            if context.func_paths.contains_key(&path) {
+                // The given function has already been added through function reference before definition.
+                return Ok(());
+            }
+
             let token: TokenRange = symbol.found.token.into();
             let id = context.insert_func_path(path.clone());
 
             context.push_affiliation(Affiliation::Function);
             context.push_hierarchy(name);
+            context.push_namespace(symbol.found.inner_namespace());
 
             let arg_items: Vec<_> = if let Some(x) = &func_def.function_declaration_opt0
                 && let Some(x) = &x.port_declaration.port_declaration_opt
@@ -958,6 +965,7 @@ impl Conv<(&FunctionDeclaration, Option<&FuncPath>)> for () {
 
             context.pop_affiliation();
             context.pop_hierarchy();
+            context.pop_namespace();
 
             let function = ir::Function {
                 name,

--- a/crates/analyzer/src/conv/ir.rs
+++ b/crates/analyzer/src/conv/ir.rs
@@ -127,8 +127,9 @@ impl Conv<&ModuleDeclaration> for ir::Module {
         context.push_affiliation(Affiliation::Module);
 
         if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
-            && let SymbolKind::Module(x) = symbol.found.kind
+            && let SymbolKind::Module(x) = &symbol.found.kind
         {
+            context.push_namespace(symbol.found.inner_namespace());
             if let Some(x) = x.default_clock {
                 let path = VarPath::new(symbol_table::get(x).unwrap().token.text);
                 context.set_default_clock(path, x);
@@ -217,6 +218,7 @@ impl Conv<&ModuleDeclaration> for ir::Module {
             }
         }
 
+        context.pop_namespace();
         upper_context.inherit(&mut context);
 
         Ok(ir::Module {
@@ -240,6 +242,15 @@ impl Conv<&InterfaceDeclaration> for ir::Interface {
 
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::Interface);
+
+        if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
+            && matches!(symbol.found.kind, SymbolKind::Interface(_))
+        {
+            context.push_namespace(symbol.found.inner_namespace());
+        } else {
+            let token: TokenRange = value.identifier.as_ref().into();
+            return Err(ir_error!(token));
+        }
 
         if let Some(x) = &value.interface_declaration_opt {
             check_generic_bound(&mut context, &x.with_generic_parameter);
@@ -296,6 +307,7 @@ impl Conv<&InterfaceDeclaration> for ir::Interface {
             .extract_if(|_, v| v.affiliation != Affiliation::Function)
             .collect();
 
+        context.pop_namespace();
         upper_context.inherit(&mut context);
 
         Ok(ir::Interface {
@@ -318,6 +330,15 @@ impl Conv<&PackageDeclaration> for () {
 
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::Package);
+
+        if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
+            && matches!(symbol.found.kind, SymbolKind::Package(_))
+        {
+            context.push_namespace(symbol.found.inner_namespace());
+        } else {
+            let token: TokenRange = value.identifier.as_ref().into();
+            return Err(ir_error!(token));
+        }
 
         if let Some(x) = &value.package_declaration_opt {
             check_generic_bound(&mut context, &x.with_generic_parameter);
@@ -351,6 +372,7 @@ impl Conv<&PackageDeclaration> for () {
             }
         }
 
+        context.pop_namespace();
         upper_context.inherit(&mut context);
 
         Ok(())
@@ -366,6 +388,15 @@ impl Conv<&ProtoModuleDeclaration> for ir::Module {
 
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::ProtoModule);
+
+        if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
+            && matches!(symbol.found.kind, SymbolKind::ProtoModule(_))
+        {
+            context.push_namespace(symbol.found.inner_namespace());
+        } else {
+            let token: TokenRange = value.identifier.as_ref().into();
+            return Err(ir_error!(token));
+        }
 
         if let Some(x) = &value.proto_module_declaration_opt
             && let Some(x) = &x.with_parameter.with_parameter_opt
@@ -398,6 +429,7 @@ impl Conv<&ProtoModuleDeclaration> for ir::Module {
             }
         }
 
+        context.pop_namespace();
         upper_context.inherit(&mut context);
 
         Ok(ir::Module {
@@ -415,6 +447,15 @@ impl Conv<&ProtoModuleDeclaration> for ir::Module {
 impl Conv<&ProtoInterfaceDeclaration> for () {
     fn conv(context: &mut Context, value: &ProtoInterfaceDeclaration) -> IrResult<Self> {
         context.push_affiliation(Affiliation::ProtoInterface);
+
+        if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
+            && matches!(symbol.found.kind, SymbolKind::ProtoInterface(_))
+        {
+            context.push_namespace(symbol.found.inner_namespace());
+        } else {
+            let token: TokenRange = value.identifier.as_ref().into();
+            return Err(ir_error!(token));
+        }
 
         for x in &value.proto_interface_declaration_list {
             if let ProtoInterfaceItem::ProtoAliasDeclaration(x) = x.proto_interface_item.as_ref() {
@@ -436,6 +477,7 @@ impl Conv<&ProtoInterfaceDeclaration> for () {
         }
 
         context.pop_affiliation();
+        context.pop_namespace();
         Ok(())
     }
 }
@@ -443,6 +485,15 @@ impl Conv<&ProtoInterfaceDeclaration> for () {
 impl Conv<&ProtoPackageDeclaration> for () {
     fn conv(context: &mut Context, value: &ProtoPackageDeclaration) -> IrResult<Self> {
         context.push_affiliation(Affiliation::ProtoPackage);
+
+        if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
+            && matches!(symbol.found.kind, SymbolKind::ProtoPackage(_))
+        {
+            context.push_namespace(symbol.found.inner_namespace());
+        } else {
+            let token: TokenRange = value.identifier.as_ref().into();
+            return Err(ir_error!(token));
+        }
 
         for x in &value.proto_package_declaration_list {
             if let ProtoPacakgeItem::ProtoAliasDeclaration(x) = x.proto_pacakge_item.as_ref() {
@@ -464,6 +515,7 @@ impl Conv<&ProtoPackageDeclaration> for () {
         }
 
         context.pop_affiliation();
+        context.pop_namespace();
         Ok(())
     }
 }

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -16,7 +16,7 @@ use crate::symbol::{
 use crate::symbol_path::{GenericSymbolPath, GenericSymbolPathKind};
 use crate::symbol_table::{self, ResolveResult};
 use crate::value::Value;
-use crate::{HashMap, ir_error, namespace_table};
+use crate::{HashMap, ir_error};
 use veryl_parser::resource_table::{self, StrId};
 use veryl_parser::token_range::TokenRange;
 use veryl_parser::veryl_grammar_trait::*;
@@ -1291,6 +1291,16 @@ pub fn eval_external_symbol(
 ) -> IrResult<ir::Factor> {
     match &symbol.found.kind {
         SymbolKind::Parameter(x) => {
+            // Parameter should be found through context.find_path from the defined namespace
+            if let Some(namespace) = context.currnet_namespace()
+                && symbol.found.namespace.included(&namespace)
+            {
+                context.insert_error(AnalyzerError::referring_before_definition(
+                    &symbol.found.token.to_string(),
+                    &token,
+                ));
+            }
+
             if let Some(expr) = &x.value {
                 let r#type = x.r#type.to_ir_type(context, TypePosition::Variable)?;
                 let (mut comptime, _) =
@@ -2091,24 +2101,8 @@ pub fn var_path_to_assign_destination(
         .collect()
 }
 
-fn get_function(
-    context: &mut Context,
-    path: &FuncPath,
-    is_local_function: bool,
-    token: TokenRange,
-) -> IrResult<FuncProto> {
+fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> IrResult<FuncProto> {
     if !context.func_paths.contains_key(path) {
-        if is_local_function
-            && context.func_call_depth == 0
-            && !context.func_paths.contains_key(&path.base())
-        {
-            context.insert_error(AnalyzerError::referring_before_definition(
-                &token.beg.text.to_string(),
-                &token,
-            ));
-            return Err(ir_error!(token));
-        }
-
         let symbol = symbol_table::get(path.sig.symbol).unwrap();
         let definition = match &symbol.kind {
             SymbolKind::Function(x) => x.definition.unwrap(),
@@ -2173,12 +2167,6 @@ pub fn function_call(
     parent_path.paths.pop();
     let sig = Signature::from_path(context, generic_path).ok_or_else(|| ir_error!(token))?;
 
-    let is_local_function = {
-        let namespace = namespace_table::get(path.identifier().token.id).unwrap();
-        let symbol = symbol_table::get(sig.symbol).unwrap();
-        namespace.included(&symbol.namespace)
-    };
-
     let path: VarPathSelect = Conv::conv(context, path)?;
     let (mut base_path, select, _) = path.into();
     let index = select.to_index();
@@ -2217,7 +2205,7 @@ pub fn function_call(
     context.push_generic_map(map);
 
     let ret = context.block(|c| {
-        let func = get_function(c, &path, is_local_function, token)?;
+        let func = get_function(c, &path, token)?;
         let (inputs, outputs) = args.to_function_args(c, &func, token)?;
 
         let mut comptime = func.r#type.clone();

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -801,6 +801,29 @@ fn function() {
 "#;
 
     check_ir(code, exp);
+
+    let code = r#"
+    module ModuleA {
+        const A: u32 = 8;
+        const B: u32 = func();
+        function func() -> u32 {
+            return A;
+        }
+    }
+    "#;
+
+    let exp = r#"module ModuleA {
+  const var0(A): bit<32> = 32'sh00000008;
+  var var2(func.return): bit<32> = 32'h00000008;
+  const var3(B): bit<32> = 32'h00000008;
+  func var1(func) -> var2 {
+    var2 = var0;
+  }
+
+}
+"#;
+
+    check_ir(code, exp);
 }
 
 #[test]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4602,7 +4602,7 @@ fn missing_reset_statement() {
         i_trst: input reset,
     ) {
         var data_shift_reg: logic<40>;
-    
+
         always_ff {
             if_reset {
                 data_shift_reg = '0;
@@ -5374,6 +5374,35 @@ fn referring_before_definition() {
     ));
 
     let code = r#"
+    module ModuleA #(
+        param A: bit<B> = 0,
+        param B: u32    = 8
+    ) {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::ReferringBeforeDefinition { .. }
+    ));
+
+    let code = r#"
+    module ModuleA #(
+        param A: u32    = 16,
+        param B: bit<A> = 0 ,
+    ) {}
+    module ModuleB {
+        inst u: ModuleA #(
+            A: 32,
+            B: 1 ,
+        );
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
     proto package ProtoPkg {
         const INFO     : bbool;
         const INFO_TYPE: type ;
@@ -5402,10 +5431,54 @@ fn referring_before_definition() {
     assert!(errors.is_empty());
 
     let code = r#"
+    package PkgA {
+        function func_a() -> u32 {
+            return 8;
+        }
+        function func_b() -> u32 {
+            return func_a();
+        }
+    }
+    module ModuleA {
+        import PkgA::*;
+        const A: u32 = func_b();
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
     module ModuleA {
         let _a: u32 = func();
         function func() -> u32 {
             return 0;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        let a : u32 = 8;
+        let _b: u32 = func();
+        function func() -> u32 {
+            return a;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        let _a: u32 = func();
+        let b : u32 = 0;
+        function func() -> u32 {
+            return b;
         }
     }
     "#;
@@ -5426,28 +5499,55 @@ fn referring_before_definition() {
     "#;
 
     let errors = analyze(code);
-    assert!(matches!(
-        errors[0],
-        AnalyzerError::ReferringBeforeDefinition { .. }
-    ));
+    assert!(errors.is_empty());
 
     let code = r#"
-    package PkgA {
-        function func_a() -> u32 {
-            return 8;
+    module ModuleA #(
+        param N: u32 = 4,
+    ) {
+        let _a: u32 = func();
+        function func() -> u32 {
+            var a: u32;
+            for _i: u32 in 0..N {
+                a = 0;
+            }
+            return a;
         }
-        function func_b() -> u32 {
-            return func_a();
-        }
-    }
-    module ModuleA {
-        import PkgA::*;
-        const A: u32 = func_b();
     }
     "#;
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        let _a: u32 = func();
+        function func() -> u32 {
+            const A: u32 = 0;
+            return A;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        let _a: u32 = func();
+
+        const W: u32 = 32;
+        function func() -> bit<W> {
+            return 0;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::ReferringBeforeDefinition { .. }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
close #2205
close #2210

This PR is to relax the limitation that any functions should be defined before calling them.
Functions that have no references to variables not defined at the time calling them can be called before definition.