### PR TITLE
Implement IR conversion for proto function

### DIFF
--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -24,7 +24,9 @@ use crate::ir::{
     ValueVariant, VarId, VarIndex, VarKind, VarPath, VarPathSelect, VarSelect, Variable,
 };
 use crate::namespace::DefineContext;
-use crate::symbol::{ClockDomain, Direction, GenericBoundKind, SymbolKind, TbComponentKind};
+use crate::symbol::{
+    ClockDomain, Direction, GenericBoundKind, Symbol, SymbolKind, TbComponentKind,
+};
 use crate::symbol_path::{GenericSymbolPath, SymbolPathNamespace};
 use crate::symbol_table;
 use crate::value::Value;
@@ -931,170 +933,21 @@ impl Conv<(&FunctionDeclaration, Option<&FuncPath>)> for () {
         }
 
         if let Ok(symbol) = symbol_table::resolve(func_def.identifier.as_ref())
-            && let SymbolKind::Function(x) = &symbol.found.kind
+            && let SymbolKind::Function(_) = &symbol.found.kind
         {
-            let is_const = x.constantable.unwrap();
-            let ret_type = if let Some(x) = &x.ret {
-                let mut r#type = x.to_ir_type(context, TypePosition::Variable)?;
-                if r#type.is_struct() {
-                    r#type.set_concrete_width(Shape::new(vec![r#type.total_width()]));
-                    r#type.kind = if r#type.is_2state() {
-                        TypeKind::Bit
-                    } else {
-                        TypeKind::Logic
-                    };
-                }
-                Comptime::from_type(r#type, ClockDomain::None, token)
-            } else {
-                let r#type = ir::Type::new(TypeKind::Void);
-                Comptime::from_type(r#type, ClockDomain::None, token)
-            };
-
-            // insert VarPath for function before statement_block conv
-            // because it may be refered by recursive function
-            let (path, name, namespace) = if let Some(path) = path {
-                let name = resource_table::insert_str(&path.sig.to_string());
-                (path.clone(), name, path.sig.namespace())
-            } else {
-                let name = func_def.identifier.text();
-                let path = FuncPath::new(symbol.found.id);
-                (path, name, symbol.found.inner_namespace())
-            };
-
-            if context.func_paths.contains_key(&path) {
-                // The given function has already been added through function reference before definition.
-                return Ok(());
-            }
-
-            let token: TokenRange = symbol.found.token.into();
-            let id = context.insert_func_path(path.clone());
-
-            context.push_affiliation(Affiliation::Function);
-            context.push_hierarchy(name);
-            context.push_namespace(namespace);
-
-            let arg_items: Vec<_> = if let Some(x) = &func_def.function_declaration_opt0
-                && let Some(x) = &x.port_declaration.port_declaration_opt
-            {
-                x.port_declaration_list.as_ref().into()
-            } else {
-                vec![]
-            };
-            let arity = arg_items.len();
-            let mut arg_map = HashMap::default();
-            let mut args = vec![];
-
-            let body = context.block(|c| {
-                // insert return value as variable
-                let ret_id = if ret_type.r#type.kind != TypeKind::Void {
-                    let path = VarPath::new(get_return_str());
-                    let kind = VarKind::Variable;
-                    let r#type = ret_type.r#type.clone();
-
-                    if let Some(_total_array) = r#type.total_array()
-                        && let Some(total_width) = r#type.total_width()
-                    {
-                        // type.expand is not necessary
-                        // because member access is not allowed for return value
-                        // All elements are initialized to the same x-state
-                        // value, so a single template suffices.
-                        let values = vec![Value::new_x(total_width, false)];
-
-                        let ret_id = c.insert_var_path(path.clone(), ret_type.clone());
-                        let array_limit = c.config.evaluate_array_limit;
-                        let variable = Variable::new(
-                            ret_id,
-                            path,
-                            kind,
-                            r#type,
-                            values,
-                            c.get_affiliation(),
-                            &token,
-                            array_limit,
-                        );
-                        c.insert_variable(ret_id, variable);
-                        Some(ret_id)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                for item in arg_items {
-                    let _: IrResult<()> = Conv::conv(c, item);
-
-                    let name = item.identifier.text();
-                    let path = VarPath::new(name);
-                    if let Some((_, comptime)) = c.var_paths.get(&path).cloned() {
-                        let modport_members = comptime.r#type.expand_modport(c, &path, token)?;
-                        if modport_members.is_empty() {
-                            let mut members = vec![];
-                            if let Some((id, comptime)) = c.var_paths.get(&path).cloned() {
-                                let variable =
-                                    c.variables.get(&id).ok_or_else(|| ir_error!(token))?;
-                                let direction = match variable.kind {
-                                    VarKind::Input => Direction::Input,
-                                    VarKind::Output => Direction::Output,
-                                    _ => unreachable!(),
-                                };
-
-                                arg_map.insert(path.clone(), id);
-                                members.push((path.clone(), comptime, direction));
-                            }
-                            let arg = FuncArg {
-                                name: path.first(),
-                                comptime,
-                                members,
-                            };
-                            args.push(arg);
-                        } else {
-                            let mut members = vec![];
-                            for (path, direction) in modport_members {
-                                if let Some((id, comptime)) = c.var_paths.get(&path) {
-                                    arg_map.insert(path.clone(), *id);
-                                    members.push((path, comptime.clone(), direction));
-                                }
-                            }
-                            let arg = FuncArg {
-                                name: path.first(),
-                                comptime,
-                                members,
-                            };
-                            args.push(arg);
-                        }
-                    }
-                }
-
-                let statements: ir::StatementBlock =
-                    Conv::conv(c, func_def.statement_block.as_ref())?;
-                Ok(ir::FunctionBody {
-                    ret: ret_id,
-                    arg_map,
-                    statements: statements.0,
-                })
-            });
-
-            context.pop_affiliation();
-            context.pop_hierarchy();
-            context.pop_namespace();
-
-            let function = ir::Function {
-                name,
-                id,
+            let port_declaration = func_def
+                .function_declaration_opt0
+                .as_ref()
+                .map(|x| x.port_declaration.as_ref());
+            let statement_block = Some(func_def.statement_block.as_ref());
+            conv_function(
+                context,
                 path,
-                r#type: ret_type,
-                array: Shape::default(),
-                arity,
-                args,
-                is_const,
-                functions: vec![body?],
+                &symbol.found,
+                port_declaration,
+                statement_block,
                 token,
-            };
-
-            // function should be inserted outside the function scope
-            context.insert_function(id, function);
-            Ok(())
+            )
         } else {
             Err(ir_error!(token))
         }
@@ -1117,6 +970,212 @@ impl Conv<&FunctionDeclaration> for () {
             ret
         }
     }
