### PR TITLE
Fix analyzer panic happened during `symbol_table::resolve_user_defined`

### DIFF
--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -1172,7 +1172,7 @@ fn conv_function(
         array: Shape::default(),
         arity,
         args,
-        is_const: proeprty.constantable.unwrap(),
+        is_const: proeprty.constantable.unwrap_or_default(),
         functions: body,
         token,
     };

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -2614,6 +2614,56 @@ endmodule
 
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
+
+    let code = r#"
+package a_pkg::<W: p32> {
+    type T = logic<W>;
+}
+package b_pkg::<W: p32> {
+    function func(w: input p32) -> p32 {
+        return w;
+    }
+
+    type T = logic<func(W)>;
+
+    gen AW: p32 = $bits(T);
+    alias package a = a_pkg::<AW>;
+}
+package c_pkg {
+    alias package b = b_pkg::<8>;
+    type T = b::a::T;
+}
+"#;
+
+    let expect = r#"package prj___a_pkg__8;
+    typedef logic [8-1:0] T;
+endpackage
+package prj___b_pkg__8;
+    function automatic int unsigned func(
+        input var int unsigned w
+    ) ;
+        return w;
+    endfunction
+
+    typedef logic [func(8)-1:0] T;
+
+
+
+endpackage
+package prj_c_pkg;
+
+
+    typedef prj___a_pkg__8::T T;
+endpackage
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = emit(&metadata, code);
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2622

Panic showen in #2622 happened during `symbol_table::resolve_user_defined`.

`gen` constant is evaluated during the resolution and `b_pkg::func` is called.
(b::a::T -> a_pkg::<AW> -> $bits(T) -> logic<func(W)>)
However, function constantable has not yet been resolved and is `None`.

To prevent `unwrap` panic, default value `false` should be used for such case.
