### PR TITLE
Add config parameter to enable/disable language server

### DIFF
--- a/support/vscode/package-lock.json
+++ b/support/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veryl-vscode",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veryl-vscode",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
@@ -967,6 +967,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1426,6 +1427,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2435,6 +2437,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5787,6 +5790,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5905,6 +5909,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/support/vscode/package.json
+++ b/support/vscode/package.json
@@ -73,6 +73,12 @@
       {
         "title": "Veryl Language Server",
         "properties": {
+          "veryl-vscode.enabled": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable or disable the Veryl language server."
+          },
           "veryl-vscode.verylLsBinary.path": {
             "scope": "window",
             "type": [

--- a/support/vscode/src/extension.ts
+++ b/support/vscode/src/extension.ts
@@ -17,6 +17,18 @@ import { start } from 'repl';
 
 let client: LanguageClient;
 
+function isLanguageServerEnabled(): boolean {
+	return workspace.getConfiguration("veryl-vscode").get("enabled") ?? true;
+}
+
+function applyLanguageServerState(context: vscode.ExtensionContext) {
+	if (isLanguageServerEnabled()) {
+		startServer(context);
+	} else {
+		stopServer();
+	}
+}
+
 function startServer(context: vscode.ExtensionContext) {
 	let verylLsIntegrated = context.asAbsolutePath(path.join('bin', 'veryl-ls'));
 
@@ -74,6 +86,15 @@ export function activate(context: vscode.ExtensionContext) {
 			stopServer().then(function () {startServer(context);}, startServer);
 		})
 	);
+
+	context.subscriptions.push(
+		workspace.onDidChangeConfiguration(event => {
+			if (event.affectsConfiguration("veryl-vscode.enabled")) {
+				applyLanguageServerState(context);
+			}
+		})
+	);
+
   // Added by Kalyan for Waveform Render start
 	// Start and live preview mode
 	context.subscriptions.push(
@@ -117,7 +138,7 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 	// Added by Kalyan for Waveform Render start
 
-	startServer(context);
+	applyLanguageServerState(context);
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
Add the ability to disable the Veryl language server via the `veryl-vscode.enabled` parameter, so users can suppress resource usage when language server features are not needed.