### PR TITLE
Implement modport parameter override

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -16,6 +16,7 @@ use miette::Result;
 use std::sync::{Arc, Mutex};
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
+use veryl_parser::veryl_grammar_trait::{ComponentInstantiation, Identifier};
 use veryl_parser::veryl_token::Token;
 
 #[derive(Clone)]
@@ -54,6 +55,8 @@ pub struct Context {
     pub declarations: Vec<Declaration>,
     pub default_clock: Option<(VarPath, SymbolId)>,
     pub default_reset: Option<(VarPath, SymbolId)>,
+    pub inst_signatures: HashMap<StrId, Signature>,
+    pub modport_signatures: Vec<HashMap<StrId, Signature>>,
     pub instance_history: InstanceHistory,
     pub select_paths: Vec<(VarPath, GenericSymbolPath)>,
     pub select_dims: Vec<usize>,
@@ -86,6 +89,7 @@ impl Context {
     pub fn inherit(&mut self, tgt: &mut Context) {
         std::mem::swap(&mut self.overrides, &mut tgt.overrides);
         std::mem::swap(&mut self.generic_maps, &mut tgt.generic_maps);
+        std::mem::swap(&mut self.modport_signatures, &mut tgt.modport_signatures);
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
         std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);
@@ -412,6 +416,49 @@ impl Context {
             } else {
                 None
             }
+        } else {
+            None
+        }
+    }
+
+    pub fn insert_inst_signature(&mut self, identifier: &Identifier, sig: &Signature) {
+        self.inst_signatures.insert(identifier.text(), sig.clone());
+    }
+
+    pub fn collect_modport_signatures(&mut self, inst: &ComponentInstantiation) {
+        let mut signatures = HashMap::default();
+        if !self.inst_signatures.is_empty()
+            && let Some(ref opt2) = inst.component_instantiation_opt2
+            && let Some(ref port_opt) = opt2.inst_port.inst_port_opt
+        {
+            let port_items: Vec<_> = port_opt.inst_port_list.as_ref().into();
+            for port_item in &port_items {
+                let inst_name = if let Some(ref x) = port_item.inst_port_item_opt {
+                    let Some(identifier) = x.expression.unwrap_identifier().map(|x| x.identifier())
+                    else {
+                        continue;
+                    };
+                    identifier.token.text
+                } else {
+                    port_item.identifier.text()
+                };
+                if let Some(sig) = self.inst_signatures.get(&inst_name) {
+                    let port_name = port_item.identifier.text();
+                    signatures.insert(port_name, sig.clone());
+                }
+            }
+        }
+
+        self.modport_signatures.push(signatures);
+    }
+
+    pub fn pop_modport_signatures(&mut self) {
+        self.modport_signatures.pop();
+    }
+
+    pub fn get_modport_signature(&self, port_identifier: &Identifier) -> Option<Signature> {
+        if let Some(signatures) = self.modport_signatures.last() {
+            signatures.get(&port_identifier.text()).cloned()
         } else {
             None
         }

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -490,7 +490,13 @@ impl Conv<&PortDeclarationItem> for () {
                 Direction::Modport => {
                     match &r#type.kind {
                         ir::TypeKind::Modport(sig, name) => {
-                            let component = get_component(context, sig, token)?;
+                            let component = if let Some(sig) =
+                                context.get_modport_signature(&value.identifier)
+                            {
+                                get_component(context, &sig, token)?
+                            } else {
+                                get_component(context, sig, token)?
+                            };
                             let base = value.identifier.text();
                             let ir::Component::Interface(component) = component.as_ref() else {
                                 return Err(ir_error!(token));
@@ -1413,10 +1419,12 @@ impl Conv<&InstDeclaration> for ir::Declaration {
         }
 
         context.push_override(overridden_params);
+        context.collect_modport_signatures(value);
 
         let component = context.block(|c| get_component(c, &sig, token));
 
         context.pop_override();
+        context.pop_modport_signatures();
 
         let component_arc = component?;
         match component_arc.as_ref() {
@@ -1474,8 +1482,6 @@ impl Conv<&InstDeclaration> for ir::Declaration {
                     }
                 }
 
-                // TOOD modport parameter override
-
                 let name = value.identifier.text();
                 Ok(ir::Declaration::Inst(Box::new(ir::InstDeclaration {
                     name,
@@ -1485,6 +1491,8 @@ impl Conv<&InstDeclaration> for ir::Declaration {
                 })))
             }
             ir::Component::Interface(component) => {
+                context.insert_inst_signature(value.identifier.as_ref(), &sig);
+
                 let mut array = Shape::default();
                 if let Some(x) = &value.component_instantiation_opt0 {
                     let exprs: Vec<_> = x.array.as_ref().into();

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -743,6 +743,88 @@ fn interface() {
 "#;
 
     check_ir(code, exp);
+
+    let code = r#"
+    interface InterfaceA #(
+        param WIDTH: u32 = 8,
+    ) {
+        var a: logic<WIDTH>;
+        modport mp_i {
+            a: input,
+        }
+        modport mp_o {
+            a: output,
+        }
+    }
+    module ModuleA #(
+        param WIDTH: u32 = 8,
+    ) (
+        a: modport InterfaceA::mp_i,
+        b: modport InterfaceA::mp_o,
+    ) {
+        always_comb {
+            for i in 0..(WIDTH / 32) {
+                b.a[i step 32] = a.a[i step 32];
+            }
+        }
+    }
+    module ModuleB {
+        inst a: InterfaceA #(WIDTH: 128);
+        inst b: InterfaceA #(WIDTH: 128);
+
+        assign a.a = '0;
+
+        inst u: ModuleA #(
+            WIDTH: 128,
+        )(
+            a: a,
+            b: b,
+        );
+    }
+    "#;
+
+    let exp = r#"module ModuleA {
+  param var0(WIDTH): bit<32> = 32'sh00000008;
+  input var1(a.a): logic<8> = 8'hxx;
+  output var6(b.a): logic<8> = 8'hxx;
+
+  comb {
+  }
+}
+module ModuleB {
+  param var0(a.WIDTH): bit<32> = 32'sh00000080;
+  var var1(a.a): logic<128> = 128'hxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  param var5(b.WIDTH): bit<32> = 32'sh00000080;
+  var var6(b.a): logic<128> = 128'hxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+
+  comb {
+    var1 = '0;
+  }
+  inst u (
+    var1 <- var1;
+    var6 -> var6;
+  ) {
+    module ModuleA {
+      param var0(WIDTH): bit<32> = 32'sh00000080;
+      input var1(a.a): logic<128> = 128'hxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+      output var6(b.a): logic<128> = 128'hxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+      const var11([0].i): signed bit<32> = 32'sh00000000;
+      const var12([1].i): signed bit<32> = 32'sh00000001;
+      const var13([2].i): signed bit<32> = 32'sh00000002;
+      const var14([3].i): signed bit<32> = 32'sh00000003;
+
+      comb {
+        var6[32'sh00000000 step 32'sh00000020] = var1[32'sh00000000 step 32'sh00000020];
+        var6[32'sh00000001 step 32'sh00000020] = var1[32'sh00000001 step 32'sh00000020];
+        var6[32'sh00000002 step 32'sh00000020] = var1[32'sh00000002 step 32'sh00000020];
+        var6[32'sh00000003 step 32'sh00000020] = var1[32'sh00000003 step 32'sh00000020];
+      }
+    }
+  }
+}
+"#;
+
+    check_ir(code, exp);
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2643

When an instance of paramterized interface is connected to a port, its inst paramters should be propagated into the connected module.
This PR is to implement it.
