### PR TITLE
Insert bit width expand if RHS bit width < assignment target

### DIFF
--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -824,6 +824,46 @@ fn function() {
 "#;
 
     check_ir(code, exp);
+
+    let code = r#"
+    module ModuleA (
+        a: input logic<64>,
+        b: input logic    ,
+    ) {
+        function func(
+            a: input logic<64>,
+            b: input logic    ,
+        ) -> logic<65> {
+            var ab: logic<65>;
+            ab[0+:64] = a;
+            ab[64]    = b;
+            return ab;
+        }
+        let _ab: logic<65> = func(a, b);
+    }
+    "#;
+
+    let exp = r#"module ModuleA {
+  input var0(a): logic<64> = 64'hxxxxxxxxxxxxxxxx;
+  input var1(b): logic = 1'hx;
+  var var3(func.return): logic<65> = 65'hxxxxxxxxxxxxxxxxx;
+  input var4(func.a): logic<64> = 64'hxxxxxxxxxxxxxxxx;
+  input var5(func.b): logic = 1'hx;
+  var var6(func.ab): logic<65> = 65'hxxxxxxxxxxxxxxxxx;
+  let var7(_ab): logic<65> = 65'hxxxxxxxxxxxxxxxxx;
+  func var2(func) -> var3 {
+    var6[32'sh00000000+:32'sh00000040] = var4;
+    var6[32'sh00000040] = var5;
+    var3 = var6;
+  }
+
+  comb {
+    var7 = var2(a: var0, b: var1);
+  }
+}
+"#;
+
+    check_ir(code, exp);
 }
 
 #[test]

--- a/crates/analyzer/src/ir/variable.rs
+++ b/crates/analyzer/src/ir/variable.rs
@@ -778,7 +778,14 @@ impl Variable {
             return false;
         };
         if let Some(total_width) = self.total_width() {
-            value.trunc(total_width);
+            let value_width = value.width();
+            let value = if value_width >= total_width {
+                value.trunc(total_width);
+                value
+            } else {
+                value.expand(total_width, true).into_owned()
+            };
+
             if let Some(x) = self.value.get_mut(index) {
                 if let Some((beg, end)) = range {
                     x.assign(value, beg, end);


### PR DESCRIPTION
fix veryl-lang/veryl#2308

This error is happend when processing assignment with variable > 64 bits and RHS < 64 bits.
To fix this error, insert bit width expand before processing assignment if RHS bit width < assignment target.