### PR TITLE
Allow to use parameter typed with i*/p* type as casting type

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -883,7 +883,19 @@ impl Symbol {
         };
         matches!(
             type_kind,
-            TypeKind::Type | TypeKind::U8 | TypeKind::U16 | TypeKind::U32 | TypeKind::U64
+            TypeKind::Type
+                | TypeKind::U8
+                | TypeKind::U16
+                | TypeKind::U32
+                | TypeKind::U64
+                | TypeKind::I8
+                | TypeKind::I16
+                | TypeKind::I32
+                | TypeKind::I64
+                | TypeKind::P8
+                | TypeKind::P16
+                | TypeKind::P32
+                | TypeKind::P64
         )
     }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3964,6 +3964,34 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    module ModuleA #(
+        param VALUE: u32 = 1,
+        param WIDTH: p32 = 1,
+    ) (
+        o: output logic<WIDTH>,
+    ) {
+        assign o = VALUE as WIDTH;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA #(
+        param VALUE: u32 = 1,
+        param WIDTH: i32 = 1,
+    ) (
+        o: output logic<WIDTH>,
+    ) {
+        assign o = VALUE as WIDTH;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Currently, parameter type with `i*`/`p*` type can't be used as casting type. This PR makes such parameter to be treated as casting type.