### PR TITLE
Fix `referring_before_definition` error during converting type expression

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1264,19 +1264,28 @@ pub fn eval_factor_path(
         comptime.is_global = true;
         Ok(ir::Factor::Anonymous(comptime))
     } else if let Ok(symbol) = symbol_table::resolve(&generic_path) {
-        // To resolve external symbol reference,
-        // use an independent context to avoid name conflict
-        let mut external_context = Context::default();
-        external_context.inherit(context);
+        let is_inernal = context
+            .currnet_namespace()
+            .map(|x| symbol.found.namespace.included(&x))
+            .unwrap_or(false);
+        if is_inernal {
+            eval_external_symbol(context, generic_path, symbol, allow_unknown_value, token)
+        } else {
+            // To resolve external symbol reference,
+            // use an independent context to avoid name conflict
+            let mut external_context = Context::default();
+            external_context.inherit(context);
 
-        external_context.push_generic_map(generic_path.to_generic_maps());
-        let ret = external_context
-            .block(|c| eval_external_symbol(c, generic_path, symbol, allow_unknown_value, token));
+            external_context.push_generic_map(generic_path.to_generic_maps());
+            let ret = external_context.block(|c| {
+                eval_external_symbol(c, generic_path, symbol, allow_unknown_value, token)
+            });
 
-        external_context.pop_generic_map();
-        context.inherit(&mut external_context);
+            external_context.pop_generic_map();
+            context.inherit(&mut external_context);
 
-        ret
+            ret
+        }
     } else {
         Err(ir_error!(token))
     }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5387,6 +5387,22 @@ fn referring_before_definition() {
     ));
 
     let code = r#"
+    package A {
+        const A: u32  = 1;
+        const X: type = logic<A>;
+
+        struct Y {
+            x: X,
+        }
+
+        const Z: type = Y;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
     module ModuleA #(
         param A: u32    = 16,
         param B: bit<A> = 0 ,


### PR DESCRIPTION
fix veryl-lang/veryl#2287

Currenlty, `eval_external_symbol` is used to converting `type` expression because there are no information about `type` in the context.
However, the given `type` cannot be converted if it is depend on `const type` because new context is used for conversion and `const type` does not exist in the new context.
https://github.com/veryl-lang/veryl/blob/7bbba6179eaaf1660f7ed1276ce5400e809a5a78/crates/analyzer/src/conv/utils.rs#L1269

To resolve this, the given context is used but not new contenxt if namespace of the symbol is matched with the current namespace 