### PR TITLE
Refactor analyzer IR

### DIFF
--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -1324,14 +1324,9 @@ impl Conv<&InstDeclaration> for ir::Declaration {
                                 Comptime::from_type(dst_type.clone(), *clock_domain, token);
 
                             for (path, dst, mut expr) in connects {
-                                let mut variables = vec![];
                                 if let Some(id) = component.ports.get(&path)
                                     && let Some(variable) = component.variables.get(id)
                                 {
-                                    variables.push(variable);
-                                }
-
-                                if !variables.is_empty() {
                                     let expr_comptime = expr.eval_comptime(context, None);
 
                                     if let Some(x) =
@@ -1347,7 +1342,7 @@ impl Conv<&InstDeclaration> for ir::Declaration {
 
                                     insert_port_connect(
                                         context,
-                                        &variables,
+                                        variable,
                                         dst,
                                         expr,
                                         &mut inputs,

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -2447,24 +2447,28 @@ pub fn get_port_connects(
 
 pub fn insert_port_connect(
     context: &mut Context,
-    variable: &[&ir::Variable],
+    variable: &ir::Variable,
     dst: Vec<VarPathSelect>,
     expr: ir::Expression,
     inputs: &mut Vec<ir::InstInput>,
     outputs: &mut Vec<ir::InstOutput>,
 ) {
-    match variable[0].kind {
+    match variable.kind {
         VarKind::Input => {
-            let id = variable.iter().map(|x| x.id).collect();
-            inputs.push(ir::InstInput { id, expr });
+            inputs.push(ir::InstInput {
+                id: variable.id,
+                expr,
+            });
         }
         VarKind::Output => {
             if !expr.is_assignable() {
                 context.insert_error(AnalyzerError::unassignable_output(&expr.token_range()));
             }
-            let id = variable.iter().map(|x| x.id).collect();
             let dst = var_path_to_assign_destination(context, dst, false);
-            outputs.push(ir::InstOutput { id, dst });
+            outputs.push(ir::InstOutput {
+                id: variable.id,
+                dst,
+            });
         }
         _ => (),
     }

--- a/crates/analyzer/src/ir/declaration.rs
+++ b/crates/analyzer/src/ir/declaration.rs
@@ -184,51 +184,25 @@ impl fmt::Display for FfDeclaration {
 
 #[derive(Clone)]
 pub struct InstInput {
-    pub id: Vec<VarId>,
+    pub id: VarId,
     pub expr: Expression,
 }
 
 impl fmt::Display for InstInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut ret = String::new();
-
-        if self.id.len() == 1 {
-            ret.push_str(&format!("{}", self.id[0]));
-        } else if !self.id.is_empty() {
-            ret.push_str(&format!("{{{}", self.id[0]));
-            for x in &self.id[1..] {
-                ret.push_str(&format!(", {}", x));
-            }
-            ret.push('}');
-        }
-
-        ret.push_str(&format!(" <- {}", self.expr));
-
-        ret.fmt(f)
+        write!(f, "{} <- {}", self.id, self.expr)
     }
 }
 
 #[derive(Clone)]
 pub struct InstOutput {
-    pub id: Vec<VarId>,
+    pub id: VarId,
     pub dst: Vec<AssignDestination>,
 }
 
 impl fmt::Display for InstOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut ret = String::new();
-
-        if self.id.len() == 1 {
-            ret.push_str(&format!("{}", self.id[0]));
-        } else {
-            ret.push_str(&format!("{{{}", self.id[0]));
-            for x in &self.id[1..] {
-                ret.push_str(&format!(", {}", x));
-            }
-            ret.push('}');
-        }
-
-        ret.push_str(" -> ");
+        let mut ret = format!("{} -> ", self.id);
 
         if self.dst.len() == 1 {
             ret.push_str(&format!("{}", self.dst[0]));

--- a/crates/simulator/src/ir/declaration.rs
+++ b/crates/simulator/src/ir/declaration.rs
@@ -641,12 +641,10 @@ impl Conv<&air::InstDeclaration> for ProtoDeclaration {
                     // read by port connections after the merged function returns
                     let mut external_reads = HashSet::default();
                     for output in &src.outputs {
-                        for child_var_id in &output.id {
-                            if let Some(child_meta) = child_variable_meta.get(child_var_id) {
-                                let element = &child_meta.elements[0];
-                                if !element.is_ff() {
-                                    external_reads.insert(element.current_offset());
-                                }
+                        if let Some(child_meta) = child_variable_meta.get(&output.id) {
+                            let element = &child_meta.elements[0];
+                            if !element.is_ff() {
+                                external_reads.insert(element.current_offset());
                             }
                         }
                     }
@@ -887,59 +885,57 @@ impl Conv<&air::InstDeclaration> for ProtoDeclaration {
 
         // Input ports: parent expr → child port var
         for input in &src.inputs {
-            for child_var_id in &input.id {
-                let child_meta = child_variable_meta.get(child_var_id).unwrap();
+            let child_meta = child_variable_meta.get(&input.id).unwrap();
 
-                // Array port with a simple variable expression: expand per-element
-                if child_meta.elements.len() > 1
-                    && let air::Expression::Term(factor) = &input.expr
-                    && let air::Factor::Variable(parent_id, index, select, _) = factor.as_ref()
-                    && index.0.is_empty()
-                    && select.is_empty()
-                {
-                    let parent_scope = context.scope();
-                    let parent_meta = parent_scope.variable_meta.get(parent_id).unwrap();
-                    for i in 0..child_meta.elements.len() {
-                        let child_element = &child_meta.elements[i];
-                        let parent_element = &parent_meta.elements[i];
-                        let parent_expr = ProtoExpression::Variable {
-                            var_offset: parent_element.current,
-                            select: None,
-                            dynamic_select: None,
+            // Array port with a simple variable expression: expand per-element
+            if child_meta.elements.len() > 1
+                && let air::Expression::Term(factor) = &input.expr
+                && let air::Factor::Variable(parent_id, index, select, _) = factor.as_ref()
+                && index.0.is_empty()
+                && select.is_empty()
+            {
+                let parent_scope = context.scope();
+                let parent_meta = parent_scope.variable_meta.get(parent_id).unwrap();
+                for i in 0..child_meta.elements.len() {
+                    let child_element = &child_meta.elements[i];
+                    let parent_element = &parent_meta.elements[i];
+                    let parent_expr = ProtoExpression::Variable {
+                        var_offset: parent_element.current,
+                        select: None,
+                        dynamic_select: None,
+                        width: child_meta.width,
+                        var_full_width: child_meta.width,
+                        expr_context: ExpressionContext {
                             width: child_meta.width,
-                            var_full_width: child_meta.width,
-                            expr_context: ExpressionContext {
-                                width: child_meta.width,
-                                signed: false,
-                            },
-                        };
-                        all_comb_statements.push(ProtoStatement::Assign(ProtoAssignStatement {
-                            dst: child_element.current,
-                            dst_width: child_meta.width,
-                            select: None,
-                            dynamic_select: None,
-                            rhs_select: None,
-                            expr: parent_expr,
-                            dst_ff_current_offset: 0, // not FF
-                            token: TokenRange::default(),
-                        }));
-                    }
-                    continue;
+                            signed: false,
+                        },
+                    };
+                    all_comb_statements.push(ProtoStatement::Assign(ProtoAssignStatement {
+                        dst: child_element.current,
+                        dst_width: child_meta.width,
+                        select: None,
+                        dynamic_select: None,
+                        rhs_select: None,
+                        expr: parent_expr,
+                        dst_ff_current_offset: 0, // not FF
+                        token: TokenRange::default(),
+                    }));
                 }
-
-                let proto_expr: ProtoExpression = Conv::conv(context, &input.expr)?;
-                let element = &child_meta.elements[0];
-                all_comb_statements.push(ProtoStatement::Assign(ProtoAssignStatement {
-                    dst: element.current,
-                    dst_width: child_meta.width,
-                    select: None,
-                    dynamic_select: None,
-                    rhs_select: None,
-                    expr: proto_expr.clone(),
-                    dst_ff_current_offset: 0, // not FF
-                    token: TokenRange::default(),
-                }));
+                continue;
             }
+
+            let proto_expr: ProtoExpression = Conv::conv(context, &input.expr)?;
+            let element = &child_meta.elements[0];
+            all_comb_statements.push(ProtoStatement::Assign(ProtoAssignStatement {
+                dst: element.current,
+                dst_width: child_meta.width,
+                select: None,
+                dynamic_select: None,
+                rhs_select: None,
+                expr: proto_expr.clone(),
+                dst_ff_current_offset: 0, // not FF
+                token: TokenRange::default(),
+            }));
         }
 
         // Output ports: child port var → parent dst
@@ -949,8 +945,8 @@ impl Conv<&air::InstDeclaration> for ProtoDeclaration {
         let needs_post_comb_propagation =
             full_internal_comb.is_some() || !all_post_comb_fns.is_empty();
         for output in &src.outputs {
-            for (child_var_id, parent_dst) in output.id.iter().zip(output.dst.iter()) {
-                let child_meta = child_variable_meta.get(child_var_id).unwrap();
+            if let Some(parent_dst) = output.dst.first() {
+                let child_meta = child_variable_meta.get(&output.id).unwrap();
 
                 let (
                     parent_index,
@@ -1073,9 +1069,7 @@ impl Conv<&air::InstDeclaration> for ProtoDeclaration {
             if let air::Expression::Term(factor) = &input.expr
                 && let air::Factor::Variable(parent_var_id, _, _, _) = factor.as_ref()
             {
-                for child_var_id in &input.id {
-                    child_to_parent_var.insert(*child_var_id, *parent_var_id);
-                }
+                child_to_parent_var.insert(input.id, *parent_var_id);
             }
         }
 


### PR DESCRIPTION
`id` field of `InstInput` / `InstOutput` is `Vec`, but it always has only one item.
At the initial phase of implementing analyzer IR, struct was expanded to multiple `VarId`s, but finally it is not necessary because struct has a single `VarId`.