### PR TITLE
Fix `invisible_identifier` error reported for `gen` const

### DIFF
--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -682,8 +682,11 @@ impl GenericSymbolPath {
 
     pub fn append_namespace_path(&mut self, namespace: &Namespace, target_namespace: &Namespace) {
         fn is_defined_in_package(symbol: &Symbol) -> bool {
-            if matches!(symbol.kind, SymbolKind::GenericParameter(_)) {
-                // Generic parameter is not visible from other namespace
+            if matches!(
+                symbol.kind,
+                SymbolKind::GenericParameter(_) | SymbolKind::GenericConst(_)
+            ) {
+                // Generic parameter and const are not visible from other namespace
                 return false;
             }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -5207,6 +5207,26 @@ fn invisible_identifier() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package a_pkg {
+        const A: u32 = 1;
+    }
+    package b_pkg {
+        const B: u32 = 1;
+    }
+    package c_pkg::<c: u32> {
+        const C: u32 = c;
+    }
+    package d_pkg::<a: u32, b: u32> {
+        gen   a_b: u32 = a + b;
+        const C  : u32 = c_pkg::<a_b>::C;
+    }
+    alias package pkg = d_pkg::<a_pkg::A, b_pkg::B>;
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2609

Like generic params, generic consts should also be invisible from other component.
However, in this current implementation, generic conts are not treated in this way.
This causes errors shown in #2609.
