### PR TITLE
Fix panic when processing binary op within `$signed`/`$unsigned` system function call

### DIFF
--- a/crates/analyzer/src/ir/system_function.rs
+++ b/crates/analyzer/src/ir/system_function.rs
@@ -224,8 +224,13 @@ impl SystemFunctionCall {
                 if args.len() != 1 {
                     return Err(ir_error!(token));
                 }
-                let arg0 = create_input(context, name, None, args.remove(0));
+
+                let mut arg = args.remove(0);
+                arg.0.eval_comptime(context, None);
+
+                let arg0 = create_input(context, name, None, arg);
                 comptime.expr_context.signed = true;
+
                 Ok(SystemFunctionCall {
                     kind: SystemFunctionKind::Signed(arg0),
                     comptime,
@@ -235,8 +240,13 @@ impl SystemFunctionCall {
                 if args.len() != 1 {
                     return Err(ir_error!(token));
                 }
-                let arg0 = create_input(context, name, None, args.remove(0));
+
+                let mut arg = args.remove(0);
+                arg.0.eval_comptime(context, None);
+
+                let arg0 = create_input(context, name, None, arg);
                 comptime.expr_context.signed = false;
+
                 Ok(SystemFunctionCall {
                     kind: SystemFunctionKind::Unsigned(arg0),
                     comptime,

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -444,6 +444,45 @@ fn system_function() {
 "#;
 
     check_ir(code, exp);
+
+    let code = r#"
+module ModuleA {
+    const A: bit<65> = 65'h00000000000000000;
+    const B: bit<65> = 65'h00000000000000001;
+    const C: bit<65> = $signed(A + B);
+
+    const D: bit<64> = 64'h0000000000000000;
+    const E: bit<65> = 65'h00000000000000001;
+    const F: bit<65> = $signed(D + E);
+
+    const G: bit<64> = 64'h0000000000000000;
+    const H: bit<64> = 64'h0000000000000001;
+    const I: bit<65> = $signed(D + E);
+
+    const J: bit<65> = 65'h00000000000000000;
+    const K: bit<65> = 65'h00000000000000001;
+    const L: bit<64> = $signed(A + B);
+}
+"#;
+
+    let exp = r#"module ModuleA {
+  const var0(A): bit<65> = 65'h00000000000000000;
+  const var1(B): bit<65> = 65'h00000000000000001;
+  const var2(C): bit<65> = 65'h00000000000000001;
+  const var3(D): bit<64> = 64'h0000000000000000;
+  const var4(E): bit<65> = 65'h00000000000000001;
+  const var5(F): bit<65> = 65'h00000000000000001;
+  const var6(G): bit<64> = 64'h0000000000000000;
+  const var7(H): bit<64> = 64'h0000000000000001;
+  const var8(I): bit<65> = 65'h00000000000000001;
+  const var9(J): bit<65> = 65'h00000000000000000;
+  const var10(K): bit<65> = 65'h00000000000000001;
+  const var11(L): bit<64> = 64'h0000000000000001;
+
+}
+"#;
+
+    check_ir(code, exp);
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2364

The arg given to `$signed`/`$unsigend` system function should be evaluated to detemine the expression bit width, but it is no actualy evaluated.
This causes #2364.
