### PR TITLE
fix(std): make $std::delay reset Verilator-compatible for unpacked arrays

### DIFF
--- a/crates/std/veryl/src/delay/delay.veryl
+++ b/crates/std/veryl/src/delay/delay.veryl
@@ -22,7 +22,9 @@ pub module delay #(
         assign o_d = delay[DELAY - 1];
         always_ff (i_clk, i_rst) {
             if_reset {
-                delay = '{0};
+                for i: u32 in 0..DELAY {
+                    delay[i] = '0;
+                }
             } else {
                 delay[0] = i_d;
                 for i: u32 in 1..DELAY {


### PR DESCRIPTION
### Issue
Related: verilator/verilator#4589

`$std::delay` currently resets its internal unpacked array with `'{0}`:

```veryl
if_reset {
    delay = '{0};
}
```

This is emitted to SystemVerilog as:

```systemverilog
delay <= '{0};
```

Verilator (at least through 5.046) rejects this form for unpacked arrays with:
`Assignment pattern missed initializing elements`.

### Fix

Replace the whole-array assignment with an explicit element-wise reset loop:

```veryl
if_reset {
    for i: u32 in 0..DELAY {
        delay[i] = '0;
    }
}
```

This will generates portable SystemVerilog and avoids simulator-specific interpretation of positional assignment patterns on unpacked arrays.

`'{default: '0}` is IEEE-correct and works for simple 1D cases, but Verilator issue #4589 tracks recursive/default behavior for subarrays. Since `delay` is generic over `TYPE`, the explicit loop is the most robust and unambiguous implementation for std.

### Verification

Minimal reproduction in Verilator:

```systemverilog
logic [7:0] arr [0:3];
arr <= '{0};    // rejected by Verilator
```

Loop-based reset equivalent:

```systemverilog
for (int unsigned i = 0; i < 4; i++) begin
    arr[i] <= '0;  // accepted
end
```