### PR TITLE
Eval exprssions in array literal during `gather_context`

### DIFF
--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -192,8 +192,23 @@ impl Expression {
                 let mut is_const = true;
                 let mut is_global = true;
                 for item in items {
-                    is_const &= item.is_const();
-                    is_global &= item.is_global();
+                    match item {
+                        ArrayLiteralItem::Value(x, y) => {
+                            let x_context = x.gather_context(context);
+                            is_const &= x_context.is_const;
+                            is_global &= x_context.is_global;
+                            if let Some(y) = y {
+                                let y_context = y.gather_context(context);
+                                is_const &= y_context.is_const;
+                                is_global &= y_context.is_global;
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(x) => {
+                            let x_context = x.gather_context(context);
+                            is_const &= x_context.is_const;
+                            is_global &= x_context.is_global;
+                        }
+                    }
                 }
 
                 comptime.is_const = is_const;

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8189,7 +8189,15 @@ fn unevaluable_value_const_value() {
         const A: bit<5>[1] = '{$sv::FOO};
         const B: bit<5>[1] = A;
     }
+    "#;
 
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        const A: u32[1] = '{ 1 + 1 };
+    }
     "#;
 
     let errors = analyze(code);


### PR DESCRIPTION
fix veryl-lang/veryl#2320

Expressions in array literal are not evaluated in `ir::Expression::gather_context`.

* https://github.com/veryl-lang/veryl/blob/082b803fcc67cc1539fd061f702b45c703851428/crates/analyzer/src/ir/expression.rs#L195
* https://github.com/veryl-lang/veryl/blob/082b803fcc67cc1539fd061f702b45c703851428/crates/analyzer/src/ir/expression.rs#L758

Due to this, expression in array literal is not treated as `const` value even if its operands are `const`.

To fix this, expressions in array literal should also be evaluated like expressions in `struct constractor` literal.