### PR TITLE
Add profiler for `analyzer_pass2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6263,6 +6263,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
+ "serde",
  "serde_json",
  "similar 3.1.0",
  "smallvec",

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -27,7 +27,9 @@ smallvec         = {workspace = true}
 strnum_bitwidth  = {workspace = true}
 strum            = "0.28.0"
 strum_macros     = "0.28.0"
+serde            = {workspace = true}
 serde_json       = {workspace = true}
+toml             = {workspace = true}
 thiserror        = {workspace = true}
 vcd              = {workspace = true}
 veryl-metadata   = {version = "0.20.0", path = "../metadata"}

--- a/crates/analyzer/src/conv.rs
+++ b/crates/analyzer/src/conv.rs
@@ -1,5 +1,6 @@
 pub mod checker;
 mod context;
+pub mod conv_profiler;
 pub mod declaration;
 pub mod expression;
 pub mod instance;

--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -1,4 +1,5 @@
 use crate::analyzer_error::{AnalyzerError, ExceedLimitKind};
+use crate::conv::conv_profiler::{ConvProfile, ConvProfileGuard};
 use crate::conv::instance::{InstanceHistory, InstanceHistoryError};
 use crate::ir::{
     Component, Comptime, Declaration, Expression, FfClock, FfReset, FuncPath, Function, Interface,
@@ -11,7 +12,8 @@ use crate::symbol::{Affiliation, ClockDomain, Direction, GenericMap, SymbolId};
 use crate::symbol_path::GenericSymbolPath;
 use crate::value::MaskCache;
 use crate::{HashMap, HashSet};
-use std::sync::Arc;
+use miette::Result;
+use std::sync::{Arc, Mutex};
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
 use veryl_parser::veryl_token::Token;
@@ -76,6 +78,8 @@ pub struct Context {
     overrides: Vec<HashMap<VarPath, (Comptime, Expression)>>,
     generic_maps: Vec<Vec<GenericMap>>,
     errors: Vec<AnalyzerError>,
+    profiler: Option<Arc<Mutex<ConvProfile>>>,
+    project_name: Option<String>,
 }
 
 impl Context {
@@ -89,6 +93,37 @@ impl Context {
         self.in_generic = tgt.in_generic;
         self.allow_component_as_factor = tgt.allow_component_as_factor;
         self.config = tgt.config.clone();
+        self.profiler = tgt.profiler.clone();
+        self.project_name = tgt.project_name.clone();
+    }
+
+    pub fn set_project_name(&mut self, project_name: &str) {
+        self.project_name = Some(project_name.to_string());
+    }
+
+    pub fn enable_conv_profiler(&mut self) {
+        if std::env::var("VERYL_CONV_PROFILE").is_ok() {
+            self.profiler = Some(Arc::new(Mutex::new(ConvProfile::default())));
+        }
+    }
+
+    pub fn conv_profile_guard(&self, component_name: StrId) -> Option<ConvProfileGuard> {
+        self.profiler.as_ref().map(|p| {
+            let key = format!(
+                "{}::{}",
+                self.project_name.as_deref().unwrap_or("unknown"),
+                component_name
+            );
+            ConvProfileGuard::new(Arc::clone(p), key)
+        })
+    }
+
+    pub fn finalize_conv_profiler(&self) -> Result<()> {
+        if let Some(profiler) = self.profiler.as_ref().map(|p| p.lock().unwrap()) {
+            profiler.to_toml_file(&std::env::var("VERYL_CONV_PROFILE").unwrap())
+        } else {
+            Ok(())
+        }
     }
 
     pub fn get_override(&self, x: &VarPath) -> Option<&(Comptime, Expression)> {

--- a/crates/analyzer/src/conv/conv_profiler.rs
+++ b/crates/analyzer/src/conv/conv_profiler.rs
@@ -1,0 +1,74 @@
+use crate::HashMap;
+use miette::{self, IntoDiagnostic, Result, WrapErr};
+use serde::Serialize;
+use std::fs;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Default, Serialize)]
+pub struct ConvStats {
+    pub count: u64,
+    pub total_us: u64,
+    pub avg_us: u64,
+    pub min_us: u64,
+    pub max_us: u64,
+}
+
+#[derive(Clone, Default)]
+pub struct ConvProfile {
+    pub entries: HashMap<String, ConvStats>,
+}
+
+impl ConvProfile {
+    pub fn record(&mut self, name: &str, duration: Duration) {
+        let us = duration.as_micros() as u64;
+        let entry = self.entries.entry(name.to_string()).or_default();
+        if entry.count == 0 {
+            entry.min_us = us;
+            entry.max_us = us;
+        } else {
+            entry.min_us = entry.min_us.min(us);
+            entry.max_us = entry.max_us.max(us);
+        }
+        entry.total_us += us;
+        entry.count += 1;
+        entry.avg_us = entry.total_us / entry.count;
+    }
+
+    pub fn to_toml_file(&self, path: &str) -> Result<()> {
+        let toml_string = self.to_toml_string();
+        fs::write(path, toml_string)
+            .into_diagnostic()
+            .wrap_err(format!("Failed to write conv profile to {path}"))
+    }
+
+    pub fn to_toml_string(&self) -> String {
+        use std::collections::BTreeMap;
+        let output: BTreeMap<_, _> = self.entries.iter().collect();
+        toml::to_string(&output).unwrap_or_default()
+    }
+}
+
+pub struct ConvProfileGuard {
+    profiler: Arc<Mutex<ConvProfile>>,
+    name: String,
+    start: Instant,
+}
+
+impl ConvProfileGuard {
+    pub fn new(profiler: Arc<Mutex<ConvProfile>>, name: impl Into<String>) -> Self {
+        Self {
+            profiler,
+            name: name.into(),
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for ConvProfileGuard {
+    fn drop(&mut self) {
+        if let Ok(mut p) = self.profiler.lock() {
+            p.record(&self.name, self.start.elapsed());
+        }
+    }
+}

--- a/crates/analyzer/src/conv/ir.rs
+++ b/crates/analyzer/src/conv/ir.rs
@@ -125,6 +125,8 @@ impl Conv<&ModuleDeclaration> for ir::Module {
         let mut context = Context::default();
         context.inherit(upper_context);
 
+        let _guard = context.conv_profile_guard(value.identifier.text());
+
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::Module);
 
@@ -243,6 +245,8 @@ impl Conv<&InterfaceDeclaration> for ir::Interface {
         let mut context = Context::default();
         context.inherit(upper_context);
 
+        let _guard = context.conv_profile_guard(value.identifier.text());
+
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::Interface);
 
@@ -326,6 +330,8 @@ impl Conv<&PackageDeclaration> for () {
         let upper_context = context;
         let mut context = Context::default();
         context.inherit(upper_context);
+
+        let _guard = context.conv_profile_guard(value.identifier.text());
 
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::Package);

--- a/crates/veryl/src/cmd_build.rs
+++ b/crates/veryl/src/cmd_build.rs
@@ -109,12 +109,15 @@ impl CmdBuild {
         }
 
         let mut analyzer_context = veryl_analyzer::Context::default();
+
         for name in defines {
             analyzer_context
                 .config
                 .defines
                 .insert(resource_table::insert_str(name));
         }
+        analyzer_context.enable_conv_profiler();
+
         // Build a local IR when the caller didn't supply one, so the
         // post-pass2 combinational-loop check has something to inspect.
         // This is cheap relative to the rest of pass2 because most of
@@ -128,6 +131,7 @@ impl CmdBuild {
         for context in &contexts {
             if !context.skip {
                 let path = &context.path;
+                analyzer_context.set_project_name(&path.prj);
                 let mut errors = context.analyzer.analyze_pass2(
                     &path.prj,
                     &context.parser.veryl,
@@ -139,6 +143,7 @@ impl CmdBuild {
         }
 
         debug!("Executed analyze_pass2 ({} milliseconds)", stopwatch.lap());
+        analyzer_context.finalize_conv_profiler()?;
 
         let mut errors = Analyzer::analyze_post_pass2(ir_for_pass2);
         check_error = check_error.append(&mut errors).check_err()?;

--- a/crates/veryl/src/cmd_check.rs
+++ b/crates/veryl/src/cmd_check.rs
@@ -104,9 +104,12 @@ impl CmdCheck {
         );
 
         let mut analyzer_context = veryl_analyzer::Context::default();
+        analyzer_context.enable_conv_profiler();
+
         let mut ir = veryl_analyzer::ir::Ir::default();
         for context in &contexts {
             let path = &context.path;
+            analyzer_context.set_project_name(&path.prj);
             let mut errors = context.analyzer.analyze_pass2(
                 &path.prj,
                 &context.parser.veryl,
@@ -117,6 +120,7 @@ impl CmdCheck {
         }
 
         debug!("Executed analyze_pass2 ({} milliseconds)", stopwatch.lap());
+        analyzer_context.finalize_conv_profiler()?;
 
         let mut errors = Analyzer::analyze_post_pass2(&ir);
         check_error = check_error.append(&mut errors).check_err()?;


### PR DESCRIPTION
Converting AST to IR is one of main routines in `analyze` phase. Profiler for `analyze_pass2` is added to analyze performance of IR conversion.
It collects elapsed time to convert AST to IR for each compoenent declarations and output them to TOML file.