### PR TITLE
Fix `cyclic_type_dependency` error is reported for path including package alias

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -248,10 +248,10 @@ impl ReferenceTable {
         generic_maps: Option<&Vec<GenericMap>>,
     ) {
         let mut path = path.clone();
-        let mut resolved_generic_maps = vec![];
+        let mut generic_maps = generic_maps.cloned().unwrap_or_default();
 
         let orig_len = path.len();
-        path.resolve_imported(namespace, generic_maps);
+        path.resolve_imported(namespace, Some(&generic_maps));
 
         // Prefix paths added by `resolve_imported` have already been resolved.
         // They should be skipped.
@@ -316,6 +316,25 @@ impl ReferenceTable {
                         continue;
                     }
 
+                    if let Some(mut alias_target) = symbol.found.alias_target(true) {
+                        // If the alias is in a generic instance namespace, include its maps
+                        // so generic parameters in the alias target can be correctly resolved.
+                        let mut alias_maps = generic_maps.clone();
+                        if let Some(ns_sym) = symbol.found.namespace.get_symbol()
+                            && matches!(ns_sym.kind, SymbolKind::GenericInstance(_))
+                        {
+                            alias_maps.extend(ns_sym.generic_maps());
+                        }
+                        alias_target.apply_map(&alias_maps);
+                        self.generic_symbol_path(
+                            &alias_target,
+                            &symbol.found.namespace,
+                            false,
+                            None,
+                            Some(&alias_maps),
+                        );
+                    }
+
                     if (params.len() + n_args) == 0 {
                         continue;
                     }
@@ -329,6 +348,10 @@ impl ReferenceTable {
                     }
 
                     for arg in args.iter_mut() {
+                        // To ensure generic instances are emitted in the correct order,
+                        // generic args must be processed before the base component is processed.
+                        self.generic_symbol_path(arg, namespace, false, None, None);
+
                         arg.unalias(None);
                         // Global function is emitted into the caller namespace.
                         // So namespace expansion is not needed.
@@ -338,13 +361,6 @@ impl ReferenceTable {
                     }
 
                     path.paths[i].arguments.append(&mut args);
-
-                    // To ensure generic instances are emitted in the correct order,
-                    // generic args must be processed before the base component is processed.
-                    for arg in &path.paths[i].arguments {
-                        self.generic_symbol_path(arg, namespace, false, None, None);
-                    }
-
                     if path.is_generic_reference() {
                         Self::add_generic_reference(&target_symbol, namespace, &path, i);
                     } else {
@@ -353,7 +369,7 @@ impl ReferenceTable {
                             i,
                             namespace,
                             &target_symbol,
-                            &mut resolved_generic_maps,
+                            &mut generic_maps,
                             None,
                         );
                     }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -26,6 +26,45 @@ fn analyze(code: &str) -> Vec<AnalyzerError> {
 }
 
 #[track_caller]
+fn analyze_multiple_inputs(inputs: &[&str]) -> Vec<AnalyzerError> {
+    symbol_table::clear();
+    attribute_table::clear();
+
+    let prj_name = "prj";
+    let metadata = Metadata::create_default(prj_name).unwrap();
+
+    let mut contexts = vec![];
+    let mut errors = vec![];
+    for i in 0..inputs.len() {
+        let path = format!("test_{}.veryl", i);
+
+        let parser = Parser::parse(inputs[i], &path).unwrap();
+        let analyzer = Analyzer::new(&metadata);
+        errors.append(&mut analyzer.analyze_pass1(&prj_name, &parser.veryl));
+
+        contexts.push((parser, analyzer));
+    }
+
+    errors.append(&mut Analyzer::analyze_post_pass1());
+
+    let mut analyzer_context = Context::default();
+    let mut ir = Ir::default();
+    for (parser, analyzer) in &contexts {
+        errors.append(&mut analyzer.analyze_pass2(
+            &prj_name,
+            &parser.veryl,
+            &mut analyzer_context,
+            Some(&mut ir),
+        ));
+    }
+
+    errors.append(&mut Analyzer::analyze_post_pass2(&ir));
+
+    dbg!(&errors);
+    errors
+}
+
+#[track_caller]
 fn analyze_with_ir(code: &str) -> Vec<AnalyzerError> {
     symbol_table::clear();
     attribute_table::clear();
@@ -688,6 +727,44 @@ fn cyclic_type_dependency() {
     "#;
 
     let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let code = r#"
+    package c_pkg::<c0: u32, c1: u32> {
+        const C0: u32 = c0;
+        const C1: u32 = c1;
+    }
+    package b_pkg::<b0: u32, b1: u32> {
+        alias package c = c_pkg::<b0, b1>;
+    }
+    alias package c = c_pkg::<b_pkg::<1, 2>::c::C0, 3>;
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
+    let mut inputs = vec![];
+    inputs.push(
+        r#"
+        alias package d = d_pkg::<b_pkg::c::d::D0, 3>;
+        "#,
+    );
+    inputs.push(
+        r#"
+        package d_pkg::<d0: u32, d1: u32> {
+            const D0: u32 = d0;
+            const D1: u32 = d1;
+        }
+        package c_pkg::<c0: u32, c1: u32> {
+            alias package d = d_pkg::<c0, c1>;
+        }
+        package b_pkg {
+            alias package c = c_pkg::<1, 2>;
+        }
+        "#,
+    );
+
+    let errors = analyze_multiple_inputs(&inputs);
     assert!(errors.is_empty());
 }
 


### PR DESCRIPTION
fix veryl-lang/veryl#2630

When a generic argument contains a path through a package alias (e.g., b_pkg::c::d::D0), `unalias` needs the generic instance symbols along the alias chain to already be registered in the symbol table.
In the original code, `generic_symbol_path` — which performs registration — was called after `unalias`, so when `unalias` attempted to expand `b_pkg::c` → `c_pkg::<1, 2>`, the instance `c_pkg::<1, 2>` was not yet registered.
As a result, the chain could not be fully resolved and stopped midway at `c_pkg::<1, 2>::d::D0` instead of reaching the final `d_pkg::<...>::D0`.
This incomplete resolution created a false circular reference between `c_pkg` and `d_pkg`, which the analyzer reported as cyclic_type_dependency.

The fix moves `generic_symbol_path` to run before `unalias` for each generic argument, and also adds pre-processing of alias targets so that all generic instances in the chain are registered before resolution is attempted.