### PR TITLE
Fix `mismatch_type` reported for struct member used as generic arg

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -657,7 +657,6 @@ pub fn eval_const_assign(
                         let mut comptime = Comptime::from_type(r#type, ClockDomain::None, token);
                         comptime.is_const = true;
                         let path = x.path.clone();
-                        comptime.part_select = Some(x);
                         context.insert_var_path_with_id(path, id, comptime);
                     }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4048,6 +4048,39 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package ab_pkg {
+        struct a_struct {
+            a: u32,
+        }
+        struct b_struct {
+            b: a_struct,
+        }
+    }
+    proto package c_proto_pkg {
+        const C: ab_pkg::b_struct;
+    }
+    package c_pkg::<a: u32> for c_proto_pkg {
+        const C: ab_pkg::b_struct = ab_pkg::b_struct'{
+            b: ab_pkg::a_struct'{ a: a },
+        };
+    }
+    module d_module::<pkg: c_proto_pkg> {
+        import ab_pkg::*;
+        const C: b_struct = pkg::C;
+        const D: u32      = func_a::<C.b>();
+        function func_a::<a: a_struct>() -> u32 {
+            return a.a;
+        }
+    }
+    module e_module {
+        inst u: d_module::<c_pkg::<32>>;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2626

Struct member (`C.b`) is inserted as part select of struct `C` to the IR context and type of `C.b` is the `b_struct` but not `a_struct`.
Due to this type check of generic arg is failed.

To resolve this, remove `part_select` field from `compime` showing struct member select.
