### PR TITLE
Add `VERYL_FORCE_SUCCESS` env variable

### DIFF
--- a/crates/veryl/src/main.rs
+++ b/crates/veryl/src/main.rs
@@ -89,27 +89,27 @@ fn main() -> Result<ExitCode> {
     let mut stopwatch = StopWatch::new();
 
     let ret = match opt.command {
-        Commands::New(x) => cmd_new::CmdNew::new(x).exec()?,
-        Commands::Init(x) => cmd_init::CmdInit::new(x).exec()?,
-        Commands::Fmt(x) => cmd_fmt::CmdFmt::new(x).exec(&mut metadata, opt.quiet)?,
-        Commands::Check(x) => cmd_check::CmdCheck::new(x).exec(&mut metadata)?,
+        Commands::New(x) => cmd_new::CmdNew::new(x).exec(),
+        Commands::Init(x) => cmd_init::CmdInit::new(x).exec(),
+        Commands::Fmt(x) => cmd_fmt::CmdFmt::new(x).exec(&mut metadata, opt.quiet),
+        Commands::Check(x) => cmd_check::CmdCheck::new(x).exec(&mut metadata),
         Commands::Build(x) => {
             let ret =
                 cmd_build::CmdBuild::new(x).exec(&mut metadata, false, opt.quiet, None, None, &[]);
             metadata.build_info.veryl_version = Some(veryl_metadata::VERYL_VERSION.to_string());
             metadata.save_build_info()?;
-            ret?
+            ret
         }
-        Commands::Clean(x) => cmd_clean::CmdClean::new(x).exec(&mut metadata)?,
-        Commands::Update(x) => cmd_update::CmdUpdate::new(x).exec(&mut metadata)?,
-        Commands::Publish(x) => cmd_publish::CmdPublish::new(x).exec(&mut metadata)?,
-        Commands::Migrate(x) => cmd_migrate::CmdMigrate::new(x).exec(&mut metadata, opt.quiet)?,
-        Commands::Doc(x) => cmd_doc::CmdDoc::new(x).exec(&mut metadata)?,
-        Commands::Metadata(x) => cmd_metadata::CmdMetadata::new(x).exec(&metadata)?,
-        Commands::Dump(x) => cmd_dump::CmdDump::new(x).exec(&mut metadata)?,
-        Commands::Test(x) => cmd_test::CmdTest::new(x).exec(&mut metadata)?,
-        Commands::Synth(x) => cmd_synth::CmdSynth::new(x).exec(&mut metadata)?,
-        Commands::Translate(x) => cmd_translate::CmdTranslate::new(x).exec()?,
+        Commands::Clean(x) => cmd_clean::CmdClean::new(x).exec(&mut metadata),
+        Commands::Update(x) => cmd_update::CmdUpdate::new(x).exec(&mut metadata),
+        Commands::Publish(x) => cmd_publish::CmdPublish::new(x).exec(&mut metadata),
+        Commands::Migrate(x) => cmd_migrate::CmdMigrate::new(x).exec(&mut metadata, opt.quiet),
+        Commands::Doc(x) => cmd_doc::CmdDoc::new(x).exec(&mut metadata),
+        Commands::Metadata(x) => cmd_metadata::CmdMetadata::new(x).exec(&metadata),
+        Commands::Dump(x) => cmd_dump::CmdDump::new(x).exec(&mut metadata),
+        Commands::Test(x) => cmd_test::CmdTest::new(x).exec(&mut metadata),
+        Commands::Synth(x) => cmd_synth::CmdSynth::new(x).exec(&mut metadata),
+        Commands::Translate(x) => cmd_translate::CmdTranslate::new(x).exec(),
     };
 
     if let Some(dot_build_lock) = dot_build_lock {
@@ -118,7 +118,8 @@ fn main() -> Result<ExitCode> {
 
     debug!("Elapsed time ({} milliseconds)", stopwatch.lap());
 
-    if ret {
+    let exit_success = std::env::var("VERYL_FORCE_SUCCESS").is_ok();
+    if exit_success || ret? {
         Ok(ExitCode::SUCCESS)
     } else {
         Ok(ExitCode::FAILURE)


### PR DESCRIPTION
When `veryl` command is used with a debugging tool (e.g. `flamegraph`), exit code from the command needs to be `success` even if errors because such tool requires exit code should be `success`.
Env variable `VERYL_FORCE_SUCCESS` is added for this case.