### PR TITLE
Fix `unassign_variable` warning

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -43,7 +43,6 @@ pub struct Context {
     pub func_paths: HashMap<FuncPath, VarId>,
     pub variables: HashMap<VarId, Variable>,
     pub functions: HashMap<VarId, Function>,
-    pub func_call_depth: u32,
     pub port_types: HashMap<VarPath, (Type, ClockDomain)>,
     pub modports: HashMap<StrId, Vec<(StrId, Direction)>>,
     pub declarations: Vec<Declaration>,
@@ -75,7 +74,6 @@ impl Context {
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
         std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);
-        self.func_call_depth = tgt.func_call_depth;
         self.in_generic = tgt.in_generic;
         self.config = tgt.config.clone();
     }

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -2140,20 +2140,27 @@ fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> Ir
             Shape::default()
         };
 
-        let mut local_context = Context::default();
-        local_context.var_id = context.var_id;
-        local_context.inherit(context);
-        local_context.extract_var_paths(context, &path.path, &array);
+        let is_local_func = context
+            .currnet_namespace()
+            .map(|namespace| symbol.namespace.included(&namespace))
+            .unwrap_or(false);
+        if is_local_func {
+            let ret: IrResult<()> = Conv::conv(context, (&definition, Some(path)));
+            ret?;
+        } else {
+            let mut local_context = Context::default();
+            local_context.var_id = context.var_id;
+            local_context.inherit(context);
+            local_context.extract_var_paths(context, &path.path, &array);
 
-        local_context.func_call_depth += 1;
-        let ret: IrResult<()> = Conv::conv(&mut local_context, (&definition, Some(path)));
-        local_context.func_call_depth -= 1;
+            let ret: IrResult<()> = Conv::conv(&mut local_context, (&definition, Some(path)));
 
-        context.extract_function(&mut local_context, &path.path, &array);
-        context.inherit(&mut local_context);
-        context.var_id = local_context.var_id;
+            context.extract_function(&mut local_context, &path.path, &array);
+            context.inherit(&mut local_context);
+            context.var_id = local_context.var_id;
 
-        ret?;
+            ret?;
+        }
     }
 
     let Some(id) = context.func_paths.get(path) else {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -7233,6 +7233,26 @@ fn unassign_variable() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA #(
+        param N: u32 = 4
+    ) {
+        initial {
+            func();
+        }
+        function func() {
+            const D: u32 = $clog2(N);
+            var a: u32;
+            for i: u32 in 0..D {
+                a = i;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2297

The caller context should be used to extract the given local function but an empty context is used.
Due to this, a `const` used in the function can't be found and `unassign_variable` is reported becuase `for` loop in the function can't be evaluated.

To fix this issue, the given context should be used if the given function is a local function.