### PR TITLE
Fix `invalid_select` for array select with `+:`, `-:` and `step` select op

### DIFF
--- a/crates/analyzer/src/ir/variable.rs
+++ b/crates/analyzer/src/ir/variable.rs
@@ -356,13 +356,14 @@ impl VarSelectOp {
         }
     }
 
-    pub fn eval_value(&self, beg: usize, end: usize) -> (usize, usize) {
-        match self {
-            VarSelectOp::Colon => (beg, end),
-            VarSelectOp::PlusColon => ((beg + end).saturating_sub(1), beg),
-            VarSelectOp::MinusColon => (beg, beg.saturating_sub(end) + 1),
-            VarSelectOp::Step => ((beg * end + end).saturating_sub(1), beg * end),
-        }
+    pub fn eval_value(&self, beg: usize, end: usize, is_array: bool) -> (usize, usize) {
+        let (beg, end, swap) = match self {
+            VarSelectOp::Colon => (beg, end, false),
+            VarSelectOp::PlusColon => ((beg + end).saturating_sub(1), beg, is_array),
+            VarSelectOp::MinusColon => (beg, beg.saturating_sub(end) + 1, is_array),
+            VarSelectOp::Step => ((beg * end + end).saturating_sub(1), beg * end, is_array),
+        };
+        if swap { (end, beg) } else { (beg, end) }
     }
 }
 
@@ -486,7 +487,7 @@ impl VarSelect {
                 let (beg, end) = if let Some((op, x)) = &self.1 {
                     range.set_end(x.token_range());
                     let end = x.eval_value(context)?.to_usize().unwrap_or(0);
-                    op.eval_value(beg, end)
+                    op.eval_value(beg, end, is_array)
                 } else {
                     (beg, beg)
                 };
@@ -605,7 +606,7 @@ impl VarSelect {
                 let x = x.eval_value(context)?.to_usize().unwrap_or(0);
                 let (x, y) = if let Some((op, y)) = &self.1 {
                     let y = y.eval_value(context)?.to_usize().unwrap_or(0);
-                    op.eval_value(x, y)
+                    op.eval_value(x, y, is_array)
                 } else {
                     (x, x)
                 };
@@ -623,7 +624,7 @@ impl VarSelect {
 
                     let (x, y) = if let Some((op, y)) = &self.1 {
                         let y = y.eval_value(context)?.to_usize().unwrap_or(0);
-                        op.eval_value(x, y)
+                        op.eval_value(x, y, is_array)
                     } else {
                         (x, x)
                     };

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8906,6 +8906,19 @@ fn invalid_select() {
 
     let code = r#"
     module ModuleA {
+        let _a: u32[4] = '{0, 1, 2, 3};
+        let _b: u32[2] = _a[0:1];
+        let _c: u32[2] = _a[0+:2];
+        let _d: u32[2] = _a[3-:2];
+        let _e: u32[2] = _a[1 step 2];
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
         let _a: logic<2> = 1;
         let _b: logic<2> = _a[0][0];
     }


### PR DESCRIPTION
fix veryl-lang/veryl#2327

Evaluated `beg`/`end` pos needs to be swapped when array select with `+:`, `-:` and `step` select op but currently not.
Swap the result for such case.
