### PR TITLE
Allow to use system functions in `gen` context

### DIFF
--- a/crates/analyzer/src/conv/checker/generic.rs
+++ b/crates/analyzer/src/conv/checker/generic.rs
@@ -136,6 +136,7 @@ fn is_referable_symbol(symbol: &Symbol, base: Option<&Symbol>) -> bool {
         | SymbolKind::ProtoPackage(_)
         | SymbolKind::GenericParameter(_)
         | SymbolKind::GenericConst(_)
+        | SymbolKind::SystemFunction(_)
         | SymbolKind::SystemVerilog => {
             return true;
         }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10098,6 +10098,16 @@ fn unresolvable_generic_expression() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        gen A: u32 = 8;
+        gen B: u32 = $clog2(A);
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2947,7 +2947,7 @@ fn gen_declaration() {
         b: input T       ,
     ) {}
     module ModuleB::<A: u32, B: u32, C: u32, D: u32> {
-        gen WIDTH_A: u32  = A + B;
+        gen WIDTH_A: u32  = $clog2(A + B);
         gen TYPE_A : u32  = logic<WIDTH_A>;
         gen TYPE_B : type = logic<C, D>;
 
@@ -2964,8 +2964,8 @@ fn gen_declaration() {
     }
     "#;
 
-    let expect = r#"module prj___ModuleA__3__logic_3_4 (
-    input var logic [3-1:0]        a,
+    let expect = r#"module prj___ModuleA__2__logic_3_4 (
+    input var logic [2-1:0]        a,
     input var logic [3-1:0][4-1:0] b
 );
 endmodule
@@ -2974,10 +2974,10 @@ module prj___ModuleB__1__2__3__4;
 
 
 
-    logic        [3-1:0] a; always_comb a = '0;
+    logic        [2-1:0] a; always_comb a = '0;
     logic [3-1:0][4-1:0] b; always_comb b = '0;
 
-    prj___ModuleA__3__logic_3_4 u (
+    prj___ModuleA__2__logic_3_4 u (
         .a (a),
         .b (a)
     );


### PR DESCRIPTION
fix veryl-lang/veryl#2512