+}
+
+impl Conv<(&ProtoFunctionDeclaration, Option<&FuncPath>)> for () {
+    fn conv(
+        context: &mut Context,
+        value: (&ProtoFunctionDeclaration, Option<&FuncPath>),
+    ) -> IrResult<Self> {
+        let (func_def, path) = value;
+        let token: TokenRange = (&func_def.identifier.identifier_token).into();
+
+        if let Some(x) = &func_def.proto_function_declaration_opt {
+            check_generic_bound(context, &x.with_generic_parameter);
+        }
+
+        if let Ok(symbol) = symbol_table::resolve(func_def.identifier.as_ref())
+            && let SymbolKind::ProtoFunction(_) = &symbol.found.kind
+        {
+            let port_declaration = func_def
+                .proto_function_declaration_opt0
+                .as_ref()
+                .map(|x| x.port_declaration.as_ref());
+            conv_function(context, path, &symbol.found, port_declaration, None, token)
+        } else {
+            Err(ir_error!(token))
+        }
+    }
+}
+
+fn conv_function(
+    context: &mut Context,
+    path: Option<&FuncPath>,
+    symbol: &Symbol,
+    port_declaratoin: Option<&PortDeclaration>,
+    statement_block: Option<&StatementBlock>,
+    token: TokenRange,
+) -> IrResult<()> {
+    // insert VarPath for function before statement_block conv
+    // because it may be refered by recursive function
+    let (path, name, namespace) = if let Some(path) = path {
+        let name = resource_table::insert_str(&path.sig.to_string());
+        (path.clone(), name, path.sig.namespace())
+    } else {
+        let path = FuncPath::new(symbol.id);
+        (path, symbol.token.text, symbol.inner_namespace())
+    };
+
+    if context.func_paths.contains_key(&path) {
+        // The given function has already been added through function reference before definition.
+        return Ok(());
+    }
+    let id = context.insert_func_path(path.clone());
+
+    let proeprty = match &symbol.kind {
+        SymbolKind::Function(x) => x,
+        SymbolKind::ProtoFunction(x) => x,
+        _ => unreachable!(),
+    };
+
+    let ret_type = if let Some(ret_type) = proeprty.ret.as_ref() {
+        let mut r#type = ret_type.to_ir_type(context, TypePosition::Variable)?;
+        if r#type.is_struct() {
+            r#type.set_concrete_width(Shape::new(vec![r#type.total_width()]));
+            r#type.kind = if r#type.is_2state() {
+                TypeKind::Bit
+            } else {
+                TypeKind::Logic
+            };
+        }
+        Comptime::from_type(r#type, ClockDomain::None, token)
+    } else {
+        let r#type = ir::Type::new(TypeKind::Void);
+        Comptime::from_type(r#type, ClockDomain::None, token)
+    };
+
+    let mut args = vec![];
+    let ports: Vec<_> = if let Some(port_declaratoin) = port_declaratoin
+        && let Some(ref x) = port_declaratoin.port_declaration_opt
+    {
+        x.port_declaration_list.as_ref().into()
+    } else {
+        vec![]
+    };
+    let arity = ports.len();
+
+    context.push_affiliation(Affiliation::Function);
+    context.push_hierarchy(name);
+    context.push_namespace(namespace);
+
+    let token: TokenRange = symbol.token.into();
+    let func = context.block(|c| {
+        let ret_id = if ret_type.r#type.kind != TypeKind::Void {
+            let path = VarPath::new(get_return_str());
+            let kind = VarKind::Variable;
+            let r#type = ret_type.r#type.clone();
+
+            // insert return value as variable
+            if let Some(_total_array) = r#type.total_array()
+                && let Some(total_width) = r#type.total_width()
+            {
+                // type.expand is not necessary
+                // because member access is not allowed for return value
+                // All elements are initialized to the same x-state
+                // value, so a single template suffices.
+                let values = vec![Value::new_x(total_width, false)];
+
+                let ret_id = c.insert_var_path(path.clone(), ret_type.clone());
+                let array_limit = c.config.evaluate_array_limit;
+                let variable = Variable::new(
+                    ret_id,
+                    path,
+                    kind,
+                    r#type,
+                    values,
+                    c.get_affiliation(),
+                    &token,
+                    array_limit,
+                );
+                c.insert_variable(ret_id, variable);
+                Some(ret_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut arg_map = HashMap::default();
+        for port in ports {
+            let _: IrResult<()> = Conv::conv(c, port);
+
+            let name = port.identifier.text();
+            let path = VarPath::new(name);
+            if let Some((_, comptime)) = c.var_paths.get(&path).cloned() {
+                let modport_members = comptime.r#type.expand_modport(c, &path, token)?;
+                if modport_members.is_empty() {
+                    let mut members = vec![];
+                    if let Some((id, comptime)) = c.var_paths.get(&path).cloned() {
+                        let variable = c.variables.get(&id).ok_or_else(|| ir_error!(token))?;
+                        let direction = match variable.kind {
+                            VarKind::Input => Direction::Input,
+                            VarKind::Output => Direction::Output,
+                            _ => unreachable!(),
+                        };
+
+                        arg_map.insert(path.clone(), id);
+                        members.push((path.clone(), comptime, direction));
+                    }
+                    let arg = FuncArg {
+                        name: path.first(),
+                        comptime,
+                        members,
+                    };
+                    args.push(arg);
+                } else {
+                    let mut members = vec![];
+                    for (path, direction) in modport_members {
+                        if let Some((id, comptime)) = c.var_paths.get(&path) {
+                            arg_map.insert(path.clone(), *id);
+                            members.push((path, comptime.clone(), direction));
+                        }
+                    }
+                    let arg = FuncArg {
+                        name: path.first(),
+                        comptime,
+                        members,
+                    };
+                    args.push(arg);
+                }
+            }
+        }
+
+        let body = if let Some(block) = statement_block {
+            let statements: ir::StatementBlock = Conv::conv(c, block)?;
+            vec![ir::FunctionBody {
+                ret: ret_id,
+                arg_map,
+                statements: statements.0,
+            }]
+        } else {
+            vec![]
+        };
+
+        Ok((args, body))
+    });
+
+    context.pop_affiliation();
+    context.pop_hierarchy();
+    context.pop_namespace();
+
+    let (args, body) = func?;
+    let func = ir::Function {
+        name,
+        id,
+        path,
+        r#type: ret_type,
+        array: Shape::default(),
+        arity,
+        args,
+        is_const: proeprty.constantable.unwrap(),
+        functions: body,
+        token,
+    };
+
+    // function should be inserted outside the function scope
+    context.insert_function(id, func);
+    Ok(())
 }
 
 impl Conv<&StructUnionDeclaration> for () {

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -6,7 +6,7 @@ use crate::conv::checker::clock_domain::check_clock_domain;
 use crate::conv::checker::generic::check_generic_refereence;
 use crate::conv::instance::InstanceHistoryError;
 use crate::conv::{Context, Conv};
-use crate::definition_table::{self, Definition};
+use crate::definition_table::{self, Definition, DefinitionId};
 use crate::ir::{
     self, Arguments, Comptime, FuncPath, FuncProto, IrResult, Op, PartSelectPath, Shape, ShapeRef,
     Signature, TbMethod, TbMethodCall, ValueVariant, VarIndex, VarKind, VarPath, VarPathSelect,
@@ -1515,7 +1515,18 @@ pub fn eval_function_call(
                 x.is_const = true;
                 Ok(ir::Expression::Term(Box::new(ir::Factor::Value(x))))
             }
-            SymbolKind::ProtoFunction(_) => Err(ir_error!(token)),
+            SymbolKind::ProtoFunction(_) => {
+                if context.in_generic {
+                    let ret =
+                        function_call(context, value.expression_identifier.as_ref(), args, token)?;
+
+                    Ok(ir::Expression::Term(Box::new(ir::Factor::FunctionCall(
+                        ret,
+                    ))))
+                } else {
+                    Err(ir_error!(token))
+                }
+            }
             _ => {
                 let name = symbol.found.token.text.to_string();
                 let kind = symbol.found.kind.to_kind_name();
@@ -2630,10 +2641,24 @@ pub fn var_path_to_assign_destination(
 }
 
 fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> IrResult<FuncProto> {
+    fn conv_function(
+        context: &mut Context,
+        definition: DefinitionId,
+        path: &FuncPath,
+    ) -> IrResult<()> {
+        let definition = definition_table::get(definition).unwrap();
+        match &definition {
+            Definition::Function(x) => Conv::conv(context, (x, Some(path))),
+            Definition::ProtoFunction(x) => Conv::conv(context, (x, Some(path))),
+            _ => unreachable!(),
+        }
+    }
+
     if !context.func_paths.contains_key(path) {
         let symbol = symbol_table::get(path.sig.symbol).unwrap();
         let (definition, is_global) = match &symbol.kind {
             SymbolKind::Function(x) => (x.definition.unwrap(), x.is_global()),
+            SymbolKind::ProtoFunction(x) => (x.definition.unwrap(), x.is_global()),
             SymbolKind::ModportFunctionMember(x) => {
                 let symbol = symbol_table::get(x.function).unwrap();
                 let SymbolKind::Function(x) = symbol.kind else {
@@ -2642,11 +2667,6 @@ fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> Ir
                 (x.definition.unwrap(), false)
             }
             _ => return Err(ir_error!(token)),
-        };
-
-        let definition = definition_table::get(definition).unwrap();
-        let Definition::Function(definition) = definition else {
-            unreachable!()
         };
 
         let array = if let Some((_, comptime)) = context.find_path(&path.path) {
@@ -2660,7 +2680,7 @@ fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> Ir
             .map(|namespace| symbol.namespace.included(&namespace))
             .unwrap_or(false);
         if is_local_func {
-            let ret: IrResult<()> = Conv::conv(context, (&definition, Some(path)));
+            let ret = conv_function(context, definition, path);
             ret?;
         } else {
             let generic_arg_paths = if is_global {
@@ -2690,7 +2710,7 @@ fn get_function(context: &mut Context, path: &FuncPath, token: TokenRange) -> Ir
                 }
             }
 
-            let ret: IrResult<()> = Conv::conv(&mut local_context, (&definition, Some(path)));
+            let ret = conv_function(&mut local_context, definition, path);
 
             for path in &generic_arg_paths {
                 if let Some((var_id, _)) = local_context.var_paths.remove(path) {

--- a/crates/analyzer/src/definition_table.rs
+++ b/crates/analyzer/src/definition_table.rs
@@ -2,7 +2,8 @@ use crate::HashMap;
 use std::cell::RefCell;
 use veryl_parser::resource_table::PathId;
 use veryl_parser::veryl_grammar_trait::{
-    FunctionDeclaration, InterfaceDeclaration, ModuleDeclaration, ProtoModuleDeclaration,
+    FunctionDeclaration, InterfaceDeclaration, ModuleDeclaration, ProtoFunctionDeclaration,
+    ProtoModuleDeclaration,
 };
 use veryl_parser::veryl_token::TokenSource;
 
@@ -24,6 +25,7 @@ pub enum Definition {
     Module(ModuleDeclaration),
     Interface(InterfaceDeclaration),
     Function(FunctionDeclaration),
+    ProtoFunction(ProtoFunctionDeclaration),
     ProtoModule(ProtoModuleDeclaration),
 }
 
@@ -45,6 +47,13 @@ impl Definition {
                 }
             }
             Definition::Function(x) => {
+                if let TokenSource::File { path, .. } = x.function.function_token.token.source {
+                    Some(path)
+                } else {
+                    None
+                }
+            }
+            Definition::ProtoFunction(x) => {
                 if let TokenSource::File { path, .. } = x.function.function_token.token.source {
                     Some(path)
                 } else {

--- a/crates/analyzer/src/handlers/create_symbol_table.rs
+++ b/crates/analyzer/src/handlers/create_symbol_table.rs
@@ -2492,6 +2492,7 @@ impl VerylGrammarTrait for CreateSymbolTable {
                 let range =
                     TokenRange::new(&arg.function.function_token, &arg.semicolon.semicolon_token);
 
+                let definition = definition_table::insert(Definition::ProtoFunction(arg.clone()));
                 let property = FunctionProperty {
                     affiliation,
                     range,
@@ -2502,7 +2503,7 @@ impl VerylGrammarTrait for CreateSymbolTable {
                     ret,
                     reference_paths: vec![],
                     constantable: None,
-                    definition: None,
+                    definition: Some(definition),
                 };
 
                 if let Some(id) = self.insert_symbol(

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -76,7 +76,9 @@ impl Signature {
                 let resolved = context.resolve_path(path.clone());
                 let symbol = symbol_table::resolve(&resolved).ok()?;
                 match &symbol.found.kind {
-                    SymbolKind::Function(_) => Self::new(symbol.found.id),
+                    SymbolKind::Function(_) | SymbolKind::ProtoFunction(_) => {
+                        Self::new(symbol.found.id)
+                    }
                     _ => return None,
                 }
             }

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -2275,9 +2275,13 @@ fn proto_function() {
   input var0(a): unknown = 1'hx;
   input var1(b): unknown = 1'hx;
   output var2(r): logic = 1'hx;
+  var var4(E.gt.return): logic = 1'hx;
+  input var5(E.gt.a): unknown = 1'hx;
+  input var6(E.gt.b): unknown = 1'hx;
+
 
   comb {
-    var2 = unknown;
+    var2 = var3(a: var0, b: var1);
   }
 }
 module Top {

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -1257,7 +1257,10 @@ impl SymbolTable {
         self.symbol_table
             .values()
             .filter_map(|symbol| {
-                if matches!(symbol.kind, SymbolKind::Function(_)) {
+                if matches!(
+                    symbol.kind,
+                    SymbolKind::Function(_) | SymbolKind::ProtoFunction(_)
+                ) {
                     Some(symbol.clone())
                 } else {
                     None

--- a/crates/analyzer/src/symbol_table/function.rs
+++ b/crates/analyzer/src/symbol_table/function.rs
@@ -9,23 +9,26 @@ pub fn resolve_function(list: &[Symbol]) {
 }
 
 fn resolve_constantable(symbol: &Symbol) -> bool {
-    if let SymbolKind::Function(func) = &symbol.kind
-        && let Some(constantable) = func.constantable
-    {
-        return constantable;
+    match &symbol.kind {
+        SymbolKind::Function(func) | SymbolKind::ProtoFunction(func) => {
+            if let Some(constantable) = func.constantable {
+                return constantable;
+            }
+        }
+        _ => {}
     }
 
-    let mut symbol = symbol.clone();
     let namespace = symbol.inner_namespace();
-    let SymbolKind::Function(mut func) = symbol.kind else {
-        unreachable!();
+    let mut symbol = symbol.clone();
+    let func = match &mut symbol.kind {
+        SymbolKind::Function(func) | SymbolKind::ProtoFunction(func) => func,
+        _ => unreachable!(),
     };
 
-    let constantable = is_constantable_function(&func, symbol.id, &namespace);
+    let constantable = is_constantable_function(func, symbol.id, &namespace);
     func.constantable = Some(constantable);
     func.reference_paths.clear();
 
-    symbol.kind = SymbolKind::Function(func);
     symbol_table::update(symbol);
 
     constantable

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8657,6 +8657,26 @@ fn unevaluable_value_const_value() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package ProtPkg {
+        function func() -> u32;
+    }
+    package Pkg::<n: u32> for ProtPkg {
+        function func() -> u32 {
+            return n;
+        }
+    }
+    module ModuleA::<pkg: ProtPkg> {
+        const A: u32 = pkg::func();
+    }
+    module ModuleB {
+        inst u: ModuleA::<Pkg::<32>>;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2562

Currenlty, proto functions are not converted into IR.
Constant expression check is failed due to this and #2562 is reported.

This PR adds IR conversion for proto function.