### PR TITLE
Fix `unassign_variable` warning reported for global function

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -2395,15 +2395,22 @@ fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> Ir
 
             for path in &generic_arg_paths {
                 // Copy var path referenced as resolved generic arg from the given context
-                if let Some(x) = context.find_path(path) {
-                    local_context.var_paths.insert(path.clone(), x);
+                if let Some((var_id, comptime)) = context.find_path(path)
+                    && let Some(var) = context.variables.get(&var_id)
+                {
+                    local_context
+                        .var_paths
+                        .insert(path.clone(), (var_id, comptime));
+                    local_context.variables.insert(var_id, var.clone());
                 }
             }
 
             let ret: IrResult<()> = Conv::conv(&mut local_context, (&definition, Some(path)));
 
             for path in &generic_arg_paths {
-                local_context.var_paths.remove(path);
+                if let Some((var_id, _)) = local_context.var_paths.remove(path) {
+                    local_context.variables.remove(&var_id);
+                }
             }
 
             context.extract_function(&mut local_context, &path.path, &array);

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -7382,6 +7382,25 @@ fn unassign_variable() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    function func::<N: p32> {
+        const DEPTH: u32 = $clog2(N);
+        var n: u32;
+        for i: u32 in 0..DEPTH {
+            n = i;
+        }
+    }
+    module ModuleA {
+        const ENTRIES: u32 = 2;
+        always_comb {
+            func::<ENTRIES>();
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/parser/src/veryl_grammar_trait.rs
+++ b/crates/parser/src/veryl_grammar_trait.rs
@@ -807,6 +807,9 @@ impl DescriptionItem {
                     PublicDescriptionItem::PackageDeclaration(x) => {
                         x.package_declaration.package_declaration_opt.is_some()
                     }
+                    PublicDescriptionItem::FunctionDeclaration(x) => {
+                        x.function_declaration.function_declaration_opt.is_some()
+                    }
                     _ => false,
                 }
             }


### PR DESCRIPTION
fix veryl-lang/veryl#2464

Evaluating a generic arg in the global function context is failed becuase the `const` specified as the generic arg is not copied from the original context.
Due to this, value of `const` defined in the global function and with generic arg as RHS value become unknown.
