### PR TITLE
Fix issues related to generic global functions

### DIFF
--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -86,7 +86,7 @@ impl Analyzer {
         let mut ret = Vec::new();
 
         let is_dependency = project_name != self.project_name;
-        namespace_table::set_default(&[project_name.into()]);
+        namespace_table::set_project(project_name.into(), !is_dependency);
         let mut pass1 = AnalyzerPass1::new(&self.build_opt, &self.lint_opt, is_dependency);
         pass1.veryl(input);
         ret.append(&mut pass1.handlers.get_errors());

--- a/crates/analyzer/src/conv/checker/generic.rs
+++ b/crates/analyzer/src/conv/checker/generic.rs
@@ -390,7 +390,7 @@ pub fn check_generic_expression(
 
     let bound_namespace = if let Some(base) = base {
         &base.namespace
-    } else if let Some(namespce) = context.currnet_namespace() {
+    } else if let Some(namespce) = context.current_namespace() {
         &namespce.clone()
     } else {
         &Namespace::default()

--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -488,7 +488,7 @@ impl Context {
         self.namespaces.pop();
     }
 
-    pub fn currnet_namespace(&self) -> Option<Namespace> {
+    pub fn current_namespace(&self) -> Option<Namespace> {
         self.namespaces.last().cloned()
     }
 

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -946,13 +946,13 @@ impl Conv<(&FunctionDeclaration, Option<&FuncPath>)> for () {
 
             // insert VarPath for function before statement_block conv
             // because it may be refered by recursive function
-            let (path, name) = if let Some(path) = path {
+            let (path, name, namespace) = if let Some(path) = path {
                 let name = resource_table::insert_str(&path.sig.to_string());
-                (path.clone(), name)
+                (path.clone(), name, path.sig.namespace())
             } else {
                 let name = func_def.identifier.text();
                 let path = FuncPath::new(symbol.found.id);
-                (path, name)
+                (path, name, symbol.found.inner_namespace())
             };
 
             if context.func_paths.contains_key(&path) {
@@ -965,7 +965,7 @@ impl Conv<(&FunctionDeclaration, Option<&FuncPath>)> for () {
 
             context.push_affiliation(Affiliation::Function);
             context.push_hierarchy(name);
-            context.push_namespace(symbol.found.inner_namespace());
+            context.push_namespace(namespace);
 
             let arg_items: Vec<_> = if let Some(x) = &func_def.function_declaration_opt0
                 && let Some(x) = &x.port_declaration.port_declaration_opt

--- a/crates/analyzer/src/conv/expression.rs
+++ b/crates/analyzer/src/conv/expression.rs
@@ -492,12 +492,14 @@ impl Conv<&Factor> for ir::Expression {
                                 } else {
                                     None
                                 };
+                            let rep = rep.map(Box::new);
                             let exp: ir::Expression = Conv::conv(context, x.expression.as_ref())?;
+                            let exp = Box::new(exp);
                             ir::ArrayLiteralItem::Value(exp, rep)
                         }
                         ArrayLiteralItemGroup::DefaulColonExpression(x) => {
                             let exp: ir::Expression = Conv::conv(context, x.expression.as_ref())?;
-                            ir::ArrayLiteralItem::Defaul(exp)
+                            ir::ArrayLiteralItem::Defaul(Box::new(exp))
                         }
                     };
                     ret.push(item);

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -339,7 +339,7 @@ pub fn eval_array_literal(
                         vec![ArrayLiteralExpression {
                             index: vec![],
                             select: vec![],
-                            expr: expr.clone(),
+                            expr: expr.as_ref().clone(),
                         }]
                     };
 
@@ -367,7 +367,7 @@ pub fn eval_array_literal(
                         vec![ArrayLiteralExpression {
                             index: vec![],
                             select: vec![],
-                            expr: expr.clone(),
+                            expr: expr.as_ref().clone(),
                         }]
                     };
 
@@ -1654,7 +1654,7 @@ pub fn eval_factor_path(
         Ok(ir::Factor::Anonymous(comptime))
     } else if let Ok(symbol) = symbol_table::resolve(&generic_path) {
         let is_inernal = context
-            .currnet_namespace()
+            .current_namespace()
             .map(|x| symbol.found.namespace.included(&x))
             .unwrap_or(false);
         if is_inernal {
@@ -1689,7 +1689,7 @@ pub fn eval_factor_symbol(
     match &symbol.found.kind {
         SymbolKind::Parameter(x) => {
             // Parameter should be found through context.find_path from the defined namespace
-            if let Some(namespace) = context.currnet_namespace()
+            if let Some(namespace) = context.current_namespace()
                 && symbol.found.namespace.included(&namespace)
             {
                 context.insert_error(AnalyzerError::referring_before_definition(
@@ -2640,7 +2640,7 @@ fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> Ir
         };
 
         let is_local_func = context
-            .currnet_namespace()
+            .current_namespace()
             .map(|namespace| symbol.namespace.included(&namespace))
             .unwrap_or(false);
         if is_local_func {

--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -862,8 +862,8 @@ impl fmt::Display for Factor {
 
 #[derive(Clone, Debug)]
 pub enum ArrayLiteralItem {
-    Value(Expression, Option<Expression>),
-    Defaul(Expression),
+    Value(Box<Expression>, Option<Box<Expression>>),
+    Defaul(Box<Expression>),
 }
 
 impl ArrayLiteralItem {

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -1,5 +1,6 @@
 use crate::conv::Context;
 use crate::ir::ValueVariant;
+use crate::namespace::Namespace;
 use crate::symbol::GenericMap;
 use crate::symbol::{GenericBoundKind, SymbolId, SymbolKind, TypeKind};
 use crate::symbol_path::GenericSymbolPath;
@@ -10,6 +11,7 @@ use veryl_parser::resource_table::StrId;
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Signature {
     pub symbol: SymbolId,
+    pub full_path: Vec<StrId>,
     pub parameters: Vec<(StrId, ValueVariant)>,
     pub generic_parameters: Vec<(StrId, GenericSymbolPath)>,
 }
@@ -18,6 +20,7 @@ impl Signature {
     pub fn new(symbol: SymbolId) -> Self {
         Self {
             symbol,
+            full_path: vec![],
             parameters: vec![],
             generic_parameters: vec![],
         }
@@ -108,6 +111,7 @@ impl Signature {
 
                 let namespace = namespace_table::get(path.paths[0].base.id).unwrap();
                 if let Ok(symbol) = symbol_table::resolve((&path.mangled_path(), &namespace)) {
+                    let current_namespace = context.current_namespace();
                     for id in &symbol.full_path {
                         let symbol = symbol_table::get(*id).unwrap();
                         let SymbolKind::GenericInstance(inst) = &symbol.kind else {
@@ -118,10 +122,17 @@ impl Signature {
                         let params = base.generic_parameters();
                         if inst.arguments.len() == params.len() {
                             for (i, (name, _)) in params.iter().enumerate() {
-                                sig.add_generic_parameter(*name, inst.arguments[i].clone());
+                                let mut arg = inst.arguments[i].clone();
+                                if let Some(current_namespace) = &current_namespace {
+                                    arg.append_namespace_path(current_namespace, &base.namespace);
+                                }
+                                sig.add_generic_parameter(*name, arg);
                             }
                         }
                     }
+
+                    sig.full_path
+                        .append(&mut symbol.found.inner_namespace().paths.to_vec());
                 }
             }
         }
@@ -135,6 +146,21 @@ impl Signature {
             ret.map.insert(*key, val.clone());
         }
         vec![ret]
+    }
+
+    pub fn namespace(&self) -> Namespace {
+        if self.full_path.is_empty() {
+            let symbol = symbol_table::get(self.symbol).unwrap();
+            symbol.inner_namespace()
+        } else {
+            let mut ret = Namespace::new();
+
+            for path in &self.full_path {
+                ret.push(*path);
+            }
+
+            ret
+        }
     }
 }
 

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -1972,7 +1972,7 @@ fn generics_resolve() {
             i_rst: '0,
         );
     }
-    "#;
+"#;
 
     let exp = r#"module ModuleA {
   input var0(i_clk): clock = 1'hx;
@@ -2008,6 +2008,37 @@ module ModuleB {
       }
     }
   }
+}
+"#;
+
+    check_ir(code, exp);
+
+    let code = r#"
+    function func_a::<A: u32> -> u32 {
+        return A;
+    }
+    package Pkg::<A: u32> {
+        const B: u32 = A;
+        function func_b() -> u32 {
+            return func_a::<B>();
+        }
+    }
+    module ModuleA {
+        const A: u32 = Pkg::<1>::func_b();
+    }
+    "#;
+
+    let exp = r#"module ModuleA {
+  var var1(Pkg.func_b::<1>.return): bit<32> = 32'h00000001;
+  var var3(Pkg.func_a::<__Pkg__1 B>.return): bit<32> = 32'h00000001;
+  const var4(A): bit<32> = 32'h00000001;
+  func var0(Pkg.func_b::<1>) -> var1 {
+    var1 = 32'h00000001;
+  }
+  func var2(Pkg.func_a::<__Pkg__1 B>) -> var3 {
+    var3 = 32'sh00000001;
+  }
+
 }
 "#;
 

--- a/crates/analyzer/src/namespace.rs
+++ b/crates/analyzer/src/namespace.rs
@@ -2,6 +2,7 @@ use crate::attribute::Attribute;
 use crate::attribute_table;
 use crate::namespace_table;
 use crate::symbol::Symbol;
+use crate::symbol::SymbolKind;
 use crate::symbol_path::SymbolPath;
 use crate::symbol_table;
 use crate::{HashMap, SVec, svec};
@@ -167,6 +168,8 @@ impl Namespace {
 
     pub fn get_symbol(&self) -> Option<Symbol> {
         let mut namespace = self.clone();
+        namespace.strip_anonymous_path();
+
         if let Some(path) = namespace.pop()
             && namespace.depth() >= 1
         {
@@ -176,6 +179,22 @@ impl Namespace {
         } else {
             None
         }
+    }
+
+    pub fn generic_namespace(&self) -> Self {
+        let mut ret = Namespace::new();
+        for i in 0..self.depth() {
+            let path = self.paths[i];
+            if i == 0 || !path.to_string().starts_with("__") {
+                ret.push(path);
+            } else if let Ok(symbol) = symbol_table::resolve((path, &ret))
+                && let SymbolKind::GenericInstance(inst) = &symbol.found.kind
+            {
+                let base = inst.base_symbol();
+                ret.push(base.token.text);
+            }
+        }
+        ret
     }
 }
 

--- a/crates/analyzer/src/namespace_table.rs
+++ b/crates/analyzer/src/namespace_table.rs
@@ -7,6 +7,8 @@ use veryl_parser::resource_table::{PathId, StrId, TokenId};
 #[derive(Clone, Debug)]
 pub struct NamespaceTable {
     default: Namespace,
+    project_names: Vec<StrId>,
+    root_project: Option<StrId>,
     table: HashMap<TokenId, (Namespace, PathId)>,
 }
 
@@ -27,6 +29,24 @@ impl NamespaceTable {
         self.table.retain(|_, x| x.1 != file_path);
     }
 
+    pub fn set_project(&mut self, project_name: StrId, is_root: bool) {
+        if !self.project_names.contains(&project_name) {
+            self.project_names.push(project_name);
+            if is_root {
+                self.root_project = Some(project_name);
+            }
+        }
+        self.set_default(&[project_name]);
+    }
+
+    pub fn match_project_name(&self, name: StrId) -> bool {
+        self.project_names.contains(&name)
+    }
+
+    pub fn root_project_name(&self) -> StrId {
+        self.root_project.unwrap()
+    }
+
     pub fn set_default(&mut self, id: &[StrId]) {
         let mut namespace = Namespace::new();
         for id in id {
@@ -40,6 +60,8 @@ impl NamespaceTable {
     }
 
     pub fn clear(&mut self) {
+        self.project_names.clear();
+        self.root_project = None;
         self.table.clear()
     }
 }
@@ -48,6 +70,8 @@ impl Default for NamespaceTable {
     fn default() -> Self {
         Self {
             default: Namespace::new(),
+            project_names: vec![],
+            root_project: None,
             table: HashMap::default(),
         }
     }
@@ -96,6 +120,18 @@ pub fn dump() -> String {
 
 pub fn drop(file_path: PathId) {
     NAMESPACE_TABLE.with(|f| f.borrow_mut().drop(file_path))
+}
+
+pub fn set_project(project_name: StrId, is_root: bool) {
+    NAMESPACE_TABLE.with(|f| f.borrow_mut().set_project(project_name, is_root))
+}
+
+pub fn match_project_name(name: StrId) -> bool {
+    NAMESPACE_TABLE.with(|f| f.borrow().match_project_name(name))
+}
+
+pub fn root_project_name() -> StrId {
+    NAMESPACE_TABLE.with(|f| f.borrow().root_project_name())
 }
 
 pub fn set_default(id: &[StrId]) {

--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -3,7 +3,7 @@ use crate::generic_inference_table;
 use crate::namespace::Namespace;
 use crate::namespace_table;
 use crate::symbol::{Direction, GenericMap, Symbol, SymbolKind};
-use crate::symbol_path::{GenericSymbolPath, SymbolPath, SymbolPathNamespace};
+use crate::symbol_path::{GenericSymbol, GenericSymbolPath, SymbolPath, SymbolPathNamespace};
 use crate::symbol_table;
 use crate::symbol_table::{ResolveError, ResolveErrorCause};
 use std::cell::RefCell;
@@ -248,6 +248,7 @@ impl ReferenceTable {
         generic_maps: Option<&Vec<GenericMap>>,
     ) {
         let mut path = path.clone();
+        let mut resolved_generic_maps = vec![];
 
         let orig_len = path.len();
         path.resolve_imported(namespace, generic_maps);
@@ -352,7 +353,14 @@ impl ReferenceTable {
                     if path.is_generic_reference() {
                         Self::add_generic_reference(&target_symbol, namespace, &path, i);
                     } else {
-                        Self::insert_generic_instance(&path, i, namespace, &target_symbol, None);
+                        Self::insert_generic_instance(
+                            &path,
+                            i,
+                            namespace,
+                            &target_symbol,
+                            &mut resolved_generic_maps,
+                            None,
+                        );
                     }
                 }
                 Err(err) => {
@@ -372,22 +380,13 @@ impl ReferenceTable {
         ith: usize,
         namespace: &Namespace,
         target: &Symbol,
+        generic_maps: &mut Vec<GenericMap>,
         affiliation_symbol: Option<&Symbol>,
     ) {
         let instance_path = &path.paths[ith];
-        let instance = if affiliation_symbol.is_some() || !target.is_global_function() {
-            instance_path.get_generic_instance(target, affiliation_symbol)
-        } else if let Some(namespace_symbol) = namespace.get_symbol() {
-            if namespace_symbol.is_component(true) {
-                instance_path.get_generic_instance(target, Some(&namespace_symbol))
-            } else {
-                instance_path
-                    .get_generic_instance(target, namespace_symbol.get_parent_component().as_ref())
-            }
-        } else {
-            instance_path.get_generic_instance(target, None)
-        };
-        let Some((token, symbol)) = instance else {
+        let Some((token, symbol)) =
+            Self::create_generic_instance(instance_path, target, namespace, affiliation_symbol)
+        else {
             return;
         };
 
@@ -395,10 +394,10 @@ impl ReferenceTable {
             symbol_table::add_generic_instance(target.id, *id);
         }
 
-        let map = vec![GenericMap {
+        generic_maps.push(GenericMap {
             id: None,
             map: target.generic_table(&instance_path.arguments),
-        }];
+        });
 
         let target_namespace = &target.inner_namespace();
         let mut referecnes = target.generic_references();
@@ -408,20 +407,62 @@ impl ReferenceTable {
                 continue;
             }
 
-            path.apply_map(&map);
+            path.apply_map(generic_maps);
             path.unalias();
             path.append_namespace_path(namespace, &target.namespace);
 
-            if let Ok(target) = symbol_table::resolve((&path.generic_path(), target_namespace)) {
+            if let Ok(path_symbol) = symbol_table::resolve((&path.generic_path(), target_namespace))
+            {
                 let ith = path.len() - 1;
-                Self::insert_generic_instance(
-                    path,
-                    ith,
-                    target_namespace,
-                    &target.found,
-                    Some(&symbol),
-                );
+                if target.is_global_function() {
+                    Self::insert_generic_instance(
+                        path,
+                        ith,
+                        namespace,
+                        &path_symbol.found,
+                        &mut generic_maps.clone(),
+                        None,
+                    );
+                } else {
+                    Self::insert_generic_instance(
+                        path,
+                        ith,
+                        target_namespace,
+                        &path_symbol.found,
+                        &mut generic_maps.clone(),
+                        Some(&symbol),
+                    );
+                }
             }
+        }
+    }
+
+    fn create_generic_instance(
+        symbol: &GenericSymbol,
+        target: &Symbol,
+        namespace: &Namespace,
+        affiliation_symbol: Option<&Symbol>,
+    ) -> Option<(Token, Symbol)> {
+        if !target.is_global_function() {
+            symbol.get_generic_instance(target, affiliation_symbol)
+        } else if let Some(affiliation_symbol) = affiliation_symbol {
+            if affiliation_symbol.is_component(true) {
+                symbol.get_generic_instance(target, Some(affiliation_symbol))
+            } else {
+                symbol.get_generic_instance(
+                    target,
+                    affiliation_symbol.get_parent_component().as_ref(),
+                )
+            }
+        } else if let Some(namespace_symbol) = namespace.get_symbol() {
+            if namespace_symbol.is_component(true) {
+                symbol.get_generic_instance(target, Some(&namespace_symbol))
+            } else {
+                symbol
+                    .get_generic_instance(target, namespace_symbol.get_parent_component().as_ref())
+            }
+        } else {
+            symbol.get_generic_instance(target, None)
         }
     }
 
@@ -448,16 +489,18 @@ impl ReferenceTable {
         };
         let path = path.slice(ith);
 
+        // existing generic maps means that the target symbol has
+        // already been processed.
+        // For this case, need to insert generic instance generated from
+        // the given path explicitly.
         let generic_maps = target.generic_maps();
         for map in generic_maps {
-            // existing generic maps means that the target symbol has
-            // already been processed.
-            // For this case, need to insert generic instance generated from
-            // the given path explicitly.
             let affiliation_symbol = map.id.map(|id| symbol_table::get(id).unwrap());
             let mut path = path.clone();
             let ith = path.len() - 1;
-            path.apply_map(&[map]);
+
+            let mut maps = vec![map];
+            path.apply_map(&maps);
             path.append_namespace_path(&namespace, &symbol.namespace);
 
             Self::insert_generic_instance(
@@ -465,6 +508,7 @@ impl ReferenceTable {
                 ith,
                 &namespace,
                 symbol,
+                &mut maps,
                 affiliation_symbol.as_ref(),
             );
         }

--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -334,7 +334,11 @@ impl ReferenceTable {
 
                     for arg in args.iter_mut() {
                         arg.unalias();
-                        arg.append_namespace_path(namespace, &target_symbol.namespace);
+                        // Global function is emitted into the caller namespace.
+                        // So namespace expansion is not needed.
+                        if !target_symbol.is_global_function() {
+                            arg.append_namespace_path(namespace, &target_symbol.namespace);
+                        }
                     }
 
                     path.paths[i].arguments.append(&mut args);
@@ -373,8 +377,15 @@ impl ReferenceTable {
         let instance_path = &path.paths[ith];
         let instance = if affiliation_symbol.is_some() || !target.is_global_function() {
             instance_path.get_generic_instance(target, affiliation_symbol)
+        } else if let Some(namespace_symbol) = namespace.get_symbol() {
+            if namespace_symbol.is_component(true) {
+                instance_path.get_generic_instance(target, Some(&namespace_symbol))
+            } else {
+                instance_path
+                    .get_generic_instance(target, namespace_symbol.get_parent_component().as_ref())
+            }
         } else {
-            instance_path.get_generic_instance(target, namespace.get_symbol().as_ref())
+            instance_path.get_generic_instance(target, None)
         };
         let Some((token, symbol)) = instance else {
             return;

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -2751,6 +2751,12 @@ pub struct GenericInstanceProperty {
     pub affiliation_symbol: Option<SymbolId>,
 }
 
+impl GenericInstanceProperty {
+    pub fn base_symbol(&self) -> Symbol {
+        symbol_table::get(self.base).unwrap()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum TestType {
     Inline,

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -521,15 +521,21 @@ impl GenericSymbolPath {
         for path in &self.paths {
             full_path.push(path.base);
             if let Ok(symbol) = symbol_table::resolve(&full_path) {
-                let params = symbol.found.generic_parameters();
-
                 let mut map = GenericMap::default();
 
-                for (i, (name, value)) in params.into_iter().enumerate() {
-                    if let Some(x) = path.arguments.get(i) {
-                        map.map.insert(name, x.clone());
-                    } else if let Some(x) = value.default_value {
-                        map.map.insert(name, x);
+                if let SymbolKind::GenericInstance(inst) = &symbol.found.kind {
+                    let params = inst.base_symbol().generic_parameters();
+                    for (i, (name, _)) in params.iter().enumerate() {
+                        map.map.insert(*name, inst.arguments[i].clone());
+                    }
+                } else {
+                    let params = symbol.found.generic_parameters();
+                    for (i, (name, value)) in params.into_iter().enumerate() {
+                        if let Some(x) = path.arguments.get(i) {
+                            map.map.insert(name, x.clone());
+                        } else if let Some(x) = value.default_value {
+                            map.map.insert(name, x);
+                        }
                     }
                 }
 
@@ -670,38 +676,53 @@ impl GenericSymbolPath {
     }
 
     pub fn append_namespace_path(&mut self, namespace: &Namespace, target_namespace: &Namespace) {
-        fn is_defined_in_package(path: &GenericSymbolPath, namespace: &Namespace) -> bool {
-            if !namespace
-                .get_symbol()
-                .map(|x| x.is_package(true))
-                .unwrap_or(false)
-            {
-                // The given namespace does not point a package
+        fn is_defined_in_package(symbol: &Symbol) -> bool {
+            if matches!(symbol.kind, SymbolKind::GenericParameter(_)) {
+                // Generic parameter is not visible from other namespace
                 return false;
             }
 
-            symbol_table::resolve((&path.base_path(0), namespace))
-                .map(|symbol| {
-                    // Generic parameter is not visible from other namespace.
-                    !matches!(symbol.found.kind, SymbolKind::GenericParameter(_))
-                        && symbol.found.namespace.matched(namespace)
-                })
+            symbol
+                .namespace
+                .get_symbol()
+                .map(|x| x.is_package(true))
                 .unwrap_or(false)
         }
 
-        fn is_component_path(path: &GenericSymbolPath, namespace: &Namespace) -> bool {
-            symbol_table::resolve((&path.base_path(0), namespace))
-                .map(|x| x.found.is_component(true))
-                .unwrap_or(false)
+        fn start_with_project_name(namespace: &Namespace) -> bool {
+            namespace.depth() >= 1 && namespace_table::match_project_name(namespace.paths[0])
         }
 
-        if let Some(file_path) = self.file_path() {
-            if !namespace.matched(target_namespace) && is_defined_in_package(self, namespace) {
+        fn add_root_project_name(namespace: &Namespace) -> Namespace {
+            let mut ret = namespace.clone();
+            if !start_with_project_name(&ret) {
+                ret.paths.insert(0, namespace_table::root_project_name());
+            }
+            ret
+        }
+
+        if let Ok(head_symbol) =
+            symbol_table::resolve((&self.base_path(0), &namespace.generic_namespace()))
+            && let Some(file_path) = self.file_path()
+        {
+            let head_symbol = &head_symbol.found;
+            let head_namespace = &head_symbol.namespace;
+
+            let mut namespace = add_root_project_name(namespace);
+            if start_with_project_name(head_namespace) {
+                namespace.paths.drain(head_namespace.depth()..);
+            } else {
+                namespace.paths.drain((head_namespace.depth() + 1)..);
+            }
+
+            let target_namespace = add_root_project_name(target_namespace);
+
+            if !namespace.matched(&target_namespace) && is_defined_in_package(head_symbol) {
                 // The given path is referened from the `target_namespace`
                 // but it is not visible because it has no package paths.
                 for i in 1..namespace.depth() {
                     let token = Token::generate(namespace.paths[i], file_path);
-                    namespace_table::insert(token.id, file_path, namespace);
+                    namespace_table::insert(token.id, file_path, &namespace);
 
                     let symbol_path = GenericSymbol {
                         base: token,
@@ -711,11 +732,10 @@ impl GenericSymbolPath {
                 }
             }
 
-            if namespace.paths[0] != target_namespace.paths[0] && is_component_path(self, namespace)
-            {
+            if namespace.paths[0] != target_namespace.paths[0] && head_symbol.is_component(true) {
                 // Append the project prefix to the path.
                 let token = Token::generate(namespace.paths[0], file_path);
-                namespace_table::insert(token.id, file_path, namespace);
+                namespace_table::insert(token.id, file_path, &namespace);
 
                 let symbol_path = GenericSymbol {
                     base: token,

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -203,9 +203,9 @@ impl TypeDag {
                 if !base_symbol.namespace.included(&parent_symbol.namespace) {
                     let (parent_symbol, parent_context) =
                         if let Some(symbol) = parent_symbol.get_parent_component() {
-                            let context = if parent_symbol.is_module(true) {
+                            let context = if symbol.is_module(true) {
                                 Context::Module
-                            } else if parent_symbol.is_interface(true) {
+                            } else if symbol.is_interface(true) {
                                 Context::Interface
                             } else {
                                 Context::Package

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -2227,12 +2227,21 @@ impl Emitter {
             .filter(|x| {
                 if let Some(id) = x.id {
                     let symbol = symbol_table::get(id).unwrap();
-                    if let SymbolKind::GenericInstance(x) = &symbol.kind
-                        && let Some(affiliation_symbol) = x.affiliation_symbol
+                    let SymbolKind::GenericInstance(inst) = &symbol.kind else {
+                        unreachable!();
+                    };
+
+                    let affiliation_symbol = inst.affiliation_symbol.unwrap();
+                    if affiliation_symbol == parent_id {
+                        true
+                    } else if let Some(parent_symbol) = symbol_table::get(parent_id)
+                        && let SymbolKind::GenericInstance(inst) = parent_symbol.kind
                     {
-                        affiliation_symbol == parent_id
+                        // The generic map is associated with generic component.
+                        // This means that it is also associated with generic instances generated from the component.
+                        inst.base_symbol().id == affiliation_symbol
                     } else {
-                        unreachable!()
+                        false
                     }
                 } else {
                     true
@@ -6238,7 +6247,9 @@ pub fn resolve_generic_path(
                     arg.apply_map(maps);
                 }
                 arg.unalias();
-                arg.append_namespace_path(namespace, &symbol.namespace);
+                if !symbol.is_global_function() {
+                    arg.append_namespace_path(namespace, &symbol.namespace);
+                }
             }
         }
     }

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1892,7 +1892,7 @@ impl Emitter {
 
         let mut emitted_functions = Vec::new();
         for path in &func_paths {
-            self.emit_global_function(path, &mut emitted_functions);
+            self.emit_global_function(path, component_symbol, &mut emitted_functions);
         }
 
         self.bound_namespace = None;
@@ -1902,6 +1902,7 @@ impl Emitter {
     fn emit_global_function(
         &mut self,
         path: &GenericSymbolPath,
+        component_symbol: &Symbol,
         emitted_functions: &mut Vec<SymbolId>,
     ) {
         let (Ok(func_symbol), _) = self.resolve_generic_path(path, None) else {
@@ -1929,11 +1930,13 @@ impl Emitter {
                 if let Some(base_symbol) = symbol_table::get(x.base)
                     && let SymbolKind::Function(base_func) = &base_symbol.kind
                 {
-                    (
-                        base_symbol.id,
-                        base_func.definition,
-                        func_symbol.found.generic_maps(),
-                    )
+                    let mut maps = func_symbol.found.generic_maps();
+                    for map in &mut maps {
+                        // Generic instance of global functoin belongs to
+                        // component where it is emitted into.
+                        map.id = Some(component_symbol.id);
+                    }
+                    (base_symbol.id, base_func.definition, maps)
                 } else {
                     return;
                 }
@@ -1944,7 +1947,7 @@ impl Emitter {
         if let Some(func_paths) = &symbol_table::get_reference_functions(func_id) {
             self.generic_map.push(generic_map);
             for func_path in func_paths {
-                self.emit_global_function(func_path, emitted_functions);
+                self.emit_global_function(func_path, component_symbol, emitted_functions);
             }
             self.generic_map.pop();
         }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2937,6 +2937,46 @@ endmodule
 
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
+
+    let code = r#"
+function func_a::<A: u32> -> u32 {
+    return A;
+}
+package Pkg::<A: u32> {
+    const B: u32 = A;
+    function func_b() -> u32 {
+        return func_a::<B>();
+    }
+}
+module ModuleA {
+    let _a: u32 = Pkg::<1>::func_b();
+}
+"#;
+
+    let expect = r#"
+
+package prj___Pkg__1;
+    localparam int unsigned B = 1;
+    function automatic int unsigned func_b() ;
+        return __func_a__B();
+    endfunction
+
+    function automatic int unsigned __func_a__B;
+        return B;
+    endfunction
+endpackage
+module prj_ModuleA;
+    int unsigned _a; always_comb _a = prj___Pkg__1::func_b();
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = emit(&metadata, code);
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
 }
 
 #[test]

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2977,6 +2977,44 @@ endmodule
 
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
+
+    let code = r#"
+function func_a::<A: u32> -> u32 {
+    return A;
+}
+package Pkg::<A: u32> {
+    function func_b::<B: u32>() -> u32 {
+        return func_a::<A>() + B;
+    }
+}
+module ModuleA {
+    let _a: u32 = Pkg::<1>::func_b::<2>();
+}
+"#;
+
+    let expect = r#"
+
+package prj___Pkg__1;
+    function automatic int unsigned __func_b__2() ;
+        return __func_a__1() + 2;
+    endfunction
+
+    function automatic int unsigned __func_a__1;
+        return 1;
+    endfunction
+endpackage
+module prj_ModuleA;
+    int unsigned _a; always_comb _a = prj___Pkg__1::__func_b__2();
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = emit(&metadata, code);
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2521
fix veryl-lang/veryl#2520

For the issue #2521,  when evaluating `Pkg::<1>::func_b()`, `func_a::<B>` is called, which builds the  generic map `{A: B}`.
While evaluating the body of `func_a`, resolving A yields B, and then the value of B (defined as B = A) needs to be resolved.
At this point, the correct generic map to use is the one from `Pkg::<1>` (`{A: 1}`), but since func_a's map ({A: B}) sits at the top of the stack, A is substituted with B again, causing infinite recursion.

When `B` is passed as an argument in `func_a::<B>`, prefix its path with the caller's package instance namespace (`Pkg::<1>::`).
This ensures that when A => B is resolved during the body evaluation of `func_a`, the subsequent lookup of B directly references the GenericInstance `Pkg::<1>`, where B is correctly resolved to 1 under the map `{A: 1}`.

For the issue #2520, when resolving `func_a::<A>`, generic map of `Pkg::<1>` is required but it is not propagated.
Due to this, correct generic instance of `func_a::<A>` is not created.
To fix this situation, generic maps should be accumulated when resolving nested generic instances.