### PR TITLE
Fix initializing struct imported from `$sv` namespace

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1217,6 +1217,7 @@ pub fn eval_struct_constructor(
         let members = match &r#type.kind {
             ir::TypeKind::Struct(x) => &x.members,
             ir::TypeKind::Union(x) => &x.members,
+            ir::TypeKind::SystemVerilog => &vec![],
             _ => {
                 // TODO error: non-struct/union type
                 return Err(ir_error!(token));

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8146,6 +8146,15 @@ fn unevaluable_value_const_value() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        const A: $sv::a_struct = $sv::a_struct'{ a: 1 };
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2311

Struct imported from `$sv` namespace is treated as a non `struct` type when evaluating `struct constructor`. This causes #2311.

This PR is to fix this situation.

