### PR TITLE
Remove deprecated --trace-threads 2 flag in cocotb runner

### DIFF
--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -170,10 +170,7 @@ impl Runner for Cocotb {
 
         let (py_waves, args) = match wave.then_some(metadata.test.waveform_format) {
             Some(WaveFormFormat::Vcd) => ("True", "['--trace']"),
-            Some(WaveFormFormat::Fst) => (
-                "True",
-                "['--trace-fst', '--trace-structs', '--trace-threads', '2']",
-            ),
+            Some(WaveFormFormat::Fst) => ("True", "['--trace-fst', '--trace-structs']"),
             None => ("False", "[]"),
         };
         let runner_path = temp_dir.path().join("runner.py");


### PR DESCRIPTION
Starting with verilator 5.048, the `--trace-threads` flag is deprecated: https://verilator.org/guide/latest/exe_verilator.html#cmdoption-trace-threads

When using cocotb to run tests, warnings are rejected by default with no easy way to allow some lints through. Therefore using FST traces results in errors.

Removing the `--trace-threads` flag would allow using older versions of verilator (albeit with a small performance hit), while enabling the use of 5.048 and onwards.