### PR TITLE
Fix stack overflow happens when processing generic component including generic instance

### DIFF
--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -94,7 +94,7 @@ impl Signature {
             }
         }
 
-        if path.is_generic() {
+        if !context.in_generic && path.is_generic() {
             let namespace = namespace_table::get(path.paths[0].base.id).unwrap();
             path.resolve_imported(&namespace, None);
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -655,6 +655,33 @@ fn cyclic_type_dependency() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package proto_pkg {
+        const A: u32;
+        const B: u32;
+    }
+    package pkg::<a: u32, b: u32> for proto_pkg {
+        const A: u32 = a;
+        const B: u32 = b;
+    }
+    interface if_a::<PKG: proto_pkg> {
+        var a: logic<PKG::A>;
+        var b: logic<PKG::B>;
+        modport mp {
+            ..output
+        }
+    }
+    module module_a::<PKG: proto_pkg> {
+        inst ifa: if_a::<pkg::<PKG::B, PKG::A>>;
+    }
+    module module_b {
+        inst u: module_a::<pkg::<1, 2>>;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2423

Signatures created from generic symbol path pointing to generic component without generic arguments has incorrect generic map; its map includes unresolved generic params.
Due to this, stack overflow happens during processing the sample code shown in #2423.

`None` should be returned from `Signature::from_path` if unresolved generic params are remained but the incompleted result is used to check genreic components (e.g. unassigned variable check).
Signature pointing to base component is returned if `cotnext.in_generic` is true.