### PR TITLE
Fix symbol path resolution including generic const

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1801,8 +1801,15 @@ pub fn eval_factor_symbol(
                     | ProtoBound::Struct((_, t))
                     | ProtoBound::Union((_, t)) => {
                         let r#type = t.to_ir_type(context, TypePosition::Generic)?;
-                        let (mut comptime, _) = eval_generic_expr(context, &x.value)?;
-                        comptime.r#type = r#type;
+
+                        let mut comptime = if context.in_generic {
+                            // RHS value of generic const may not be evaluated in generic component
+                            Comptime::from_type(r#type.clone(), ClockDomain::None, token)
+                        } else {
+                            let (mut comptime, _) = eval_generic_expr(context, &x.value)?;
+                            comptime.r#type = r#type;
+                            comptime
+                        };
                         comptime.is_const = true;
                         comptime.is_global = true;
                         comptime.token = token;

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -145,9 +145,14 @@ impl Signature {
 
     pub fn to_generic_map(&self) -> Vec<GenericMap> {
         let mut ret = GenericMap::default();
+
         for (key, val) in &self.generic_parameters {
             ret.map.insert(*key, val.clone());
         }
+
+        let symbol = symbol_table::get(self.symbol).unwrap();
+        symbol.eval_generic_consts(&mut ret);
+
         vec![ret]
     }
 

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -2043,6 +2043,43 @@ module ModuleB {
 "#;
 
     check_ir(code, exp);
+
+    let code = r#"
+    package PkgA::<W: u32> {
+        type T = logic<W>;
+    }
+    module ModuleB::<W: u32> {
+        gen WW: u32 = 2 * W;
+        let _a: PkgA::<WW>::T = '0;
+    }
+    module ModuleC {
+        inst u: ModuleB::<1>;
+    }
+    "#;
+
+    let exp = r#"module ModuleB {
+
+
+  comb {
+    var0 = '0;
+  }
+}
+module ModuleC {
+
+  inst u (
+  ) {
+    module ModuleB {
+      let var0(_a): logic<2> = 2'hx;
+
+      comb {
+        var0 = '0;
+      }
+    }
+  }
+}
+"#;
+
+    check_ir(code, exp);
 }
 
 #[test]

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -380,22 +380,22 @@ impl Symbol {
                 .insert(param.0, param.1.default_value.as_ref().unwrap().clone());
         }
 
-        let consts = self.generic_consts();
-        if !consts.is_empty() {
-            for (name, r#const) in &consts {
-                let maps = vec![map.clone()];
-                if let Some(path) = Self::expr_to_generic_symbol_path(&r#const.value, &maps) {
-                    map.map.insert(*name, path);
-                }
-            }
-        }
+        self.eval_generic_consts(&mut map);
 
         map.map
     }
 
+    pub fn eval_generic_consts(&self, generic_map: &mut GenericMap) {
+        for (name, r#const) in self.generic_consts() {
+            if let Some(path) = Self::expr_to_generic_symbol_path(&r#const.value, generic_map) {
+                generic_map.map.insert(name, path);
+            }
+        }
+    }
+
     fn expr_to_generic_symbol_path(
         expr: &syntax_tree::Expression,
-        maps: &[GenericMap],
+        generic_map: &GenericMap,
     ) -> Option<GenericSymbolPath> {
         fn eval_value(
             context: &mut Context,
@@ -419,17 +419,20 @@ impl Symbol {
                     if x.identifier_factor.identifier_factor_opt.is_none() =>
                 {
                     let mut context = Context::default();
-                    context.push_generic_map(maps.to_vec());
+                    context.push_generic_map(vec![generic_map.clone()]);
 
                     let path = context
                         .resolve_path(x.identifier_factor.expression_identifier.as_ref().into());
                     return Some(path);
                 }
                 syntax_tree::Factor::LParenExpressionRParen(x) => {
-                    return Self::expr_to_generic_symbol_path(&x.expression, maps);
+                    return Self::expr_to_generic_symbol_path(&x.expression, generic_map);
                 }
                 syntax_tree::Factor::TypeExpression(x) => {
-                    return Self::expr_to_generic_symbol_path(&x.type_expression.expression, maps);
+                    return Self::expr_to_generic_symbol_path(
+                        &x.type_expression.expression,
+                        generic_map,
+                    );
                 }
                 syntax_tree::Factor::FactorTypeFactor(x) => {
                     match x.factor_type_factor.factor_type.factor_type_group.as_ref() {
@@ -440,7 +443,7 @@ impl Symbol {
                             let mut width = Vec::new();
                             if let Some(x) = &x.factor_type_opt {
                                 let mut context = Context::default();
-                                context.push_generic_map(maps.to_vec());
+                                context.push_generic_map(vec![generic_map.clone()]);
 
                                 for expr in Vec::from(x.width.as_ref()) {
                                     if let Some((x, _)) = eval_value(&mut context, expr)
@@ -463,7 +466,7 @@ impl Symbol {
         };
 
         let mut context = Context::default();
-        context.push_generic_map(maps.to_vec());
+        context.push_generic_map(vec![generic_map.clone()]);
         if let Some((value, token)) = eval_value(&mut context, expr)
             && !value.is_xz()
         {

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -338,7 +338,10 @@ impl GenericSymbol {
                 }
                 let head = &arg.paths[0];
                 if let Ok(symbol) = symbol_table::resolve(&head.base)
-                    && matches!(symbol.found.kind, SymbolKind::GenericParameter(_))
+                    && matches!(
+                        symbol.found.kind,
+                        SymbolKind::GenericParameter(_) | SymbolKind::GenericConst(_)
+                    )
                 {
                     return self.base();
                 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5484,6 +5484,22 @@ fn undefined_identifier() {
     //    errors[0],
     //    AnalyzerError::UndefinedIdentifier { .. }
     //));
+
+    let code = r#"
+    package PkgA::<W: u32> {
+        type T = logic<W>;
+    }
+    module ModuleB::<W: u32> {
+        gen WW: u32 = 2 * W;
+        let _a: PkgA::<WW>::T = '0;
+    }
+    module ModuleC {
+        inst u: ModuleB::<1>;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2542

For the issue shown in #2542, in `GenericSymbol::mangled`, generic consts should be treated same as generic params but not.
Namespace `PkgA::<WW>` is used when resolving `T` in `reference_table` but generic isntance `Pkg::<WW>` has not been inserted so resolving `T` is failed.

After fixing the issue, stack overflow is happened when converting `let _a: PkgA::<WW>::T = '0;` to IR.
When processing `ModuleB` itself, `WW` can't be evaluated becuase generic param `W` has not been applied and then `WW` is propagated into `PkgA` via generic param `W`.
Generic param `W` of `PkgA` is replaced with `WW` and then RHS value of `WW` is being evaluated. However it has reference to `W` and it is repalced with `Ww`.
This results in an infinite loop.

RHS value of generic const in generic component should not be evaluated to eliminate such infinite loop.