### PR TITLE
Disable const optimization within function body

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -54,6 +54,7 @@ pub struct Context {
     pub select_paths: Vec<(VarPath, GenericSymbolPath)>,
     pub select_dims: Vec<usize>,
     pub ignore_var_func: bool,
+    pub disalbe_const_opt: bool,
     pub namespaces: Vec<Namespace>,
     pub in_generic: bool,
     pub allow_component_as_factor: bool,
@@ -82,6 +83,7 @@ impl Context {
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
         std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);
+        self.disalbe_const_opt = tgt.disalbe_const_opt;
         self.in_generic = tgt.in_generic;
         self.allow_component_as_factor = tgt.allow_component_as_factor;
         self.config = tgt.config.clone();

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -1142,11 +1142,15 @@ fn conv_function(
         }
 
         let body = if let Some(block) = statement_block {
-            let statements: ir::StatementBlock = Conv::conv(c, block)?;
+            let disable_const_opt = c.disalbe_const_opt;
+            c.disalbe_const_opt = true;
+            let statements: IrResult<ir::StatementBlock> = Conv::conv(c, block);
+            c.disalbe_const_opt = disable_const_opt;
+
             vec![ir::FunctionBody {
                 ret: ret_id,
                 arg_map,
-                statements: statements.0,
+                statements: statements?.0,
             }]
         } else {
             vec![]

--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -415,7 +415,8 @@ impl Expression {
             }
 
             // const optimization
-            if comptime.is_const
+            if !context.disalbe_const_opt
+                && comptime.is_const
                 && let Some(value) = value
                 && !value.is_xz()
             {

--- a/crates/analyzer/src/ir/function.rs
+++ b/crates/analyzer/src/ir/function.rs
@@ -192,9 +192,12 @@ impl FunctionCall {
             var.set_value(&[], value, None);
         }
 
+        let disable_const_opt = context.disalbe_const_opt;
+        context.disalbe_const_opt = true;
         for x in &func.statements {
             x.eval_value(context);
         }
+        context.disalbe_const_opt = disable_const_opt;
 
         // TODO get outputs
 

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -926,7 +926,7 @@ fn function() {
   var var3(PkgB.PkgA.func_a.return): bit<32> = 32'h00000008;
   const var4(A): bit<32> = 32'h00000008;
   func var0(PkgB.func_b) -> var1 {
-    var1 = 32'h00000008;
+    var1 = var2();
   }
   func var2(PkgB.PkgA.func_a) -> var3 {
     var3 = 32'sh00000008;
@@ -1049,6 +1049,36 @@ fn function() {
   comb {
     var4 = var5(c: var3, a: var1, b: var2);
   }
+}
+"#;
+
+    check_ir(code, exp);
+
+    let code = r#"
+    module ModuleA {
+        function f(a: input u32) -> u32 {
+            var b: u32;
+            b = $clog2(a);
+            return b;
+        }
+        const A: u32 = f(1);
+        const B: u32 = f(2);
+        const C: u32 = f(3);
+    }
+    "#;
+
+    let exp = r#"module ModuleA {
+  var var1(f.return): bit<32> = 32'h00000002;
+  input var2(f.a): bit<32> = 32'sh00000003;
+  var var3(f.b): bit<32> = 32'h00000002;
+  const var4(A): bit<32> = 32'h00000000;
+  const var5(B): bit<32> = 32'h00000001;
+  const var6(C): bit<32> = 32'h00000002;
+  func var0(f) -> var1 {
+    var3 = $clog2(var2);
+    var1 = var3;
+  }
+
 }
 "#;
 
@@ -2033,7 +2063,7 @@ module ModuleB {
   var var3(Pkg.func_a::<__Pkg__1 B>.return): bit<32> = 32'h00000001;
   const var4(A): bit<32> = 32'h00000001;
   func var0(Pkg.func_b::<1>) -> var1 {
-    var1 = 32'h00000001;
+    var1 = var2();
   }
   func var2(Pkg.func_a::<__Pkg__1 B>) -> var3 {
     var3 = 32'sh00000001;


### PR DESCRIPTION
fix veryl-lang/veryl#2572

Functions may be called multiple times. 
Therefore, expressions in function body should be evaluated every calls but currently they may not be evaluated due to const optimization.
This causes #2572.

To fix this, const optimization should not be performed in function body.