### PR TITLE
Propagate resolved generic maps during unaliasing path

### DIFF
--- a/crates/analyzer/src/conv/checker/generic.rs
+++ b/crates/analyzer/src/conv/checker/generic.rs
@@ -64,7 +64,7 @@ fn check_referable_generic_expression(
     let mut paths = collect_symbol_paths(expression);
     for path in paths.drain(..) {
         let mut path = context.resolve_path(path);
-        path.unalias();
+        path.unalias(None);
         let error = check_referable_path(&path, base, token);
         if error.is_some() {
             return error;
@@ -344,7 +344,7 @@ pub fn check_generic_refereence(context: &mut Context, path: &GenericSymbolPath)
                 let bound = &param.1.bound;
 
                 let mut arg = context.resolve_path(arg.clone());
-                arg.unalias();
+                arg.unalias(None);
 
                 if let Some(error) =
                     check_referable_path(&arg, Some(&symbol.found), symbol.found.token.into())

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -43,7 +43,7 @@ impl Signature {
     pub fn from_path(context: &mut Context, mut path: GenericSymbolPath) -> Option<Self> {
         let namespace = namespace_table::get(path.paths[0].base.id).unwrap();
         path.resolve_imported(&namespace, None);
-        path.unalias();
+        path.unalias(None);
 
         let symbol = symbol_table::resolve(&path).ok()?;
 

--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -329,7 +329,7 @@ impl ReferenceTable {
                     }
 
                     for arg in args.iter_mut() {
-                        arg.unalias();
+                        arg.unalias(None);
                         // Global function is emitted into the caller namespace.
                         // So namespace expansion is not needed.
                         if !target_symbol.is_global_function() {
@@ -461,7 +461,7 @@ impl ReferenceTable {
             }
 
             path.apply_map(generic_maps);
-            path.unalias();
+            path.unalias(None);
             path.append_namespace_path(namespace, &target.namespace);
 
             if let Ok(path_symbol) = symbol_table::resolve((&path.generic_path(), target_namespace))

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -467,7 +467,7 @@ impl GenericSymbolPath {
         }
     }
 
-    pub fn unalias(&mut self) {
+    pub fn unalias(&mut self, generic_maps: Option<&Vec<GenericMap>>) {
         if !self.is_resolvable() {
             return;
         }
@@ -475,8 +475,8 @@ impl GenericSymbolPath {
         let Some(namespace) = namespace_table::get(self.paths[0].base.id) else {
             return;
         };
-        let mut generic_maps: Vec<_> = Vec::new();
 
+        let mut generic_maps = generic_maps.cloned().unwrap_or_default();
         for i in 0..self.len() {
             let symbol = symbol_table::resolve((&self.slice(i).mangled_path(), &namespace));
 
@@ -490,7 +490,7 @@ impl GenericSymbolPath {
                         alias_target.paths.push(self.paths[j].clone());
                     }
                 }
-                alias_target.unalias();
+                alias_target.unalias(Some(&generic_maps));
 
                 self.paths = alias_target.paths;
                 self.kind = alias_target.kind;
@@ -500,7 +500,7 @@ impl GenericSymbolPath {
 
             if let Some(path) = self.paths.get_mut(i) {
                 for arg in path.arguments.iter_mut() {
-                    arg.unalias();
+                    arg.unalias(Some(&generic_maps));
                 }
 
                 if let Ok(ref symbol) = symbol
@@ -660,7 +660,7 @@ impl GenericSymbolPath {
                 if let Some(maps) = generic_maps {
                     package_path.apply_map(maps);
                 }
-                package_path.unalias();
+                package_path.unalias(None);
 
                 for (i, path) in package_path.paths.iter().enumerate() {
                     let token = Token::generate(path.base.text, self_file_path);

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -185,7 +185,7 @@ impl SymbolTable {
 
             let mut path = x.path.clone();
             path.resolve_imported(&context.namespace, None);
-            path.unalias();
+            path.unalias(None);
             let symbol = self.resolve(
                 &path.generic_path(),
                 &path.generic_arguments(),
@@ -768,7 +768,7 @@ impl SymbolTable {
                             SymbolKind::Instance(x) => {
                                 let mut type_name = x.type_name.clone();
                                 type_name.resolve_imported(&context.namespace, None);
-                                type_name.unalias();
+                                type_name.unalias(None);
                                 context = self.trace_type_path(context, &type_name)?;
                             }
                             SymbolKind::GenericInstance(_) => {

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -6245,7 +6245,7 @@ pub fn resolve_generic_path(
     if let Some(maps) = generic_maps {
         path.apply_map(maps);
     }
-    path.unalias();
+    path.unalias(None);
 
     let path_symbols: Vec<_> = (0..path.len())
         .filter_map(|i| {
@@ -6270,7 +6270,7 @@ pub fn resolve_generic_path(
                     break;
                 };
                 let mut arg = default.clone();
-                arg.unalias();
+                arg.unalias(None);
                 path.paths[*i].arguments.push(arg);
             }
 
@@ -6278,7 +6278,7 @@ pub fn resolve_generic_path(
                 if let Some(maps) = generic_maps {
                     arg.apply_map(maps);
                 }
-                arg.unalias();
+                arg.unalias(None);
                 if !symbol.is_global_function() {
                     arg.append_namespace_path(namespace, &symbol.namespace);
                 }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2617,6 +2617,64 @@ endmodule
 }
 
 #[test]
+fn interface_alias_defined_in_package() {
+    let code = r#"
+proto package a_proto_pkg {
+    const W: p32;
+}
+package a_pkg::<w: p32> for a_proto_pkg {
+    const W: p32 = w;
+}
+interface a_if::<pkg: a_proto_pkg> {
+    var a: logic<pkg::W>;
+    modport mp {
+        a: output,
+    }
+}
+package b_pkg::<W: p32> {
+    alias package   apkg = a_pkg::<W>;
+    alias interface aif  = a_if::<apkg>;
+}
+module module_b (
+    aif: modport b_pkg::<8>::aif::mp,
+) {
+    assign aif.a = 0;
+}
+"#;
+
+    let expect = r#"
+
+package prj___a_pkg__8;
+    localparam int unsigned W = 8;
+endpackage
+interface prj___a_if____a_pkg__8;
+    logic [prj___a_pkg__8::W-1:0] a;
+    modport mp (
+        output a
+    );
+endinterface
+package prj___b_pkg__8;
+
+
+
+endpackage
+module prj_module_b (
+    prj___a_if____a_pkg__8.mp aif
+);
+    always_comb aif.a = 0;
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = emit(&metadata, code);
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
+}
+
+#[test]
 fn function_call_via_generic_interface() {
     let code = r#"module ModuleA (
     a_if: interface::slave,


### PR DESCRIPTION
fix veryl-lang/veryl#2605

Resolved generic maps may be reuqired if the given path depending on package aliases.
However, in the current implmementation, they are not propagated when unaliasing dependent paths.
This causes #2605.
