### PR TITLE
Add function calculating leading zero count

### DIFF
--- a/crates/std/veryl/src/lzc/lzc_common_pkg.veryl
+++ b/crates/std/veryl/src/lzc/lzc_common_pkg.veryl
@@ -1,0 +1,95 @@
+pub package lzc_common_pkg {
+    struct result::<N: p32> {
+        all_zero: logic           ,
+        count   : logic<$clog2(N)>,
+    }
+
+    function lzc4 (
+        bits: input logic<4>,
+    ) -> result::<4> {
+        var ret         : result::<4>;
+        ret.all_zero = bits == '0;
+        ret.count[1] = bits[1:0] == '0;
+        ret.count[0] = !(bits[0] || ((!bits[1]) && bits[2]));
+        return ret;
+    }
+
+    function lzc8 (
+        bits: input logic<8>,
+    ) -> result::<8> {
+        var ret4: result::<4> [2];
+        var ret : result::<8>    ;
+
+        ret4[0] = lzc4(bits[0 step 4]);
+        ret4[1] = lzc4(bits[1 step 4]);
+
+        ret.all_zero = ret4[0].all_zero && ret4[1].all_zero;
+        if !ret4[0].all_zero {
+            ret.count = {1'b0, ret4[0].count};
+        } else {
+            ret.count = {1'b1, ret4[1].count};
+        }
+
+        return ret;
+    }
+
+    function lzc16 (
+        bits: input logic<16>,
+    ) -> result::<16> {
+        var ret4       : result::<4>     [4];
+        var any_one    : logic       <4>    ;
+        var ret_any_one: result::<4>        ;
+        var ret        : result::<16>       ;
+
+        for i: u32 in 0..4 {
+            ret4[i]    = lzc4(bits[i step 4]);
+            any_one[i] = !ret4[i].all_zero;
+        }
+        ret_any_one = lzc4(any_one);
+
+        ret.all_zero = ret_any_one.all_zero;
+        ret.count    = {ret_any_one.count, ret4[ret_any_one.count].count};
+
+        return ret;
+    }
+
+    function lzc32 (
+        bits: input logic<32>,
+    ) -> result::<32> {
+        var ret8       : result::<8>     [4];
+        var any_one    : logic       <4>    ;
+        var ret_any_one: result::<4>        ;
+        var ret        : result::<32>       ;
+
+        for i: u32 in 0..4 {
+            ret8[i]    = lzc8(bits[i step 8]);
+            any_one[i] = !ret8[i].all_zero;
+        }
+        ret_any_one = lzc4(any_one);
+
+        ret.all_zero = ret_any_one.all_zero;
+        ret.count    = {ret_any_one.count, ret8[ret_any_one.count].count};
+
+        return ret;
+    }
+
+    function lzc64 (
+        bits: input logic<64>,
+    ) -> result::<64> {
+        var ret8       : result::<8>     [8];
+        var any_one    : logic       <8>    ;
+        var ret_any_one: result::<8>        ;
+        var ret        : result::<64>       ;
+
+        for i: u32 in 0..8 {
+            ret8[i]    = lzc8(bits[i step 8]);
+            any_one[i] = !ret8[i].all_zero;
+        }
+        ret_any_one = lzc8(any_one);
+
+        ret.all_zero = ret_any_one.all_zero;
+        ret.count    = {ret_any_one.count, ret8[ret_any_one.count].count};
+
+        return ret;
+    }
+}

--- a/crates/std/veryl/src/lzc/lzc_pkg.veryl
+++ b/crates/std/veryl/src/lzc/lzc_pkg.veryl
@@ -1,0 +1,68 @@
+pub package lzc_pkg::<N: p32> {
+    const COUNT_WIDTH      : p32 = if N >= 2 ? $clog2(N) : 1;
+    const COUNT_UPPER_WIDTH: p32 = if N >: 64 ? COUNT_WIDTH - 6 : 1;
+    const N_SPLITS         : p32 = if N >: 64 ? (N + 63) / 64 : 2; // 2 is to prevent verilator warning
+
+    type lzc_result = lzc_common_pkg::result::<N>             ;
+    type lzc_count  = logic                      <COUNT_WIDTH>;
+
+    function lzc (
+        bits    : input logic<N>,
+        from_msb: input logic   ,
+    ) -> lzc_result {
+        var input_bits: logic     <N>;
+        var ret       : lzc_result   ;
+
+        if from_msb {
+            input_bits = bit_reverse::<N>(bits);
+        } else {
+            input_bits = bits;
+        }
+
+        if N <= 4 {
+            var ret4        : lzc_common_pkg::result::<4>;
+            ret4         = lzc_common_pkg::lzc4(input_bits as 4);
+            ret.all_zero = ret4.all_zero;
+            ret.count    = ret4.count as COUNT_WIDTH;
+        } else if N <= 8 {
+            var ret8        : lzc_common_pkg::result::<8>;
+            ret8         = lzc_common_pkg::lzc8(input_bits as 8);
+            ret.all_zero = ret8.all_zero;
+            ret.count    = ret8.count;
+        } else if N <= 16 {
+            var ret16       : lzc_common_pkg::result::<16>;
+            ret16        = lzc_common_pkg::lzc16(input_bits as 16);
+            ret.all_zero = ret16.all_zero;
+            ret.count    = ret16.count;
+        } else if N <= 32 {
+            var ret32       : lzc_common_pkg::result::<32>;
+            ret32        = lzc_common_pkg::lzc32(input_bits as 32);
+            ret.all_zero = ret32.all_zero;
+            ret.count    = ret32.count;
+        } else if N <= 64 {
+            var ret64       : lzc_common_pkg::result::<64>;
+            ret64        = lzc_common_pkg::lzc64(input_bits as 64);
+            ret.all_zero = ret64.all_zero;
+            ret.count    = ret64.count;
+        } else {
+            var count   : lzc_count<N_SPLITS>;
+            var all_zero: logic    <N_SPLITS>;
+
+            for i: u32                              in 0..N_SPLITS {
+                var bits64: logic                       <64>;
+                var ret64 : lzc_common_pkg::result::<64>    ;
+
+                bits64 = (input_bits >> (64 * i)) as 64;
+                ret64  = lzc_common_pkg::lzc64(bits64);
+
+                count[i]    = {i as COUNT_UPPER_WIDTH, ret64.count};
+                all_zero[i] = ret64.all_zero;
+            }
+
+            ret.all_zero = all_zero == '1;
+            ret.count    = select_vector::<N_SPLITS, lzc_count>(~all_zero, count);
+        }
+
+        return ret;
+    }
+}

--- a/crates/std/veryl/src/lzc/test_lzc.veryl
+++ b/crates/std/veryl/src/lzc/test_lzc.veryl
@@ -1,0 +1,167 @@
+#[test(test_lzc_4)]
+module test_lzc_4 {
+    import lzc_pkg::<4>::*;
+
+    var bits  : logic     <4>;
+    var result: lzc_result   ;
+
+    initial {
+        bits    = '0;
+        result  = lzc(bits, true);
+        $assert(result.all_zero);
+
+        for i: i32      in 0..4 {
+            var exp: logic<2>;
+
+            bits    = '0;
+            bits[i] = '1;
+            result  = lzc(bits, true);
+
+            exp     = 3 - i;
+            $assert(!result.all_zero);
+            $assert(result.count == exp);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_lzc_8)]
+module test_lzc_8 {
+    import lzc_pkg::<8>::*;
+
+    var bits  : logic     <8>;
+    var result: lzc_result   ;
+
+    initial {
+        bits    = '0;
+        result  = lzc(bits, true);
+        $assert(result.all_zero);
+
+        for i: i32      in 0..8 {
+            var exp: logic<3>;
+
+            bits    = '0;
+            bits[i] = '1;
+            result  = lzc(bits, true);
+
+            exp     = 7 - i;
+            $assert(!result.all_zero);
+            $assert(result.count == exp);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_lzc_16)]
+module test_lzc_16 {
+    import lzc_pkg::<16>::*;
+
+    var bits  : logic     <16>;
+    var result: lzc_result    ;
+
+    initial {
+        bits    = '0;
+        result  = lzc(bits, true);
+        $assert(result.all_zero);
+
+        for i: i32      in 0..16 {
+            var exp: logic<4>;
+
+            bits    = '0;
+            bits[i] = '1;
+            result  = lzc(bits, true);
+
+            exp     = 15 - i;
+            $assert(!result.all_zero);
+            $assert(result.count == exp);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_lzc_32)]
+module test_lzc_32 {
+    import lzc_pkg::<32>::*;
+
+    var bits  : logic     <32>;
+    var result: lzc_result    ;
+
+    initial {
+        bits    = '0;
+        result  = lzc(bits, true);
+        $assert(result.all_zero);
+
+        for i: i32      in 0..32 {
+            var exp: logic<5>;
+
+            bits    = '0;
+            bits[i] = '1;
+            result  = lzc(bits, true);
+
+            exp     = 31 - i;
+            $assert(!result.all_zero);
+            $assert(result.count == exp);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_lzc_64)]
+module test_lzc_64 {
+    import lzc_pkg::<64>::*;
+
+    var bits  : logic     <64>;
+    var result: lzc_result    ;
+
+    initial {
+        bits    = '0;
+        result  = lzc(bits, true);
+        $assert(result.all_zero);
+
+        for i: i32      in 0..64 {
+            var exp: logic<6>;
+
+            bits    = '0;
+            bits[i] = '1;
+            result  = lzc(bits, true);
+
+            exp     = 63 - i;
+            $assert(!result.all_zero);
+            $assert(result.count == exp);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_lzc_128)]
+module test_lzc_128 {
+    import lzc_pkg::<128>::*;
+
+    var bits  : logic     <128>;
+    var result: lzc_result     ;
+
+    initial {
+        bits    = '0;
+        result  = lzc(bits, true);
+        $assert(result.all_zero);
+
+        for i: i32      in 0..128 {
+            var exp: logic<7>;
+
+            bits    = '0;
+            bits[i] = '1;
+            result  = lzc(bits, true);
+
+            exp     = 127 - i;
+            $assert(!result.all_zero);
+            $assert(result.count == exp);
+        }
+
+        $finish();
+    }
+}

--- a/crates/std/veryl/src/utility_functions/reverse.veryl
+++ b/crates/std/veryl/src/utility_functions/reverse.veryl
@@ -1,0 +1,11 @@
+pub function bit_reverse::<N: p32> (
+    bits: input logic<N>,
+) -> logic<N> {
+    var ret: logic<N>;
+
+    for i: u32 in 0..N {
+        ret[i] = bits[N - i - 1];
+    }
+
+    return ret;
+}


### PR DESCRIPTION
This PR adds a function calculating leading zero count as `std` library.
Implementation is based on the paper below.
https://zenodo.org/records/14810176

For now, test `test_lzc_128` is commented out because simulator panics whem simulating this test case.

```console
thread '<unnamed>' (57563) panicked at /home/taichi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cranelift-codegen-0.130.1/src/isa/x64/lower/isle.rs:76:5:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' (57554) panicked at crates/veryl/src/cmd_test.rs:238:54:
called `Result::unwrap()` on an `Err` value: Any { .. }
```