### PR TITLE
Fix `invalid_operand` error reproted for `gen` value used as casting type

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -950,6 +950,27 @@ pub fn eval_type(
                     }
                     _ => ir::TypeKind::Unknown,
                 },
+                SymbolKind::GenericConst(x) => match &x.bound {
+                    GenericBoundKind::Proto(x) => {
+                        let mut r#type = x.to_ir_type(context, pos)?;
+                        width.append(&mut r#type.width);
+                        array.append(&mut r#type.array);
+                        signed = r#type.signed;
+
+                        r#type.kind
+                    }
+                    GenericBoundKind::Type => {
+                        let (comptime, _) = eval_generic_expr(context, &x.value)?;
+                        if let ValueVariant::Type(mut x) = comptime.value {
+                            width.append(&mut x.width);
+                            array.append(&mut x.array);
+                            x.kind
+                        } else {
+                            ir::TypeKind::Unknown
+                        }
+                    }
+                    _ => ir::TypeKind::Unknown,
+                },
                 SymbolKind::Parameter(x) => {
                     if x.r#type.kind.is_type() {
                         if let Some(expr) = &x.value {

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -382,11 +382,9 @@ impl Symbol {
 
         let consts = self.generic_consts();
         if !consts.is_empty() {
-            let namespace = self.inner_namespace();
             for (name, r#const) in &consts {
                 let maps = vec![map.clone()];
-                if let Some(mut path) = Self::expr_to_generic_symbol_path(&r#const.value, &maps) {
-                    path.resolve_imported(&namespace, Some(&maps));
+                if let Some(path) = Self::expr_to_generic_symbol_path(&r#const.value, &maps) {
                     map.map.insert(*name, path);
                 }
             }
@@ -419,7 +417,13 @@ impl Symbol {
                 }
                 syntax_tree::Factor::IdentifierFactor(x) => {
                     if x.identifier_factor.identifier_factor_opt.is_none() {
-                        return Some(x.identifier_factor.expression_identifier.as_ref().into());
+                        let mut context = Context::default();
+                        context.push_generic_map(maps.to_vec());
+
+                        let path = context.resolve_path(
+                            x.identifier_factor.expression_identifier.as_ref().into(),
+                        );
+                        return Some(path);
                     }
                 }
                 syntax_tree::Factor::LParenExpressionRParen(x) => {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8494,6 +8494,22 @@ fn invalid_operand() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InvalidOperand { .. }));
+
+    let code = r#"
+    module ModuleA {
+        function func::<N: u32> {
+            gen W: u32 = N;
+            var a: u32;
+            a = 0 as W;
+        }
+        always_comb {
+            func::<8>();
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2998,4 +2998,41 @@ endmodule
 
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
+
+    let code = r#"
+module ModuleA {
+    function func::<N: u32> {
+        gen W: u32 = N;
+        var a: u32;
+        a = 0 as W;
+    }
+    always_comb {
+        func::<8>();
+    }
+}
+    "#;
+
+    let expect = r#"module prj_ModuleA;
+    function automatic void __func__8;
+
+        int unsigned a;
+        a = 8'(0);
+    endfunction
+    always_comb begin
+        __func__8();
+    end
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = if cfg!(windows) {
+        emit(&metadata, code).replace("\r\n", "\n")
+    } else {
+        emit(&metadata, code)
+    };
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
 }


### PR DESCRIPTION
fix veryl-lang/veryl#2514

`eval_type` does not implement the caes where the given `path` points a `GenericConst`.
This cuases the error shown in #2514.