### PR TITLE
Support importing items from imported alias package

### DIFF
--- a/crates/analyzer/src/conv/checker/import.rs
+++ b/crates/analyzer/src/conv/checker/import.rs
@@ -1,26 +1,38 @@
 use crate::analyzer_error::AnalyzerError;
 use crate::conv::Context;
 use crate::symbol::SymbolKind;
+use crate::symbol_path::GenericSymbolPath;
 use crate::symbol_table;
 use veryl_parser::veryl_grammar_trait::*;
 
 pub fn check_import(context: &mut Context, value: &ImportDeclaration) {
-    if let Ok(symbol) = symbol_table::resolve(value.scoped_identifier.as_ref()) {
+    let path: GenericSymbolPath = value.scoped_identifier.as_ref().into();
+    if let Ok(symbol) = symbol_table::resolve(&path) {
         let is_wildcard = value.import_declaration_opt.is_some();
         let is_valid_import = if matches!(symbol.found.kind, SymbolKind::SystemVerilog) {
             true
         } else if is_wildcard {
-            symbol.found.is_package(false) || matches!(symbol.found.kind, SymbolKind::Enum(_))
+            symbol.found.is_package(false)
+                || matches!(symbol.found.kind, SymbolKind::ProtoAliasPackage(_)) && symbol.imported
+                || matches!(symbol.found.kind, SymbolKind::Enum(_))
         } else if symbol.full_path.len() >= 2 {
             let parent_symbol = symbol
                 .full_path
                 .get(symbol.full_path.len() - 2)
                 .map(|x| symbol_table::get(*x).unwrap())
                 .unwrap();
-            // The preceding symbol must be a package, an enum, or
-            // a proto-package referenced through a generic parameter.
-            (parent_symbol.is_package(false) || matches!(parent_symbol.kind, SymbolKind::Enum(_)))
-                && symbol.found.is_importable(true)
+            if matches!(parent_symbol.kind, SymbolKind::ProtoAliasPackage(_)) {
+                let parent_path = path.slice(path.len() - 2);
+                symbol_table::resolve(&parent_path)
+                    .map(|parent| parent.imported && symbol.found.is_importable(true))
+                    .unwrap()
+            } else {
+                // The preceding symbol must be a package, an enum, or
+                // a proto-package referenced through a generic parameter.
+                (parent_symbol.is_package(false)
+                    || matches!(parent_symbol.kind, SymbolKind::Enum(_)))
+                    && symbol.found.is_importable(true)
+            }
         } else {
             false
         };

--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -529,6 +529,7 @@ impl ReferenceTable {
 
             let mut maps = vec![map];
             path.apply_map(&maps);
+            path.unalias(None);
             path.append_namespace_path(&namespace, &symbol.namespace);
 
             Self::insert_generic_instance(

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -762,7 +762,7 @@ impl Symbol {
     pub fn is_package(&self, include_proto: bool) -> bool {
         match &self.kind {
             SymbolKind::Package(_) | SymbolKind::AliasPackage(_) => return true,
-            SymbolKind::ProtoPackage(_) => return include_proto,
+            SymbolKind::ProtoPackage(_) | SymbolKind::ProtoAliasPackage(_) => return include_proto,
             SymbolKind::GenericInstance(x) => {
                 let symbol = symbol_table::get(x.base).unwrap();
                 return symbol.is_package(false);
@@ -833,7 +833,13 @@ impl Symbol {
             | SymbolKind::Enum(_)
             | SymbolKind::Struct(_)
             | SymbolKind::Union(_)
-            | SymbolKind::Function(_) => {
+            | SymbolKind::Function(_)
+            | SymbolKind::AliasModule(_)
+            | SymbolKind::ProtoAliasModule(_)
+            | SymbolKind::AliasInterface(_)
+            | SymbolKind::ProtoAliasInterface(_)
+            | SymbolKind::AliasPackage(_)
+            | SymbolKind::ProtoAliasPackage(_) => {
                 if let Some(parent) = self.get_parent() {
                     return parent.is_package(include_proto);
                 }

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -662,6 +662,14 @@ impl GenericSymbolPath {
                 }
                 package_path.unalias(None);
 
+                if let Ok(package_symbol) =
+                    symbol_table::resolve((&package_path.generic_path(), namespace))
+                    && package_symbol.imported
+                {
+                    // 'package_path' points imported alias package or proto alias package.
+                    package_path.resolve_imported(namespace, generic_maps);
+                }
+
                 for (i, path) in package_path.paths.iter().enumerate() {
                     let token = Token::generate(path.base.text, self_file_path);
                     namespace_table::insert(token.id, self_file_path, &self_namespace);

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -901,6 +901,27 @@ impl SymbolTable {
                 .collect()
         }
 
+        // Namespace::get_symbol (used in Symbol::get_parent) uses symbol_table::resolve.
+        // This causes 'RefCell already mutably borrowed' error.
+        // The function below is to prevent this error.
+        fn get_parent_symbol(symbol_table: &SymbolTable, symbol: &Symbol) -> Option<Symbol> {
+            let mut namespace = symbol.namespace.clone();
+            namespace.strip_anonymous_path();
+
+            if let Some(path) = namespace.pop()
+                && namespace.depth() >= 1
+            {
+                let context = ResolveContext::new(&namespace);
+                let symbol_path = SymbolPath::new(&[path]);
+                symbol_table
+                    .resolve(&symbol_path, &[], context)
+                    .map(|x| (*x.found).clone())
+                    .ok()
+            } else {
+                None
+            }
+        }
+
         match &symbol.kind {
             SymbolKind::Module(x) => vec![collect_generic_params(self, &x.generic_parameters)],
             SymbolKind::Interface(x) => vec![collect_generic_params(self, &x.generic_parameters)],
@@ -910,7 +931,7 @@ impl SymbolTable {
                 self.collect_generic_bounds(&symbol)
             }
             SymbolKind::Function(x) => {
-                let mut bounds = if let Some(parent) = symbol.get_parent() {
+                let mut bounds = if let Some(parent) = get_parent_symbol(self, symbol) {
                     self.collect_generic_bounds(&parent)
                 } else {
                     vec![]
@@ -919,7 +940,7 @@ impl SymbolTable {
                 bounds
             }
             SymbolKind::Struct(x) => {
-                let mut bounds = if let Some(parent) = symbol.get_parent() {
+                let mut bounds = if let Some(parent) = get_parent_symbol(self, symbol) {
                     self.collect_generic_bounds(&parent)
                 } else {
                     vec![]
@@ -928,7 +949,7 @@ impl SymbolTable {
                 bounds
             }
             SymbolKind::Union(x) => {
-                let mut bounds = if let Some(parent) = symbol.get_parent() {
+                let mut bounds = if let Some(parent) = get_parent_symbol(self, symbol) {
                     self.collect_generic_bounds(&parent)
                 } else {
                     vec![]
@@ -937,7 +958,7 @@ impl SymbolTable {
                 bounds
             }
             SymbolKind::Block => {
-                if let Some(parent) = symbol.get_parent() {
+                if let Some(parent) = get_parent_symbol(self, symbol) {
                     self.collect_generic_bounds(&parent)
                 } else {
                     vec![]
@@ -1069,58 +1090,48 @@ impl SymbolTable {
         self.import_list.push(import);
     }
 
-    pub fn get_imported_symbols(&self) -> Vec<(Import, Symbol)> {
-        let mut ret = Vec::new();
-        for import in &self.import_list {
+    pub fn apply_import(&mut self) {
+        let import_list: Vec<_> = self.import_list.drain(0..).collect();
+        for import in &import_list {
             let context = ResolveContext::new(&import.path.1);
-            if let Ok(symbol) = self.resolve(&import.path.0.generic_path(), &[], context) {
-                ret.push((import.clone(), (*symbol.found).clone()));
-            }
-        }
-        ret
-    }
+            let Ok((symbol, imported)) = self
+                .resolve(&import.path.0.generic_path(), &[], context)
+                .map(|x| ((*x.found).clone(), x.imported))
+            else {
+                continue;
+            };
 
-    pub fn apply_import(&mut self, symbols: &[(Import, Symbol)]) {
-        // Group wildcard imports by target namespace for batch processing
-        let mut package_imports: HashMap<SVec<StrId>, Vec<(Namespace, &Import)>> =
-            HashMap::default();
-        for (import, symbol) in symbols {
             if import.wildcard {
                 let wildcard_target = if matches!(symbol.kind, SymbolKind::Enum(_)) {
                     Some(symbol.clone())
                 } else {
-                    self.get_package(symbol, false)
+                    self.get_package(&symbol, false, imported)
                 };
                 if let Some(target_symbol) = wildcard_target {
                     let target = target_symbol.inner_namespace();
-                    let paths = target.paths.clone();
-                    package_imports
-                        .entry(paths)
-                        .or_default()
-                        .push((target, import));
-                }
-            } else if !matches!(symbol.kind, SymbolKind::SystemVerilog) {
-                self.add_imported_item(symbol.id, import);
-            }
-        }
-        // Batch apply all wildcard imports using namespace_index
-        for (paths, imports) in &package_imports {
-            if let Some(ids) = self.namespace_index.get(paths).cloned() {
-                for id in ids {
-                    if let Some(symbol) = self.symbol_table.get_mut(&id) {
-                        for (target, import) in imports {
-                            if symbol.namespace.matched(target) {
+                    if let Some(ids) = self.namespace_index.get(&target.paths) {
+                        for id in ids {
+                            let Some(symbol) = self.symbol_table.get_mut(id) else {
+                                continue;
+                            };
+                            if symbol.namespace.matched(&target) {
                                 symbol.imported.push((*import).to_owned());
                             }
                         }
                     }
                 }
+            } else if !matches!(symbol.kind, SymbolKind::SystemVerilog) {
+                self.add_imported_item(symbol.id, import);
             }
         }
-        self.import_list.clear();
     }
 
-    fn get_package(&self, symbol: &Symbol, include_proto: bool) -> Option<Symbol> {
+    fn get_package(
+        &self,
+        symbol: &Symbol,
+        include_proto: bool,
+        include_proto_alias: bool,
+    ) -> Option<Symbol> {
         match &symbol.kind {
             SymbolKind::Package(_) => return Some(symbol.clone()),
             SymbolKind::ProtoPackage(_) if include_proto => return Some(symbol.clone()),
@@ -1130,12 +1141,18 @@ impl SymbolTable {
                 // because symbol_table::get is forbidden in apply_import which borrows `&mut self`
                 // It is not necessary for apply_import
                 if let Ok(symbol) = self.resolve(&x.target.generic_path(), &[], context) {
-                    return self.get_package(&symbol.found, include_proto);
+                    return self.get_package(&symbol.found, include_proto, false);
+                }
+            }
+            SymbolKind::ProtoAliasPackage(x) if include_proto_alias => {
+                let context = ResolveContext::new(&symbol.namespace);
+                if let Ok(symbol) = self.resolve(&x.target.generic_path(), &[], context) {
+                    return self.get_package(&symbol.found, true, false);
                 }
             }
             SymbolKind::GenericInstance(x) => {
                 let symbol = self.get(x.base).unwrap();
-                return self.get_package(&symbol, false);
+                return self.get_package(&symbol, false, false);
             }
             SymbolKind::GenericParameter(x) => {
                 if let GenericBoundKind::Proto(proto) = &x.bound
@@ -1143,7 +1160,7 @@ impl SymbolTable {
                 {
                     let context = ResolveContext::new(&symbol.namespace);
                     if let Ok(symbol) = self.resolve(&x.path.generic_path(), &[], context) {
-                        return self.get_package(&symbol.found, true);
+                        return self.get_package(&symbol.found, true, false);
                     }
                 }
             }
@@ -1886,8 +1903,7 @@ pub fn add_import(import: Import) {
 
 pub fn apply_import() {
     SYMBOL_CACHE.with(|f| f.borrow_mut().clear());
-    let symbols = SYMBOL_TABLE.with(|f| f.borrow().get_imported_symbols());
-    SYMBOL_TABLE.with(|f| f.borrow_mut().apply_import(&symbols));
+    SYMBOL_TABLE.with(|f| f.borrow_mut().apply_import());
 }
 
 pub fn add_bind(bind: Bind) {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1313,6 +1313,55 @@ fn invalid_import() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InvalidImport { .. }));
+
+    let code = r#"
+    package a_pkg::<a: u32> {
+        const A: u32 = a;
+    }
+    package b_pkg::<b: u32> {
+        alias package a = a_pkg::<b>;
+    }
+    module c_module {
+        import b_pkg::<32>::a;
+        import a::*;
+        const C: u32 = A;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    proto package a_proto_pkg {
+        const A: u32;
+    }
+    package a_pkg::<a: u32> for a_proto_pkg {
+        const A: u32 = a;
+    }
+    proto package b_proto_pkg {
+        alias package a: a_proto_pkg;
+    }
+    package b_pkg::<b: u32> for b_proto_pkg {
+        alias package a = a_pkg::<b>;
+    }
+    module c_module::<pkg: b_proto_pkg> {
+        import pkg::*;
+        import a::*;
+        const C: u32 = A;
+    }
+    module d_module::<pkg: b_proto_pkg> {
+        import pkg::*;
+        import a::A;
+        const D: u32 = A;
+    }
+    module e_module {
+        inst u0: c_module::<b_pkg::<32>>;
+        inst u1: d_module::<b_pkg::<32>>;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -164,9 +164,9 @@ fn is_ifdef_attribute(arg: &Attribute) -> bool {
 }
 
 // SV `import` only accepts `package::symbol` or `package::*`, so suppress
-// imports whose target is an enum (wildcard) or an enum member outside a
-// package — emitting them would produce invalid SystemVerilog.
-fn should_skip_emit_import(arg: &ScopedIdentifier, is_wildcard: bool) -> bool {
+// imports whose target is an enum (wildcard), an enum member or an alias
+// outside a package — emitting them would produce invalid SystemVerilog.
+fn should_skip_import(arg: &ScopedIdentifier, is_wildcard: bool) -> bool {
     let Ok(symbol) = symbol_table::resolve(arg) else {
         return false;
     };
@@ -177,6 +177,12 @@ fn should_skip_emit_import(arg: &ScopedIdentifier, is_wildcard: bool) -> bool {
             .get_parent()
             .and_then(|enum_sym| enum_sym.get_parent())
             .is_none_or(|grandparent| !grandparent.is_package(true)),
+        SymbolKind::AliasModule(_)
+        | SymbolKind::ProtoAliasModule(_)
+        | SymbolKind::AliasInterface(_)
+        | SymbolKind::ProtoAliasInterface(_)
+        | SymbolKind::AliasPackage(_)
+        | SymbolKind::ProtoAliasPackage(_) => !is_wildcard,
         _ => false,
     }
 }
@@ -1040,7 +1046,7 @@ impl Emitter {
 
     fn emit_import_declaration(&mut self, arg: &ImportDeclaration, moved: bool) {
         let is_wildcard = arg.import_declaration_opt.is_some();
-        if should_skip_emit_import(&arg.scoped_identifier, is_wildcard) {
+        if should_skip_import(&arg.scoped_identifier, is_wildcard) {
             return;
         }
 

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -3253,3 +3253,120 @@ endmodule
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
 }
+
+#[test]
+fn imported_alias_package() {
+    let code = r#"
+package a_pkg::<a: u32> {
+    const A: u32 = a;
+}
+package b_pkg::<b: u32> {
+    alias package a = a_pkg::<b>;
+}
+module c_module {
+    import b_pkg::<32>::a;
+    import a::*;
+    const C: u32 = A;
+}
+"#;
+
+    let expect = r#"package prj___a_pkg__32;
+    localparam int unsigned A = 32;
+endpackage
+package prj___b_pkg__32;
+
+
+endpackage
+module prj_c_module;
+
+    import prj___a_pkg__32::*;
+
+
+    localparam int unsigned C = A;
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = if cfg!(windows) {
+        emit(&metadata, code).replace("\r\n", "\n")
+    } else {
+        emit(&metadata, code)
+    };
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
+
+    let code = r#"
+proto package a_proto_pkg {
+    const A: u32;
+}
+package a_pkg::<a: u32> for a_proto_pkg {
+    const A: u32 = a;
+}
+proto package b_proto_pkg {
+    alias package a: a_proto_pkg;
+}
+package b_pkg::<b: u32> for b_proto_pkg {
+    alias package a = a_pkg::<b>;
+}
+module c_module::<pkg: b_proto_pkg> {
+    import pkg::*;
+    import a::*;
+    const C: u32 = A;
+}
+module d_module::<pkg: b_proto_pkg> {
+    import pkg::*;
+    import a::A;
+    const D: u32 = A;
+}
+module e_module {
+    inst u0: c_module::<b_pkg::<32>>;
+    inst u1: d_module::<b_pkg::<32>>;
+}
+"#;
+
+    let expect = r#"
+
+package prj___a_pkg__32;
+    localparam int unsigned A = 32;
+endpackage
+
+
+package prj___b_pkg__32;
+
+
+endpackage
+module prj___c_module____b_pkg__32;
+    import prj___b_pkg__32::*;
+    import prj___a_pkg__32::*;
+
+
+    localparam int unsigned C = prj___a_pkg__32::A;
+endmodule
+module prj___d_module____b_pkg__32;
+    import prj___b_pkg__32::*;
+    import prj___a_pkg__32::A;
+
+
+    localparam int unsigned D = prj___a_pkg__32::A;
+endmodule
+module prj_e_module;
+    prj___c_module____b_pkg__32 u0 ();
+    prj___d_module____b_pkg__32 u1 ();
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = if cfg!(windows) {
+        emit(&metadata, code).replace("\r\n", "\n")
+    } else {
+        emit(&metadata, code)
+    };
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
+}


### PR DESCRIPTION
fix veryl-lang/veryl#2612

Currently, `import` declarations are batch processed.
* Collect target symbols
* Apply wildcard import

Due to this, import declarations whose target is imported from other package are not processed correctly.

To support such use case, import declarations need to be processed sequentialy.