### PR TITLE
Fix array literal evaluation including `$sv` member

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -397,19 +397,19 @@ fn eval_array_literal_expressions(
 
         let mut part_type = r#type.clone();
         part_type.width.drain(0..expr.select.len());
-        let part_width = part_type.total_width().ok_or_else(|| ir_error!(token))?;
 
-        let mut part_value = expr
-            .expr
-            .eval_value(context)
-            .ok_or_else(|| ir_error!(token))?;
-        part_value.trunc(part_width);
+        if let Some(mut part_value) = expr.expr.eval_value(context) {
+            let part_width = part_type.total_width().ok_or_else(|| ir_error!(token))?;
+            part_value.trunc(part_width);
 
-        value = if let Some(x) = value {
-            Some(x.concat(&part_value))
+            value = if let Some(x) = value {
+                Some(x.concat(&part_value))
+            } else {
+                Some(part_value)
+            };
         } else {
-            Some(part_value)
-        };
+            value = None;
+        }
 
         prev = Some(expr.index);
     }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8183,6 +8183,17 @@ fn unevaluable_value_const_value() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        const A: bit<5>[1] = '{$sv::FOO};
+        const B: bit<5>[1] = A;
+    }
+
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2317

Currently array literal including `$sv` member is treated as error.
Due to this, const array with such literal is not added to the `context` and #2317 is happened.

This PR is to stop such array literal is treated as error.