### PR TITLE
Support `for` loops with dynamically determined ranges

### DIFF
--- a/crates/analyzer/src/conv/statement.rs
+++ b/crates/analyzer/src/conv/statement.rs
@@ -631,16 +631,15 @@ impl Conv<&ForStatement> for ir::StatementBlock {
             .for_statement_opt0
             .as_ref()
             .map(|x| (x.assignment_operator.as_ref(), x.expression.as_ref()));
+        let for_range = build_for_range(context, &value.range, rev, step)?;
 
-        if context.in_sequential_block {
-            let for_range = build_for_range(context, &value.range, rev, step)?;
+        if context.in_sequential_block || for_range.is_dynamic() {
             return build_for_statement(context, value, &r#type, clock_domain, for_range, token);
         }
 
-        let range = eval_for_range(context, &value.range, rev, step, token)?;
+        let range = eval_for_range(context, &for_range, token)?;
 
         let mut ret = ir::StatementBlock::default();
-
         for i in range {
             let label = format!("[{}]", i);
             let label = resource_table::insert_str(&label);

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -86,19 +86,18 @@ pub fn eval_generic_expr(
     ret
 }
 
-pub fn eval_range(context: &mut Context, range: &Range) -> IrResult<(usize, usize)> {
+pub fn eval_range(
+    context: &mut Context,
+    range: &Range,
+) -> IrResult<(ir::ForBound, ir::ForBound, bool)> {
     eval_range_inner(context, range, false)
-}
-
-pub fn eval_range_const(context: &mut Context, range: &Range) -> IrResult<(usize, usize)> {
-    eval_range_inner(context, range, true)
 }
 
 fn eval_range_inner(
     context: &mut Context,
     range: &Range,
     require_const: bool,
-) -> IrResult<(usize, usize)> {
+) -> IrResult<(ir::ForBound, ir::ForBound, bool)> {
     let mut beg: ir::Expression = Conv::conv(context, range.expression.as_ref())?;
     let beg_comptime = beg.eval_comptime(context, None);
     if require_const && !beg_comptime.is_const {
@@ -107,9 +106,14 @@ fn eval_range_inner(
             &range.into(),
         ));
     }
-    let beg = beg_comptime.get_value()?.to_usize().unwrap_or(0);
+    let beg = if beg_comptime.is_const {
+        let val = beg_comptime.get_value()?.to_usize().unwrap_or(0);
+        ir::ForBound::Const(val)
+    } else {
+        ir::ForBound::Expression(Box::new(beg))
+    };
 
-    let end = if let Some(x) = &range.range_opt {
+    let (end, inclusive) = if let Some(x) = &range.range_opt {
         let mut end: ir::Expression = Conv::conv(context, x.expression.as_ref())?;
         let end_comptime = end.eval_comptime(context, None);
         if require_const && !end_comptime.is_const {
@@ -118,18 +122,23 @@ fn eval_range_inner(
                 &range.into(),
             ));
         }
-        let end = end_comptime.get_value()?.to_usize().unwrap_or(0);
+        let end = if end_comptime.is_const {
+            let val = end_comptime.get_value()?.to_usize().unwrap_or(0);
+            ir::ForBound::Const(val)
+        } else {
+            ir::ForBound::Expression(Box::new(end))
+        };
 
         if matches!(x.range_operator.as_ref(), RangeOperator::DotDotEqu(_)) {
-            end + 1
+            (end, true)
         } else {
-            end
+            (end, false)
         }
     } else {
-        beg
+        (beg.clone(), false)
     };
 
-    Ok((beg, end))
+    Ok((beg, end, inclusive))
 }
 
 #[derive(Clone)]
@@ -1202,12 +1211,70 @@ pub fn eval_width_select(
 
 pub fn eval_for_range(
     context: &mut Context,
-    range: &Range,
-    rev: bool,
-    step: Option<(&AssignmentOperator, &Expression)>,
+    range: &ir::ForRange,
     token: TokenRange,
 ) -> IrResult<Vec<usize>> {
-    eval_for_range_inner(context, range, rev, step, token, false)
+    let (start, end, inclusive, step, op) = match range {
+        ir::ForRange::Forward {
+            start,
+            end,
+            inclusive,
+            step,
+        } => {
+            let start = start.eval_value(context).unwrap_or(0);
+            let end = end.eval_value(context).unwrap_or(0);
+            if *step != 1 {
+                (start, end, *inclusive, *step, ir::Op::Add)
+            } else {
+                let end = if *inclusive { end + 1 } else { end };
+                return Ok((start..end).collect());
+            }
+        }
+        ir::ForRange::Reverse {
+            start,
+            end,
+            inclusive,
+            step: _step,
+        } => {
+            let start = start.eval_value(context).unwrap_or(0);
+            let end = end.eval_value(context).unwrap_or(0);
+            if *inclusive {
+                return Ok((start..=end).rev().collect());
+            } else {
+                return Ok((start..end).rev().collect());
+            }
+        }
+        ir::ForRange::Stepped {
+            start,
+            end,
+            inclusive,
+            step,
+            op,
+        } => {
+            let start = start.eval_value(context).unwrap_or(0);
+            let end = end.eval_value(context).unwrap_or(0);
+            (start, end, *inclusive, *step, *op)
+        }
+    };
+
+    let end = if inclusive { end + 1 } else { end };
+    let mut ret = vec![];
+    let mut tmp = start;
+    let mut count = 0;
+    while tmp < end {
+        ret.push(tmp);
+        tmp = op.eval(tmp, step);
+        count += 1;
+
+        if tmp == op.eval(tmp, step) {
+            break;
+        }
+        if context.check_size(count, token).is_none() {
+            break;
+        }
+    }
+
+    Ok(ret)
 }
 
 pub fn eval_generate_for_range(
@@ -1217,50 +1284,8 @@ pub fn eval_generate_for_range(
     step: Option<(&AssignmentOperator, &Expression)>,
     token: TokenRange,
 ) -> IrResult<Vec<usize>> {
-    eval_for_range_inner(context, range, rev, step, token, true)
-}
-
-fn eval_for_range_inner(
-    context: &mut Context,
-    range: &Range,
-    rev: bool,
-    step: Option<(&AssignmentOperator, &Expression)>,
-    token: TokenRange,
-    require_const: bool,
-) -> IrResult<Vec<usize>> {
-    let (beg, end) = if require_const {
-        eval_range_const(context, range)?
-    } else {
-        eval_range(context, range)?
-    };
-
-    if let Some((op, expr)) = step {
-        let mut step: ir::Expression = Conv::conv(context, expr)?;
-        let step = step.eval_comptime(context, None);
-        let step = step.get_value()?.to_usize().unwrap_or(0);
-        let op: ir::Op = Conv::conv(context, op)?;
-
-        let mut ret = vec![];
-        let mut tmp = beg;
-        let mut count = 0;
-        while tmp < end {
-            ret.push(tmp);
-            tmp = op.eval(tmp, step);
-            count += 1;
-
-            if tmp == op.eval(tmp, step) {
-                break;
-            }
-            if context.check_size(count, token).is_none() {
-                break;
-            }
-        }
-        Ok(ret)
-    } else if rev {
-        Ok((beg..end).rev().collect())
-    } else {
-        Ok((beg..end).collect())
-    }
+    let for_range = build_for_range_inner(context, range, rev, step, true)?;
+    eval_for_range(context, &for_range, token)
 }
 
 /// Build a `ForRange` from syntactic elements of a for-loop.
@@ -1270,7 +1295,17 @@ pub fn build_for_range(
     rev: bool,
     step: Option<(&AssignmentOperator, &Expression)>,
 ) -> IrResult<ir::ForRange> {
-    let (beg, end) = eval_range(context, range)?;
+    build_for_range_inner(context, range, rev, step, false)
+}
+
+fn build_for_range_inner(
+    context: &mut Context,
+    range: &Range,
+    rev: bool,
+    step: Option<(&AssignmentOperator, &Expression)>,
+    require_const: bool,
+) -> IrResult<ir::ForRange> {
+    let (beg, end, inclusive) = eval_range_inner(context, range, require_const)?;
 
     if let Some((op, expr)) = step {
         let mut step_expr: ir::Expression = Conv::conv(context, expr)?;
@@ -1282,12 +1317,14 @@ pub fn build_for_range(
             Ok(ir::ForRange::Forward {
                 start: beg,
                 end,
+                inclusive,
                 step: step_val,
             })
         } else {
             Ok(ir::ForRange::Stepped {
                 start: beg,
                 end,
+                inclusive,
                 step: step_val,
                 op,
             })
@@ -1296,19 +1333,23 @@ pub fn build_for_range(
         Ok(ir::ForRange::Reverse {
             start: beg,
             end,
+            inclusive,
             step: 1,
         })
     } else {
         Ok(ir::ForRange::Forward {
             start: beg,
             end,
+            inclusive,
             step: 1,
         })
     }
 }
 
 /// Convert a `ForStatement` AST node into a runtime `ir::Statement::For`
-/// (used in initial blocks to avoid loop unrolling).
+/// This is used for the for loop below to avoid loop unrolling:
+/// * for loop with dynamically determined range
+/// * for loop used in initial block
 pub fn build_for_statement(
     context: &mut Context,
     value: &ForStatement,

--- a/crates/analyzer/src/ir.rs
+++ b/crates/analyzer/src/ir.rs
@@ -33,8 +33,8 @@ pub use op::Op;
 pub use shape::{Shape, ShapeRef};
 pub use signature::Signature;
 pub use statement::{
-    AssignDestination, AssignStatement, ForRange, ForStatement, IfResetStatement, IfStatement,
-    Statement, StatementBlock, TbMethod, TbMethodCall,
+    AssignDestination, AssignStatement, ForBound, ForRange, ForStatement, IfResetStatement,
+    IfStatement, Statement, StatementBlock, TbMethod, TbMethodCall,
 };
 pub use system_function::{Input as SystemFunctionInput, SystemFunctionCall, SystemFunctionKind};
 pub use utils::convert_cast;

--- a/crates/analyzer/src/ir/statement.rs
+++ b/crates/analyzer/src/ir/statement.rs
@@ -39,28 +39,70 @@ pub struct ForStatement {
     pub token: TokenRange,
 }
 
+#[derive(Clone, Debug)]
+pub enum ForBound {
+    Const(usize),
+    Expression(Box<Expression>),
+}
+
+impl ForBound {
+    pub fn eval_value(&self, context: &mut Context) -> Option<usize> {
+        match self {
+            Self::Const(x) => Some(*x),
+            Self::Expression(exp) => {
+                let mut exp = exp.as_ref().clone();
+                let comptime = exp.eval_comptime(context, None);
+                comptime.get_value().ok()?.to_usize()
+            }
+        }
+    }
+}
+
+impl fmt::Display for ForBound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ForBound::Const(x) => x.fmt(f),
+            ForBound::Expression(x) => format!("{}", x.as_ref()).fmt(f),
+        }
+    }
+}
+
 /// Loop iteration range representation.
 #[derive(Clone, Debug)]
 pub enum ForRange {
     /// start..end with additive step (default step=1)
     Forward {
-        start: usize,
-        end: usize,
+        start: ForBound,
+        end: ForBound,
+        inclusive: bool,
         step: usize,
     },
     /// (start..end).rev() with additive step (default step=1)
     Reverse {
-        start: usize,
-        end: usize,
+        start: ForBound,
+        end: ForBound,
+        inclusive: bool,
         step: usize,
     },
     /// start..end with arbitrary step operator (e.g., step *= 2)
     Stepped {
-        start: usize,
-        end: usize,
+        start: ForBound,
+        end: ForBound,
+        inclusive: bool,
         step: usize,
         op: Op,
     },
+}
+
+impl ForRange {
+    pub fn is_dynamic(&self) -> bool {
+        let (start, end) = match self {
+            Self::Forward { start, end, .. } => (start, end),
+            Self::Reverse { start, end, .. } => (start, end),
+            Self::Stepped { start, end, .. } => (start, end),
+        };
+        matches!(start, ForBound::Expression(_)) || matches!(end, ForBound::Expression(_))
+    }
 }
 
 #[derive(Clone)]
@@ -208,30 +250,70 @@ impl fmt::Display for Statement {
             },
             Statement::For(x) => {
                 match &x.range {
-                    ForRange::Forward { start, end, step } if *step == 1 => {
-                        writeln!(f, "for {} in {}..{} {{", x.var_name, start, end)?;
+                    ForRange::Forward {
+                        start,
+                        end,
+                        inclusive,
+                        step,
+                    } if *step == 1 => {
+                        if *inclusive {
+                            writeln!(f, "for {} in {}..={} {{", x.var_name, start, end)?;
+                        } else {
+                            writeln!(f, "for {} in {}..{} {{", x.var_name, start, end)?;
+                        }
                     }
-                    ForRange::Forward { start, end, step } => {
-                        writeln!(
-                            f,
-                            "for {} in {}..{} step += {} {{",
-                            x.var_name, start, end, step
-                        )?;
+                    ForRange::Forward {
+                        start,
+                        end,
+                        inclusive,
+                        step,
+                    } => {
+                        if *inclusive {
+                            writeln!(
+                                f,
+                                "for {} in {}..={} step += {} {{",
+                                x.var_name, start, end, step
+                            )?;
+                        } else {
+                            writeln!(
+                                f,
+                                "for {} in {}..{} step += {} {{",
+                                x.var_name, start, end, step
+                            )?;
+                        }
                     }
-                    ForRange::Reverse { start, end, .. } => {
-                        writeln!(f, "for {} in rev {}..{} {{", x.var_name, start, end)?;
+                    ForRange::Reverse {
+                        start,
+                        end,
+                        inclusive,
+                        ..
+                    } => {
+                        if *inclusive {
+                            writeln!(f, "for {} in rev {}..={} {{", x.var_name, start, end)?;
+                        } else {
+                            writeln!(f, "for {} in rev {}..{} {{", x.var_name, start, end)?;
+                        }
                     }
                     ForRange::Stepped {
                         start,
                         end,
+                        inclusive,
                         step,
                         op,
                     } => {
-                        writeln!(
-                            f,
-                            "for {} in {}..{} step {op}= {} {{",
-                            x.var_name, start, end, step
-                        )?;
+                        if *inclusive {
+                            writeln!(
+                                f,
+                                "for {} in {}..={} step {op}= {} {{",
+                                x.var_name, start, end, step
+                            )?;
+                        } else {
+                            writeln!(
+                                f,
+                                "for {} in {}..{} step {op}= {} {{",
+                                x.var_name, start, end, step
+                            )?;
+                        }
                     }
                 }
                 for s in &x.body {

--- a/crates/simulator/src/ir/statement.rs
+++ b/crates/simulator/src/ir/statement.rs
@@ -204,6 +204,7 @@ impl Statement {
             Statement::AssignDynamic(x) => x.eval_step(mask_cache),
             Statement::If(x) => x.eval_step(mask_cache),
             Statement::For(x) => {
+                let (start, end) = x.range.eval(mask_cache);
                 let mut step_body = |i: u64| {
                     let val = Value::new(i, x.var_width, x.var_signed);
                     unsafe {
@@ -213,29 +214,25 @@ impl Statement {
                         s.eval_step(mask_cache);
                     }
                 };
+
                 match &x.range {
-                    SimForRange::Forward { start, end, step } => {
-                        let mut i = *start;
-                        while i < *end {
+                    SimForRange::Forward { step, .. } => {
+                        let mut i = start;
+                        while i < end {
                             step_body(i);
                             i += step;
                         }
                     }
-                    SimForRange::Reverse { start, end, step } => {
-                        let mut i = *end;
-                        while i > *start {
+                    SimForRange::Reverse { step, .. } => {
+                        let mut i = end;
+                        while i > start {
                             i -= step;
                             step_body(i);
                         }
                     }
-                    SimForRange::Stepped {
-                        start,
-                        end,
-                        step,
-                        op,
-                    } => {
-                        let mut i = *start;
-                        while i < *end {
+                    SimForRange::Stepped { step, op, .. } => {
+                        let mut i = start;
+                        while i < end {
                             step_body(i);
                             i = op.eval(i as usize, *step as usize) as u64;
                         }
@@ -686,24 +683,316 @@ pub struct CompiledBlockStatement {
 }
 
 #[derive(Clone, Debug)]
+pub enum ProtoForBound {
+    Const(usize),
+    Expression(Box<ProtoExpression>),
+}
+
+impl ProtoForBound {
+    pub fn adjust_offsets(&mut self, ff_delta: isize, comb_delta: isize) {
+        if let Self::Expression(exp) = self {
+            exp.adjust_offsets(ff_delta, comb_delta);
+        }
+    }
+
+    pub fn gather_variable_offsets(&self, inputs: &mut Vec<VarOffset>) {
+        if let Self::Expression(exp) = self {
+            exp.gather_variable_offsets(inputs);
+        }
+    }
+}
+
+impl Conv<&air::ForBound> for ProtoForBound {
+    fn conv(context: &mut ConvContext, src: &air::ForBound) -> Result<Self, SimulatorError> {
+        match src {
+            air::ForBound::Const(x) => Ok(Self::Const(*x)),
+            air::ForBound::Expression(exp) => {
+                let exp = Conv::conv(context, exp.as_ref())?;
+                Ok(Self::Expression(Box::new(exp)))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SimForBound {
+    Const(u64),
+    Expression(Box<Expression>),
+}
+
+impl SimForBound {
+    pub fn from_proto(
+        proto: &ProtoForBound,
+        ff_values_ptr: *mut u8,
+        ff_len: usize,
+        comb_values_ptr: *mut u8,
+        comb_len: usize,
+        use_4state: bool,
+    ) -> Self {
+        match proto {
+            ProtoForBound::Const(x) => Self::Const(*x as u64),
+            ProtoForBound::Expression(exp) => {
+                let exp = unsafe {
+                    exp.apply_values_ptr(
+                        ff_values_ptr,
+                        ff_len,
+                        comb_values_ptr,
+                        comb_len,
+                        use_4state,
+                    )
+                };
+                Self::Expression(Box::new(exp))
+            }
+        }
+    }
+
+    pub fn eval(&self, mask_cache: &mut MaskCache) -> u64 {
+        match self {
+            Self::Const(x) => *x,
+            Self::Expression(exp) => {
+                let val = exp.eval(mask_cache);
+                val.to_u64().unwrap_or_default()
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ProtoForRange {
+    Forward {
+        start: ProtoForBound,
+        end: ProtoForBound,
+        inclusive: bool,
+        step: usize,
+    },
+    Reverse {
+        start: ProtoForBound,
+        end: ProtoForBound,
+        inclusive: bool,
+        step: usize,
+    },
+    Stepped {
+        start: ProtoForBound,
+        end: ProtoForBound,
+        inclusive: bool,
+        step: usize,
+        op: air::Op,
+    },
+}
+
+impl ProtoForRange {
+    pub fn adjust_offsets(&mut self, ff_delta: isize, comb_delta: isize) {
+        match self {
+            Self::Forward { start, end, .. }
+            | Self::Reverse { start, end, .. }
+            | Self::Stepped { start, end, .. } => {
+                start.adjust_offsets(ff_delta, comb_delta);
+                end.adjust_offsets(ff_delta, comb_delta);
+            }
+        }
+    }
+
+    pub fn gather_variable_offsets(&self, inputs: &mut Vec<VarOffset>) {
+        match self {
+            Self::Forward { start, end, .. }
+            | Self::Reverse { start, end, .. }
+            | Self::Stepped { start, end, .. } => {
+                start.gather_variable_offsets(inputs);
+                end.gather_variable_offsets(inputs);
+            }
+        }
+    }
+}
+
+impl Conv<&air::ForRange> for ProtoForRange {
+    fn conv(context: &mut ConvContext, src: &air::ForRange) -> Result<Self, SimulatorError> {
+        match src {
+            air::ForRange::Forward {
+                start,
+                end,
+                inclusive,
+                step,
+            } => Ok(Self::Forward {
+                start: Conv::conv(context, start)?,
+                end: Conv::conv(context, end)?,
+                inclusive: *inclusive,
+                step: *step,
+            }),
+            air::ForRange::Reverse {
+                start,
+                end,
+                inclusive,
+                step,
+            } => Ok(Self::Reverse {
+                start: Conv::conv(context, start)?,
+                end: Conv::conv(context, end)?,
+                inclusive: *inclusive,
+                step: *step,
+            }),
+            air::ForRange::Stepped {
+                start,
+                end,
+                inclusive,
+                step,
+                op,
+            } => Ok(Self::Stepped {
+                start: Conv::conv(context, start)?,
+                end: Conv::conv(context, end)?,
+                inclusive: *inclusive,
+                step: *step,
+                op: *op,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum SimForRange {
     Forward {
-        start: u64,
-        end: u64,
+        start: SimForBound,
+        end: SimForBound,
+        inclusive: bool,
         step: u64,
     },
     Reverse {
-        start: u64,
-        end: u64,
+        start: SimForBound,
+        end: SimForBound,
+        inclusive: bool,
         step: u64,
     },
     Stepped {
-        start: u64,
-        end: u64,
+        start: SimForBound,
+        end: SimForBound,
+        inclusive: bool,
         step: u64,
         op: air::Op,
     },
 }
+
+impl SimForRange {
+    pub fn from_proto(
+        proto: &ProtoForRange,
+        ff_values_ptr: *mut u8,
+        ff_len: usize,
+        comb_values_ptr: *mut u8,
+        comb_len: usize,
+        use_4state: bool,
+    ) -> Self {
+        match proto {
+            ProtoForRange::Forward {
+                start,
+                end,
+                inclusive,
+                step,
+            } => Self::Forward {
+                start: SimForBound::from_proto(
+                    start,
+                    ff_values_ptr,
+                    ff_len,
+                    comb_values_ptr,
+                    comb_len,
+                    use_4state,
+                ),
+                end: SimForBound::from_proto(
+                    end,
+                    ff_values_ptr,
+                    ff_len,
+                    comb_values_ptr,
+                    comb_len,
+                    use_4state,
+                ),
+                inclusive: *inclusive,
+                step: *step as u64,
+            },
+            ProtoForRange::Reverse {
+                start,
+                end,
+                inclusive,
+                step,
+            } => Self::Reverse {
+                start: SimForBound::from_proto(
+                    start,
+                    ff_values_ptr,
+                    ff_len,
+                    comb_values_ptr,
+                    comb_len,
+                    use_4state,
+                ),
+                end: SimForBound::from_proto(
+                    end,
+                    ff_values_ptr,
+                    ff_len,
+                    comb_values_ptr,
+                    comb_len,
+                    use_4state,
+                ),
+                inclusive: *inclusive,
+                step: *step as u64,
+            },
+            ProtoForRange::Stepped {
+                start,
+                end,
+                inclusive,
+                step,
+                op,
+            } => Self::Stepped {
+                start: SimForBound::from_proto(
+                    start,
+                    ff_values_ptr,
+                    ff_len,
+                    comb_values_ptr,
+                    comb_len,
+                    use_4state,
+                ),
+                end: SimForBound::from_proto(
+                    end,
+                    ff_values_ptr,
+                    ff_len,
+                    comb_values_ptr,
+                    comb_len,
+                    use_4state,
+                ),
+                inclusive: *inclusive,
+                step: *step as u64,
+                op: *op,
+            },
+        }
+    }
+
+    pub fn eval(&self, mask_cache: &mut MaskCache) -> (u64, u64) {
+        match self {
+            SimForRange::Forward {
+                start,
+                end,
+                inclusive,
+                ..
+            }
+            | SimForRange::Reverse {
+                start,
+                end,
+                inclusive,
+                ..
+            }
+            | SimForRange::Stepped {
+                start,
+                end,
+                inclusive,
+                ..
+            } => {
+                let start = start.eval(mask_cache);
+                let end = end.eval(mask_cache);
+                if *inclusive {
+                    (start, end + 1)
+                } else {
+                    (start, end)
+                }
+            }
+        }
+    }
+}
+
+// SAFETY: ForwardDynamic::end_ptr points into an exclusively-owned simulation buffer.
+unsafe impl Send for SimForRange {}
 
 #[derive(Clone, Debug)]
 pub struct ProtoForStatement {
@@ -711,7 +1000,7 @@ pub struct ProtoForStatement {
     pub var_width: usize,
     pub var_native_bytes: usize,
     pub var_signed: bool,
-    pub range: SimForRange,
+    pub range: ProtoForRange,
     pub body: Vec<ProtoStatement>,
 }
 
@@ -799,6 +1088,7 @@ impl ProtoStatement {
             }
             ProtoStatement::For(x) => {
                 x.var_offset = x.var_offset.adjust(ff_delta, comb_delta);
+                x.range.adjust_offsets(ff_delta, comb_delta);
                 for s in &mut x.body {
                     s.adjust_offsets(ff_delta, comb_delta);
                 }
@@ -949,6 +1239,7 @@ impl ProtoStatement {
                 }
             }
             ProtoStatement::For(x) => {
+                x.range.gather_variable_offsets(inputs);
                 for s in &x.body {
                     s.gather_variable_offsets(inputs, outputs);
                 }
@@ -1193,6 +1484,16 @@ impl ProtoStatement {
                     } else {
                         comb_values_ptr.offset(x.var_offset.raw())
                     };
+
+                    let range = SimForRange::from_proto(
+                        &x.range,
+                        ff_values_ptr,
+                        ff_len,
+                        comb_values_ptr,
+                        comb_len,
+                        use_4state,
+                    );
+
                     let body = x
                         .body
                         .iter()
@@ -1212,7 +1513,7 @@ impl ProtoStatement {
                         var_use_4state: use_4state,
                         var_width: x.var_width,
                         var_signed: x.var_signed,
-                        range: x.range.clone(),
+                        range,
                         body,
                     })
                 }
@@ -2353,35 +2654,13 @@ impl Conv<&air::Statement> for Vec<ProtoStatement> {
                 let var_native_bytes = meta.native_bytes;
                 let var_signed = x.var_type.signed;
 
+                let range: ProtoForRange = Conv::conv(context, &x.range)?;
+
                 let mut body = vec![];
                 for stmt in &x.body {
                     let stmts: Vec<ProtoStatement> = Conv::conv(context, stmt)?;
                     body.extend(stmts);
                 }
-
-                let range = match &x.range {
-                    air::ForRange::Forward { start, end, step } => SimForRange::Forward {
-                        start: *start as u64,
-                        end: *end as u64,
-                        step: *step as u64,
-                    },
-                    air::ForRange::Reverse { start, end, step } => SimForRange::Reverse {
-                        start: *start as u64,
-                        end: *end as u64,
-                        step: *step as u64,
-                    },
-                    air::ForRange::Stepped {
-                        start,
-                        end,
-                        step,
-                        op,
-                    } => SimForRange::Stepped {
-                        start: *start as u64,
-                        end: *end as u64,
-                        step: *step as u64,
-                        op: *op,
-                    },
-                };
 
                 vec![ProtoStatement::For(ProtoForStatement {
                     var_offset,

--- a/crates/simulator/src/testbench.rs
+++ b/crates/simulator/src/testbench.rs
@@ -522,6 +522,7 @@ fn exec_one(sim: &mut Simulator, stmt: &TestbenchStatement) -> ExecResult {
             loop_var,
         } => {
             if let Some(lv) = loop_var {
+                let (start, end) = lv.range.eval(&mut sim.mask_cache);
                 let mut step_body = |i: u64| -> ExecResult {
                     let val = Value::new(i, lv.width, lv.signed);
                     unsafe {
@@ -530,9 +531,9 @@ fn exec_one(sim: &mut Simulator, stmt: &TestbenchStatement) -> ExecResult {
                     exec(sim, body)
                 };
                 match &lv.range {
-                    SimForRange::Forward { start, end, step } => {
-                        let mut i = *start;
-                        while i < *end {
+                    SimForRange::Forward { step, .. } => {
+                        let mut i = start;
+                        while i < end {
                             let result = step_body(i);
                             if result.should_stop() {
                                 return result;
@@ -540,9 +541,9 @@ fn exec_one(sim: &mut Simulator, stmt: &TestbenchStatement) -> ExecResult {
                             i += step;
                         }
                     }
-                    SimForRange::Reverse { start, end, step } => {
-                        let mut i = *end;
-                        while i > *start {
+                    SimForRange::Reverse { step, .. } => {
+                        let mut i = end;
+                        while i > start {
                             i -= step;
                             let result = step_body(i);
                             if result.should_stop() {
@@ -550,14 +551,9 @@ fn exec_one(sim: &mut Simulator, stmt: &TestbenchStatement) -> ExecResult {
                             }
                         }
                     }
-                    SimForRange::Stepped {
-                        start,
-                        end,
-                        step,
-                        op,
-                    } => {
-                        let mut i = *start;
-                        while i < *end {
+                    SimForRange::Stepped { step, op, .. } => {
+                        let mut i = start;
+                        while i < end {
                             let result = step_body(i);
                             if result.should_stop() {
                                 return result;

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -10927,3 +10927,299 @@ fn function_var_reassign_not_comb_loop() {
         );
     }
 }
+
+#[test]
+fn for_loop_range_determied_by_variable() {
+    let code = r#"
+    module Top #(
+        param T: type = logic<4>,
+    )(
+        o0: output T,
+        o1: output T,
+        o2: output T,
+        o3: output T,
+        o4: output T,
+        o5: output T,
+        o6: output T,
+        o7: output T,
+    ) {
+        function func(
+            out: output T<8>,
+        ) {
+            var m: u32;
+            var n: u32;
+
+            for i: u32 in 0..8 {
+                out[i] = 0 as T;
+            }
+
+            m = 8;
+            for i: u32 in 0..2 {
+                n = m;
+                m = n / 2;
+                $display("i %d m %d n %d", i, m, n);
+                for j: u32 in 0..m {
+                    out[4 * i + j] = (4 * i + j) as T;
+                }
+            }
+        }
+
+        var out: T<8>;
+
+        always_comb {
+            func(out);
+            o0  = out[0];
+            o1  = out[1];
+            o2  = out[2];
+            o3  = out[3];
+            o4  = out[4];
+            o5  = out[5];
+            o6  = out[6];
+            o7  = out[7];
+        }
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        let exp_list: [u64; 8] = [0, 1, 2, 3, 4, 5, 0, 0];
+        for (i, exp) in exp_list.iter().enumerate() {
+            let port = format!("o{}", i);
+            assert_eq!(
+                sim.get(&port).unwrap(),
+                Value::new(*exp, 4, false),
+                "i={} expected={} JIT={} 4st={}",
+                i,
+                exp,
+                config.use_jit,
+                config.use_4state,
+            );
+        }
+    }
+
+    let code = r#"
+    module Top #(
+        param T: type = logic<4>,
+    )(
+        o0: output T,
+        o1: output T,
+        o2: output T,
+        o3: output T,
+        o4: output T,
+        o5: output T,
+        o6: output T,
+        o7: output T,
+    ) {
+        function func(
+            beg_outer: input  u32 ,
+            end_outer: input  u32 ,
+            out      : output T<8>,
+        ) {
+            var m: u32;
+            var n: u32;
+
+            for i: u32 in 0..8 {
+                out[i] = 0 as T;
+            }
+
+            m = 8;
+            for i: u32 in beg_outer..end_outer {
+                n = m;
+                m = n / 2;
+                for j: u32 in 0..m {
+                    out[4 * i + j] = (4 * i + j) as T;
+                }
+            }
+        }
+
+        var out: T<8>;
+
+        always_comb {
+            func(0, 2, out);
+            o0  = out[0];
+            o1  = out[1];
+            o2  = out[2];
+            o3  = out[3];
+            o4  = out[4];
+            o5  = out[5];
+            o6  = out[6];
+            o7  = out[7];
+        }
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        let exp_list: [u64; 8] = [0, 1, 2, 3, 4, 5, 0, 0];
+        for (i, exp) in exp_list.iter().enumerate() {
+            let port = format!("o{}", i);
+            assert_eq!(
+                sim.get(&port).unwrap(),
+                Value::new(*exp, 4, false),
+                "i={} expected={} JIT={} 4st={}",
+                i,
+                exp,
+                config.use_jit,
+                config.use_4state,
+            );
+        }
+    }
+
+    let code = r#"
+    module Top #(
+        param T: type = logic<4>,
+    )(
+        o0: output T,
+        o1: output T,
+        o2: output T,
+        o3: output T,
+        o4: output T,
+        o5: output T,
+        o6: output T,
+        o7: output T,
+    ) {
+        function func(
+            out: output T<8>,
+        ) {
+            var m: i32;
+            var n: i32;
+
+            for i: u32 in 0..8 {
+                out[i] = 0 as T;
+            }
+
+            m = -2;
+            for i: u32 in 0..2 {
+                n = m;
+                m = n + 2;
+                for j: u32 in m..4 {
+                    out[4 * i + j] = (4 * i + j) as T;
+                }
+            }
+        }
+
+        var out: T<8>;
+
+        always_comb {
+            func(out);
+            o0  = out[0];
+            o1  = out[1];
+            o2  = out[2];
+            o3  = out[3];
+            o4  = out[4];
+            o5  = out[5];
+            o6  = out[6];
+            o7  = out[7];
+        }
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        let exp_list: [u64; 8] = [0, 1, 2, 3, 0, 0, 6, 7];
+        for (i, exp) in exp_list.iter().enumerate() {
+            let port = format!("o{}", i);
+            assert_eq!(
+                sim.get(&port).unwrap(),
+                Value::new(*exp, 4, false),
+                "i={} expected={} JIT={} 4st={}",
+                i,
+                exp,
+                config.use_jit,
+                config.use_4state,
+            );
+        }
+    }
+
+    let code = r#"
+    module Top #(
+        param T: type = logic<4>,
+    )(
+        o0: output T,
+        o1: output T,
+        o2: output T,
+        o3: output T,
+        o4: output T,
+        o5: output T,
+        o6: output T,
+        o7: output T,
+    ) {
+        function func(
+            beg_outer: input  u32 ,
+            end_outer: input  u32 ,
+            out      : output T<8>,
+        ) {
+            var m: i32;
+            var n: i32;
+
+            for i: u32 in 0..8 {
+                out[i] = 0 as T;
+            }
+
+            m = -2;
+            for i: u32 in beg_outer..end_outer {
+                n = m;
+                m = n + 2;
+                for j: u32 in m..4 {
+                    out[4 * i + j] = (4 * i + j) as T;
+                }
+            }
+        }
+
+        var out: T<8>;
+
+        always_comb {
+            func(0, 2, out);
+            o0  = out[0];
+            o1  = out[1];
+            o2  = out[2];
+            o3  = out[3];
+            o4  = out[4];
+            o5  = out[5];
+            o6  = out[6];
+            o7  = out[7];
+        }
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        let exp_list: [u64; 8] = [0, 1, 2, 3, 0, 0, 6, 7];
+        for (i, exp) in exp_list.iter().enumerate() {
+            let port = format!("o{}", i);
+            assert_eq!(
+                sim.get(&port).unwrap(),
+                Value::new(*exp, 4, false),
+                "i={} expected={} JIT={} 4st={}",
+                i,
+                exp,
+                config.use_jit,
+                config.use_4state,
+            );
+        }
+    }
+}


### PR DESCRIPTION
fix veryl-lang/veryl#2490

Currently, simulator does not support `for` loop with dynamically determined range.
Due to this, `$std::select_vector` and `$std::select_one hot` are not simulated correctlly.

This PR is to add such `for` loop support veryl simulator.