### PR TITLE
Add multi-line formatting support for generic parameter and argument lists

### DIFF
--- a/crates/formatter/src/formatter.rs
+++ b/crates/formatter/src/formatter.rs
@@ -2105,30 +2105,105 @@ impl VerylWalker for Formatter {
         }
     }
 
+    /// Semantic action for non-terminal 'WithGenericParameter'
+    fn with_generic_parameter(&mut self, arg: &WithGenericParameter) {
+        if arg.colon_colon_l_angle.line() != arg.r_angle.line() {
+            self.multi_line_start();
+        }
+        self.colon_colon_l_angle(&arg.colon_colon_l_angle);
+        if self.multi_line() {
+            self.newline_push();
+        }
+
+        self.with_generic_parameter_list(&arg.with_generic_parameter_list);
+
+        if self.multi_line() {
+            self.newline_pop();
+            self.align_reset();
+        }
+        self.r_angle(&arg.r_angle);
+        if arg.colon_colon_l_angle.line() != arg.r_angle.line() {
+            self.multi_line_finish();
+        }
+    }
+
     /// Semantic action for non-terminal 'WithGenericParameterList'
     fn with_generic_parameter_list(&mut self, arg: &WithGenericParameterList) {
         self.with_generic_parameter_item(&arg.with_generic_parameter_item);
         for x in &arg.with_generic_parameter_list_list {
             self.comma(&x.comma);
-            self.space(1);
+            if self.multi_line() {
+                self.newline();
+            } else {
+                self.space(1);
+            }
             self.with_generic_parameter_item(&x.with_generic_parameter_item);
         }
-        if let Some(ref x) = arg.with_generic_parameter_list_opt {
-            self.comma(&x.comma);
+        if self.multi_line() {
+            if let Some(ref x) = arg.with_generic_parameter_list_opt {
+                self.comma(&x.comma);
+            } else {
+                self.str(",");
+            }
         }
     }
 
     /// Semantic action for non-terminal 'WithGenericParameterItem'
     fn with_generic_parameter_item(&mut self, arg: &WithGenericParameterItem) {
+        if self.multi_line() {
+            self.align_start(align_kind::IDENTIFIER);
+        }
         self.identifier(&arg.identifier);
+        if self.multi_line() {
+            self.align_finish(align_kind::IDENTIFIER);
+        }
         self.colon(&arg.colon);
         self.space(1);
+        if self.multi_line() {
+            self.align_start(align_kind::TYPE);
+        }
         self.generic_bound(&arg.generic_bound);
+        if self.multi_line() {
+            self.align_finish(align_kind::TYPE);
+        }
         if let Some(ref x) = arg.with_generic_parameter_item_opt {
             self.space(1);
             self.equ(&x.equ);
             self.space(1);
+            if self.multi_line() {
+                self.align_start(align_kind::EXPRESSION);
+            }
             self.with_generic_argument_item(&x.with_generic_argument_item);
+            if self.multi_line() {
+                self.align_finish(align_kind::EXPRESSION);
+            }
+        }
+    }
+
+    /// Semantic action for non-terminal 'WithGenericArgument'
+    fn with_generic_argument(&mut self, arg: &WithGenericArgument) {
+        let multi_line = arg.with_generic_argument_opt.is_some()
+            && arg.colon_colon_l_angle.line() != arg.r_angle.line();
+
+        if multi_line {
+            self.multi_line_start();
+        }
+        self.colon_colon_l_angle(&arg.colon_colon_l_angle);
+        if self.multi_line() {
+            self.newline_push();
+        }
+
+        if let Some(x) = &arg.with_generic_argument_opt {
+            self.with_generic_argument_list(&x.with_generic_argument_list);
+        }
+
+        if self.multi_line() {
+            self.newline_pop();
+            self.align_reset();
+        }
+        self.r_angle(&arg.r_angle);
+        if multi_line {
+            self.multi_line_finish();
         }
     }
 
@@ -2137,11 +2212,43 @@ impl VerylWalker for Formatter {
         self.with_generic_argument_item(&arg.with_generic_argument_item);
         for x in &arg.with_generic_argument_list_list {
             self.comma(&x.comma);
-            self.space(1);
+            if self.multi_line() {
+                self.newline();
+            } else {
+                self.space(1);
+            }
             self.with_generic_argument_item(&x.with_generic_argument_item);
         }
-        if let Some(ref x) = arg.with_generic_argument_list_opt {
-            self.comma(&x.comma);
+        if self.multi_line() {
+            if let Some(ref x) = arg.with_generic_argument_list_opt {
+                self.comma(&x.comma);
+            } else {
+                self.str(",");
+            }
+        }
+    }
+
+    /// Semantic action for non-terminal 'WithGenericArgumentItem'
+    fn with_generic_argument_item(&mut self, arg: &WithGenericArgumentItem) {
+        if self.multi_line() {
+            self.align_start(align_kind::EXPRESSION);
+        }
+        match arg {
+            WithGenericArgumentItem::GenericArgIdentifier(x) => {
+                self.generic_arg_identifier(&x.generic_arg_identifier);
+            }
+            WithGenericArgumentItem::FixedType(x) => {
+                self.fixed_type(&x.fixed_type);
+            }
+            WithGenericArgumentItem::Number(x) => {
+                self.number(&x.number);
+            }
+            WithGenericArgumentItem::BooleanLiteral(x) => {
+                self.boolean_literal(&x.boolean_literal);
+            }
+        }
+        if self.multi_line() {
+            self.align_finish(align_kind::EXPRESSION);
         }
     }
 

--- a/crates/formatter/src/tests.rs
+++ b/crates/formatter/src/tests.rs
@@ -211,3 +211,56 @@ fn const_above_let_alignment() {
     let ret = format(&metadata, code);
     assert_eq!(ret, expect);
 }
+
+#[test]
+fn format_generic_list() {
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let code = r#"module ModuleA::<A : a_type, AA: u32,> {}
+"#;
+
+    let expect = r#"module ModuleA::<A: a_type, AA: u32> {}
+"#;
+
+    let ret = format(&metadata, &code);
+    assert_eq!(ret, expect);
+
+    let code = r#"module ModuleA::<
+    A: a_type,
+    AA: u32
+> {}
+"#;
+
+    let expect = r#"module ModuleA::<
+    A : a_type,
+    AA: u32   ,
+> {}
+"#;
+
+    let ret = format(&metadata, &code);
+    assert_eq!(ret, expect);
+
+    let code = r#"alias module ModuleA = ModuleB::<8, 16,>;
+"#;
+
+    let expect = r#"alias module ModuleA = ModuleB::<8, 16>;
+"#;
+
+    let ret = format(&metadata, &code);
+    assert_eq!(ret, expect);
+
+    let code = r#"alias module ModuleB = ModuleC::<
+    8,
+    16
+>;
+"#;
+
+    let expect = r#"alias module ModuleB = ModuleC::<
+    8 ,
+    16,
+>;
+"#;
+
+    let ret = format(&metadata, &code);
+    assert_eq!(ret, expect);
+}

--- a/crates/std/veryl/src/selector/demux.veryl
+++ b/crates/std/veryl/src/selector/demux.veryl
@@ -1,4 +1,4 @@
-pub function dispatch_binary::<N: p32, T: type,> (
+pub function dispatch_binary::<N: p32, T: type> (
     sel         : input logic<selector_pkg::calc_binary_select_width(N)>,
     data        : input T                                               ,
     default_data: input T                                               ,
@@ -13,7 +13,7 @@ pub function dispatch_binary::<N: p32, T: type,> (
     return result;
 }
 
-pub function dispatch_vector::<N: p32, T: type,> (
+pub function dispatch_vector::<N: p32, T: type> (
     sel         : input logic<N>,
     data        : input T       ,
     default_data: input T       ,
@@ -31,7 +31,7 @@ pub function dispatch_vector::<N: p32, T: type,> (
     return result;
 }
 
-pub function dispatch::<KIND: selector_pkg::selector_kind, N: p32, T: type,> (
+pub function dispatch::<KIND: selector_pkg::selector_kind, N: p32, T: type> (
     sel         : input logic<selector_pkg::calc_select_width(N, KIND)>,
     data        : input T                                              ,
     default_data: input T                                              ,

--- a/crates/std/veryl/src/selector/mux.veryl
+++ b/crates/std/veryl/src/selector/mux.veryl
@@ -1,11 +1,11 @@
-pub function select_binary::<N: p32, T: type,> (
+pub function select_binary::<N: p32, T: type> (
     sel : input logic<selector_pkg::calc_binary_select_width(N)>,
     data: input T    <N>                                        ,
 ) -> T {
     return data[sel];
 }
 
-pub function select_vector::<N: p32, T: type,> (
+pub function select_vector::<N: p32, T: type> (
     sel : input logic<N>,
     data: input T    <N>,
 ) -> T {
@@ -49,7 +49,7 @@ pub function select_vector::<N: p32, T: type,> (
     return next_d[0];
 }
 
-pub function select_onehot::<N: p32, T: type,> (
+pub function select_onehot::<N: p32, T: type> (
     sel : input logic<N>,
     data: input T    <N>,
 ) -> T {
@@ -86,7 +86,7 @@ pub function select_onehot::<N: p32, T: type,> (
     return next_d[0];
 }
 
-pub function select::<KIND: selector_pkg::selector_kind, N: p32, T: type,> (
+pub function select::<KIND: selector_pkg::selector_kind, N: p32, T: type> (
     sel : input logic<selector_pkg::calc_select_width(N, KIND)>,
     data: input T    <N>                                       ,
 ) -> T {

--- a/crates/std/veryl/src/utility_functions/extend.veryl
+++ b/crates/std/veryl/src/utility_functions/extend.veryl
@@ -1,4 +1,4 @@
-pub function zero_extend::<FROM_TYPE: type, TO_TYPE: type,> (
+pub function zero_extend::<FROM_TYPE: type, TO_TYPE: type> (
     from: input FROM_TYPE,
 ) -> TO_TYPE {
     const FROM_WIDTH  : p32 = $bits(FROM_TYPE);
@@ -7,7 +7,7 @@ pub function zero_extend::<FROM_TYPE: type, TO_TYPE: type,> (
     return {1'b0 repeat EXTEND_WIDTH, from} as TO_TYPE;
 }
 
-pub function one_extend::<FROM_TYPE: type, TO_TYPE: type,> (
+pub function one_extend::<FROM_TYPE: type, TO_TYPE: type> (
     from: input FROM_TYPE,
 ) -> TO_TYPE {
     const FROM_WIDTH  : p32 = $bits(FROM_TYPE);
@@ -16,7 +16,7 @@ pub function one_extend::<FROM_TYPE: type, TO_TYPE: type,> (
     return {1'b1 repeat EXTEND_WIDTH, from} as TO_TYPE;
 }
 
-pub function sign_extend::<FROM_TYPE: type, TO_TYPE: type,> (
+pub function sign_extend::<FROM_TYPE: type, TO_TYPE: type> (
     from: input FROM_TYPE,
 ) -> TO_TYPE {
     const FROM_WIDTH  : p32 = $bits(FROM_TYPE);

--- a/crates/std/veryl/src/utility_functions/truncate.veryl
+++ b/crates/std/veryl/src/utility_functions/truncate.veryl
@@ -1,4 +1,4 @@
-pub function truncate::<FROM_TYPE: type, TO_TYPE: type,> (
+pub function truncate::<FROM_TYPE: type, TO_TYPE: type> (
     from: input FROM_TYPE,
 ) -> TO_TYPE {
     return from as TO_TYPE;


### PR DESCRIPTION
fix veryl-lang/veryl#2473

When generic parameters/arguments span multiple lines, items are now separated by newlines with proper indentation, trailing commas are added automatically, and identifiers/types are aligned across items.
Single-line formatting is unchanged except trailing commas are removed.