### PR TITLE
Fix duplicated global function instances

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -387,13 +387,21 @@ impl ReferenceTable {
 
         if let Some(ref id) = symbol_table::insert(&token, symbol.clone()) {
             symbol_table::add_generic_instance(target.id, *id);
+        } else {
+            symbol_table::update_generic_instance_affiliation(target.id, &symbol);
         }
 
         generic_maps.push(GenericMap {
             id: None,
             map: target.generic_table(&instance_path.arguments),
         });
-        Self::insert_subordinate_generic_instances(namespace, target, &symbol, generic_maps);
+        Self::insert_subordinate_generic_instances(
+            namespace,
+            target,
+            &symbol,
+            generic_maps,
+            affiliation_symbol,
+        );
     }
 
     fn create_generic_instance(
@@ -430,6 +438,7 @@ impl ReferenceTable {
         target: &Symbol,
         inst_symbol: &Symbol,
         generic_maps: &[GenericMap],
+        affiliation_symbol: Option<&Symbol>,
     ) {
         let is_global_func = target.is_global_function();
         let mut subordinate_paths = if !is_global_func {
@@ -465,7 +474,7 @@ impl ReferenceTable {
                         namespace,
                         &path_symbol.found,
                         &mut generic_maps.to_vec(),
-                        None,
+                        affiliation_symbol,
                     );
                 } else {
                     Self::insert_generic_instance(

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -2751,7 +2751,7 @@ pub struct GenericConstProperty {
 pub struct GenericInstanceProperty {
     pub base: SymbolId,
     pub arguments: Vec<GenericSymbolPath>,
-    pub affiliation_symbol: Option<SymbolId>,
+    pub affiliation_symbols: Vec<SymbolId>,
 }
 
 impl GenericInstanceProperty {

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -366,15 +366,17 @@ impl GenericSymbol {
         if self.arguments.is_empty() {
             None
         } else {
-            let affiliation_id = if let Some(symbol) = affiliation_symbol {
-                Some(symbol.id)
+            let affiliation_symbols = if let Some(symbol) = affiliation_symbol {
+                vec![symbol.id]
+            } else if let Some(symbol) = base.get_parent() {
+                vec![symbol.id]
             } else {
-                base.get_parent().map(|parent| parent.id)
+                vec![]
             };
             let property = GenericInstanceProperty {
                 base: base.id,
                 arguments: self.arguments.clone(),
-                affiliation_symbol: affiliation_id,
+                affiliation_symbols,
             };
             let kind = SymbolKind::GenericInstance(property);
             let token = &self.base;

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -1031,6 +1031,34 @@ impl SymbolTable {
         }
     }
 
+    pub fn update_generic_instance_affiliation(&mut self, target: SymbolId, instance: &Symbol) {
+        let Some(target_inst_ids) = self
+            .symbol_table
+            .get(&target)
+            .map(|x| x.generic_instances.clone())
+        else {
+            return;
+        };
+        for target_inst_id in &target_inst_ids {
+            if let Some(target_inst_symbol) = self.symbol_table.get_mut(target_inst_id)
+                && target_inst_symbol.token.text == instance.token.text
+            {
+                let SymbolKind::GenericInstance(target_inst) = &mut target_inst_symbol.kind else {
+                    unreachable!();
+                };
+                let SymbolKind::GenericInstance(inst) = &instance.kind else {
+                    unreachable!();
+                };
+                if let Some(affiliation_symbol) = inst.affiliation_symbols.first()
+                    && !target_inst.affiliation_symbols.contains(affiliation_symbol)
+                {
+                    target_inst.affiliation_symbols.push(*affiliation_symbol);
+                }
+                break;
+            }
+        }
+    }
+
     fn add_imported_item(&mut self, target: SymbolId, import: &Import) {
         if let Some(symbol) = self.symbol_table.get_mut(&target) {
             symbol.imported.push(import.to_owned());
@@ -1836,6 +1864,14 @@ pub fn add_reference(target: SymbolId, token: &Token) {
 pub fn add_generic_instance(target: SymbolId, instance: SymbolId) {
     clear_cache();
     SYMBOL_TABLE.with(|f| f.borrow_mut().add_generic_instance(target, instance))
+}
+
+pub fn update_generic_instance_affiliation(target: SymbolId, instance: &Symbol) {
+    clear_cache();
+    SYMBOL_TABLE.with(|f| {
+        f.borrow_mut()
+            .update_generic_instance_affiliation(target, instance)
+    })
 }
 
 pub fn add_import(import: Import) {

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -93,6 +93,7 @@ pub struct Emitter {
     modport_ports_table: Option<ExpandedModportPortTable>,
     inst_module_namespace: Option<Namespace>,
     bound_namespace: Option<Namespace>,
+    bound_symbol: Option<SymbolId>,
     skip_comment: bool,
 }
 
@@ -149,6 +150,7 @@ impl Default for Emitter {
             modport_ports_table: None,
             inst_module_namespace: None,
             bound_namespace: None,
+            bound_symbol: None,
             skip_comment: false,
         }
     }
@@ -1889,20 +1891,25 @@ impl Emitter {
 
         let src_line = self.src_line;
         self.bound_namespace = Some(component_symbol.inner_namespace());
+        if let Some(generic_inst) = self.current_generic_instance() {
+            self.bound_symbol = Some(generic_inst);
+        } else {
+            self.bound_symbol = Some(component_symbol.id);
+        }
 
         let mut emitted_functions = Vec::new();
         for path in &func_paths {
-            self.emit_global_function(path, component_symbol, &mut emitted_functions);
+            self.emit_global_function(path, &mut emitted_functions);
         }
 
         self.bound_namespace = None;
+        self.bound_symbol = None;
         self.src_line = src_line;
     }
 
     fn emit_global_function(
         &mut self,
         path: &GenericSymbolPath,
-        component_symbol: &Symbol,
         emitted_functions: &mut Vec<SymbolId>,
     ) {
         let (Ok(func_symbol), _) = self.resolve_generic_path(path, None) else {
@@ -1913,29 +1920,13 @@ impl Emitter {
             return;
         }
 
-        if emitted_functions.contains(&func_symbol.found.id) {
-            // The given function has already been emitted.
-            // Nothing to do.
-            return;
-        }
-
-        if emitted_functions.is_empty() {
-            self.newline();
-        }
-
-        emitted_functions.push(func_symbol.found.id);
         let (func_id, definition, generic_map) = match &func_symbol.found.kind {
             SymbolKind::Function(x) => (func_symbol.found.id, x.definition, vec![]),
             SymbolKind::GenericInstance(x) => {
                 if let Some(base_symbol) = symbol_table::get(x.base)
                     && let SymbolKind::Function(base_func) = &base_symbol.kind
                 {
-                    let mut maps = func_symbol.found.generic_maps();
-                    for map in &mut maps {
-                        // Generic instance of global functoin belongs to
-                        // component where it is emitted into.
-                        map.id = Some(component_symbol.id);
-                    }
+                    let maps = func_symbol.found.generic_maps();
                     (base_symbol.id, base_func.definition, maps)
                 } else {
                     return;
@@ -1944,10 +1935,21 @@ impl Emitter {
             _ => return,
         };
 
+        if emitted_functions.is_empty() {
+            self.newline();
+        }
+
+        if emitted_functions.contains(&func_id) {
+            // The given function has already been emitted.
+            // Nothing to do.
+            return;
+        }
+        emitted_functions.push(func_id);
+
         if let Some(func_paths) = &symbol_table::get_reference_functions(func_id) {
             self.generic_map.push(generic_map);
             for func_path in func_paths {
-                self.emit_global_function(func_path, component_symbol, emitted_functions);
+                self.emit_global_function(func_path, emitted_functions);
             }
             self.generic_map.pop();
         }
@@ -2210,29 +2212,32 @@ impl Emitter {
         }
     }
 
-    fn get_generic_maps(&self, symbol: &Symbol) -> Vec<GenericMap> {
-        let mut associated_components = vec![];
-        if symbol.is_global_function()
-            && let Some(bound_namespace) = self.bound_namespace.as_ref()
-            && let Some(bound_symbol) = bound_namespace.get_symbol()
-        {
-            // Generic instance of global function is associated with
-            // caller (bound) namespace.
-            associated_components.push(bound_symbol.id);
-        }
+    fn current_generic_instance(&self) -> Option<SymbolId> {
         if let Some(maps) = self.generic_map.last()
             && let Some(map) = maps.last()
-            && let Some(id) = map.id
         {
-            associated_components.push(id);
+            map.id
+        } else {
+            None
         }
+    }
+
+    fn get_generic_maps(&self, symbol: &Symbol) -> Vec<GenericMap> {
+        let is_global_func = symbol.is_global_function();
+
+        let associated_component = if is_global_func {
+            self.bound_symbol
+        } else {
+            self.current_generic_instance()
+        };
 
         // The given symbol is a top level symbol or
         // the parent symbol is a non generic object.
-        if associated_components.is_empty() {
+        if associated_component.is_none() {
             return symbol.generic_maps();
         }
 
+        let associated_component = associated_component.unwrap();
         symbol
             .generic_maps()
             .into_iter()
@@ -2243,8 +2248,16 @@ impl Emitter {
                         unreachable!();
                     };
 
-                    let affiliation_symbol = inst.affiliation_symbol.unwrap();
-                    associated_components.contains(&affiliation_symbol)
+                    if inst.affiliation_symbols.contains(&associated_component) {
+                        true
+                    } else if is_global_func
+                        && let Some(associated_symbol) = symbol_table::get(associated_component)
+                        && let SymbolKind::GenericInstance(associated_inst) = associated_symbol.kind
+                    {
+                        inst.affiliation_symbols.contains(&associated_inst.base)
+                    } else {
+                        false
+                    }
                 } else {
                     true
                 }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -3015,6 +3015,87 @@ endmodule
 
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
+
+    let code = r#"
+function func_a::<V: u32, T: type> -> T {
+    return V as T;
+}
+function func_b::<V: u32, T: type> -> T {
+    return func_a::<V, T>();
+}
+module ModuleA::<T: type> #(
+    param V: u32 = 1,
+) {
+    const A: bbool = func_b::<V, bbool>();
+    const B: T     = func_b::<V, T>();
+}
+module ModuleB::<T: type> #(
+    param V: u32 = 1,
+) {
+    const A: bbool = func_b::<V, bbool>();
+    const B: T     = func_b::<V, T>();
+}
+module ModuleC {
+    inst u0: ModuleB::<i16>;
+    inst u1: ModuleB::<i32>;
+}
+"#;
+
+    let expect = r#"
+
+
+
+module prj___ModuleB__i16 #(
+    parameter int unsigned V = 1
+);
+    localparam bit A = __func_b__V__bbool();
+    localparam shortint B = __func_b__V__i16();
+
+    function automatic bit __func_a__V__bbool;
+        return bit'(V);
+    endfunction
+    function automatic shortint __func_a__V__i16;
+        return shortint'(V);
+    endfunction
+    function automatic bit __func_b__V__bbool;
+        return __func_a__V__bbool();
+    endfunction
+    function automatic shortint __func_b__V__i16;
+        return __func_a__V__i16();
+    endfunction
+endmodule
+module prj___ModuleB__i32 #(
+    parameter int unsigned V = 1
+);
+    localparam bit A = __func_b__V__bbool();
+    localparam int B = __func_b__V__i32();
+
+    function automatic bit __func_a__V__bbool;
+        return bit'(V);
+    endfunction
+    function automatic int __func_a__V__i32;
+        return int'(V);
+    endfunction
+    function automatic bit __func_b__V__bbool;
+        return __func_a__V__bbool();
+    endfunction
+    function automatic int __func_b__V__i32;
+        return __func_a__V__i32();
+    endfunction
+endmodule
+module prj_ModuleC;
+    prj___ModuleB__i16 u0 ();
+    prj___ModuleB__i32 u1 ();
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = emit(&metadata, code);
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2596

Analyzer and Emitter do not resolve relationship between global functions and caller namespace.
This PR is to fix this.