### PR TITLE
Fix gather_context panic with assignment operators on array-indexed variables

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1247,6 +1247,7 @@ pub fn eval_factor_path(
             Err(ir_error!(token))
         } else {
             let index = array_select.to_index();
+            comptime.r#type.array.drain(0..index.dimension());
 
             comptime.token = token;
             if comptime.r#type.is_type() {

--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -521,8 +521,9 @@ impl Factor {
 
     pub fn gather_context(&mut self, context: &mut Context) -> ExpressionContext {
         match self {
-            Factor::Variable(_, index, select, comptime) => {
-                comptime.r#type.array.drain(0..index.dimension());
+            Factor::Variable(_, _index, select, comptime) => {
+                // Array dimensions are already drained at Factor construction time
+                // (in VarPathSelect::to_expression and eval_factor).
 
                 // Struct/Union/Enum should be treated as flatten bit/logic when it is bit-selected
                 if !select.is_empty() {

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -1976,3 +1976,98 @@ module Top (
 
     check_ir(code, exp);
 }
+
+#[test]
+fn assignment_operator_with_array_index() {
+    let code = r#"
+    module Top #(
+        param N: u32 = 4,
+    ) (
+        a: input  logic [N],
+        b: output logic<32> [N],
+    ) {
+        var score: logic<32> [N];
+        always_comb {
+            for i: u32 in 0..N {
+                score[i] = 0;
+                for j: u32 in 0..N {
+                    score[i] += a[j];
+                }
+            }
+            for i: u32 in 0..N {
+                b[i] = score[i];
+            }
+        }
+    }
+    "#;
+
+    let exp = r#"module Top {
+  param var0(N): bit<32> = 32'sh00000004;
+  input var1[0](a): logic = 1'hx;
+  input var1[1](a): logic = 1'hx;
+  input var1[2](a): logic = 1'hx;
+  input var1[3](a): logic = 1'hx;
+  output var2[0](b): logic<32> = 32'hxxxxxxxx;
+  output var2[1](b): logic<32> = 32'hxxxxxxxx;
+  output var2[2](b): logic<32> = 32'hxxxxxxxx;
+  output var2[3](b): logic<32> = 32'hxxxxxxxx;
+  var var3[0](score): logic<32> = 32'hxxxxxxxx;
+  var var3[1](score): logic<32> = 32'hxxxxxxxx;
+  var var3[2](score): logic<32> = 32'hxxxxxxxx;
+  var var3[3](score): logic<32> = 32'hxxxxxxxx;
+  const var4([0].i): bit<32> = 32'h00000000;
+  const var5([0].[0].j): bit<32> = 32'h00000000;
+  const var6([0].[1].j): bit<32> = 32'h00000001;
+  const var7([0].[2].j): bit<32> = 32'h00000002;
+  const var8([0].[3].j): bit<32> = 32'h00000003;
+  const var9([1].i): bit<32> = 32'h00000001;
+  const var10([1].[0].j): bit<32> = 32'h00000000;
+  const var11([1].[1].j): bit<32> = 32'h00000001;
+  const var12([1].[2].j): bit<32> = 32'h00000002;
+  const var13([1].[3].j): bit<32> = 32'h00000003;
+  const var14([2].i): bit<32> = 32'h00000002;
+  const var15([2].[0].j): bit<32> = 32'h00000000;
+  const var16([2].[1].j): bit<32> = 32'h00000001;
+  const var17([2].[2].j): bit<32> = 32'h00000002;
+  const var18([2].[3].j): bit<32> = 32'h00000003;
+  const var19([3].i): bit<32> = 32'h00000003;
+  const var20([3].[0].j): bit<32> = 32'h00000000;
+  const var21([3].[1].j): bit<32> = 32'h00000001;
+  const var22([3].[2].j): bit<32> = 32'h00000002;
+  const var23([3].[3].j): bit<32> = 32'h00000003;
+  const var24([0].i): bit<32> = 32'h00000000;
+  const var25([1].i): bit<32> = 32'h00000001;
+  const var26([2].i): bit<32> = 32'h00000002;
+  const var27([3].i): bit<32> = 32'h00000003;
+
+  comb {
+    var3[32'h00000000] = 32'sh00000000;
+    var3[32'h00000000] = (var3[32'h00000000] + var1[32'h00000000]);
+    var3[32'h00000000] = (var3[32'h00000000] + var1[32'h00000001]);
+    var3[32'h00000000] = (var3[32'h00000000] + var1[32'h00000002]);
+    var3[32'h00000000] = (var3[32'h00000000] + var1[32'h00000003]);
+    var3[32'h00000001] = 32'sh00000000;
+    var3[32'h00000001] = (var3[32'h00000001] + var1[32'h00000000]);
+    var3[32'h00000001] = (var3[32'h00000001] + var1[32'h00000001]);
+    var3[32'h00000001] = (var3[32'h00000001] + var1[32'h00000002]);
+    var3[32'h00000001] = (var3[32'h00000001] + var1[32'h00000003]);
+    var3[32'h00000002] = 32'sh00000000;
+    var3[32'h00000002] = (var3[32'h00000002] + var1[32'h00000000]);
+    var3[32'h00000002] = (var3[32'h00000002] + var1[32'h00000001]);
+    var3[32'h00000002] = (var3[32'h00000002] + var1[32'h00000002]);
+    var3[32'h00000002] = (var3[32'h00000002] + var1[32'h00000003]);
+    var3[32'h00000003] = 32'sh00000000;
+    var3[32'h00000003] = (var3[32'h00000003] + var1[32'h00000000]);
+    var3[32'h00000003] = (var3[32'h00000003] + var1[32'h00000001]);
+    var3[32'h00000003] = (var3[32'h00000003] + var1[32'h00000002]);
+    var3[32'h00000003] = (var3[32'h00000003] + var1[32'h00000003]);
+    var2[32'h00000000] = var3[32'h00000000];
+    var2[32'h00000001] = var3[32'h00000001];
+    var2[32'h00000002] = var3[32'h00000002];
+    var2[32'h00000003] = var3[32'h00000003];
+  }
+}
+"#;
+
+    check_ir(code, exp);
+}

--- a/crates/analyzer/src/ir/variable.rs
+++ b/crates/analyzer/src/ir/variable.rs
@@ -106,6 +106,7 @@ impl VarPathSelect {
 
         if let Some((id, mut comptime)) = context.find_path(&path) {
             let (array_select, width_select) = select.split(comptime.r#type.array.dims());
+            comptime.r#type.array.drain(0..array_select.dimension());
 
             comptime.token = token;
             let src = Factor::Variable(id, array_select.to_index(), width_select, comptime);


### PR DESCRIPTION
`Factor::gather_context` panics when called on a `Factor::Variable` that has already been evaluated. This occurs with assignment operators (e.g. `+=`) on array-indexed variables.
  
Commit a1684bc4 moved the `array.drain()`  call from `VarPathSelect::to_expression` into `Factor::gather_context`, and added an `eval_comptime` call on the newly constructed Binary expression.

This causes gather_context to be called twice on the same `Factor::Variable`.
  1. `eval_expr()` → `eval_comptime()` → `gather_context()`: drains the array dimensions
  2. Parent `Binary.eval_comptime()` → `gather_context()`: recurses into the already-drained child → panic (`range end index 1 out of range for slice of length 0`)