### PR TITLE
Fix emittion of generic param defined in global function

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -2152,7 +2152,13 @@ impl Emitter {
         let path: GenericSymbolPath = arg.into();
 
         let (result, path) = self.resolve_generic_path(&path, None);
-        if result.is_ok() || self.bound_namespace.is_none() {
+        // GenericParameter resolved in the function namespace takes priority over the caller,
+        // so fall through to the bound_namespace lookup to find the actual generic argument.
+        let is_generic_param = result
+            .as_ref()
+            .ok()
+            .is_some_and(|r| matches!(r.found.kind, SymbolKind::GenericParameter(_)));
+        if (result.is_ok() && !is_generic_param) || self.bound_namespace.is_none() {
             return (result, path);
         }
 

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -3010,6 +3010,42 @@ endmodule
 #[test]
 fn emit_unbound_function() {
     let code = r#"
+function func::<A: u32>() -> u32 {
+    return A;
+}
+module ModuleA #(
+    param A: u32 = 0,
+) {
+    let _a: u32 = func::<A>();
+}
+"#;
+
+    let expect = r#"
+
+module prj_ModuleA #(
+    parameter int unsigned A = 0
+);
+    int unsigned _a; always_comb _a = __func__A();
+
+    function automatic int unsigned __func__A() ;
+        return A;
+    endfunction
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = if cfg!(windows) {
+        emit(&metadata, code).replace("\r\n", "\n")
+    } else {
+        emit(&metadata, code)
+    };
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
+
+    let code = r#"
     function func_ab::<W: u32>(
         a: input logic<W>,
         b: input logic<W>,


### PR DESCRIPTION
fix veryl-lang/veryl#2452

For the sample code showing the above issue, generic param `A` and generic param `A` have the same name , so generic param `A` is resolved when resolving identifier `A`. Due to this, empty string is emitted as identifier `A`.

To resolve this, resolution result should be ignored when generic param is resolved in the functoin namespace.