### PR TITLE
Add --out-dir option to veryl build for redirecting output location

### DIFF
--- a/crates/metadata/src/metadata.rs
+++ b/crates/metadata/src/metadata.rs
@@ -66,6 +66,11 @@ pub struct Metadata {
     pub lockfile: Lockfile,
     #[serde(skip)]
     pub build_info: BuildInfo,
+    /// Output base directory override (e.g. `veryl build --base-dir`).
+    /// When set, build outputs are emitted relative to this directory
+    /// instead of the project path. Never read from Veryl.toml.
+    #[serde(skip)]
+    pub output_base_override: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -310,6 +315,12 @@ impl Metadata {
         };
 
         let base = self.project_path();
+        // Build outputs may be redirected (e.g. `veryl build --base-dir`);
+        // sources are always resolved against the project path.
+        let out_base = self
+            .output_base_override
+            .clone()
+            .unwrap_or_else(|| base.clone());
         let mut ret = Vec::new();
 
         // Pre-canonicalize explicit file args once so we can route each to
@@ -354,21 +365,29 @@ impl Metadata {
                     return Err(MetadataError::InvalidSourceLocation(src));
                 };
                 let dst = match self.build.target {
-                    Target::Source => src.with_extension("sv"),
-                    Target::Directory { ref path } => {
-                        base.join(path.join(src_relative.with_extension("sv")))
+                    Target::Source => {
+                        if self.output_base_override.is_some() {
+                            // Redirected source-target builds keep the
+                            // source-relative layout under the override.
+                            out_base.join(src_relative.with_extension("sv"))
+                        } else {
+                            src.with_extension("sv")
+                        }
                     }
-                    Target::Bundle { .. } => base.join(
+                    Target::Directory { ref path } => {
+                        out_base.join(path.join(src_relative.with_extension("sv")))
+                    }
+                    Target::Bundle { .. } => out_base.join(
                         PathBuf::from("target").join(src.with_extension("sv").file_name().unwrap()),
                     ),
                 };
                 let map = match &self.build.sourcemap_target {
                     SourceMapTarget::Directory { path } => {
                         if let Target::Directory { .. } = self.build.target {
-                            base.join(path.join(src_relative.with_extension("sv.map")))
+                            out_base.join(path.join(src_relative.with_extension("sv.map")))
                         } else {
-                            let dst = dst.strip_prefix(&base).unwrap();
-                            base.join(path.join(dst.with_extension("sv.map")))
+                            let dst = dst.strip_prefix(&out_base).unwrap();
+                            out_base.join(path.join(dst.with_extension("sv.map")))
                         }
                     }
                     _ => {

--- a/crates/metadata/src/metadata.rs
+++ b/crates/metadata/src/metadata.rs
@@ -66,11 +66,11 @@ pub struct Metadata {
     pub lockfile: Lockfile,
     #[serde(skip)]
     pub build_info: BuildInfo,
-    /// Output base directory override (e.g. `veryl build --base-dir`).
+    /// Output directory override (e.g. `veryl build --out-dir`).
     /// When set, build outputs are emitted relative to this directory
     /// instead of the project path. Never read from Veryl.toml.
     #[serde(skip)]
-    pub output_base_override: Option<PathBuf>,
+    pub output_dir_override: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -315,12 +315,9 @@ impl Metadata {
         };
 
         let base = self.project_path();
-        // Build outputs may be redirected (e.g. `veryl build --base-dir`);
+        // Build outputs may be redirected (e.g. `veryl build --out-dir`);
         // sources are always resolved against the project path.
-        let out_base = self
-            .output_base_override
-            .clone()
-            .unwrap_or_else(|| base.clone());
+        let out_base = self.output_dir();
         let mut ret = Vec::new();
 
         // Pre-canonicalize explicit file args once so we can route each to
@@ -366,7 +363,7 @@ impl Metadata {
                 };
                 let dst = match self.build.target {
                     Target::Source => {
-                        if self.output_base_override.is_some() {
+                        if self.output_dir_override.is_some() {
                             // Redirected source-target builds keep the
                             // source-relative layout under the override.
                             out_base.join(src_relative.with_extension("sv"))
@@ -413,9 +410,9 @@ impl Metadata {
             return Err(MetadataError::InvalidSourceLocation(cf[pos].clone()));
         }
 
-        let base_dst = self.project_dependencies_path();
+        let base_dst = self.output_dependencies_path();
         if !base_dst.exists() {
-            ignore_already_exists(fs::create_dir(&base_dst))
+            ignore_already_exists(fs::create_dir_all(&base_dst))
                 .map_err(|x| MetadataError::file_io(x, &base_dst))?;
         }
 
@@ -468,8 +465,18 @@ obj_dir/
         self.metadata_path.parent().unwrap().to_path_buf()
     }
 
+    pub fn output_dir(&self) -> PathBuf {
+        self.output_dir_override
+            .clone()
+            .unwrap_or_else(|| self.project_path())
+    }
+
     pub fn project_dependencies_path(&self) -> PathBuf {
         self.project_path().join("dependencies")
+    }
+
+    pub fn output_dependencies_path(&self) -> PathBuf {
+        self.output_dir().join("dependencies")
     }
 
     pub fn project_dot_build_path(&self) -> PathBuf {
@@ -487,7 +494,7 @@ obj_dir/
             FilelistType::Flgen => format!("{}.list.rb", self.project.name),
         };
 
-        self.metadata_path.with_file_name(filelist_name)
+        self.output_dir().join(filelist_name)
     }
 
     pub fn doc_path(&self) -> PathBuf {

--- a/crates/veryl/src/cmd_build.rs
+++ b/crates/veryl/src/cmd_build.rs
@@ -37,16 +37,17 @@ impl CmdBuild {
         test_filter: Option<&str>,
         defines: &[String],
     ) -> Result<bool> {
-        if let Some(ref base_dir) = self.opt.base_dir {
-            let base_dir = if base_dir.is_absolute() {
-                base_dir.clone()
+        if let Some(ref out_dir) = self.opt.out_dir {
+            let out_dir = if out_dir.is_absolute() {
+                out_dir.clone()
             } else {
                 std::env::current_dir()
                     .into_diagnostic()
                     .wrap_err("")?
-                    .join(base_dir)
+                    .join(out_dir)
             };
-            metadata.output_base_override = Some(base_dir);
+            std::fs::create_dir_all(&out_dir).into_diagnostic()?;
+            metadata.output_dir_override = Some(out_dir.canonicalize().into_diagnostic()?);
         }
 
         let paths = metadata.paths(&self.opt.files, true, true)?;
@@ -176,16 +177,13 @@ impl CmdBuild {
             if !context.skip {
                 let path = &context.path;
                 let (dst, map) = if let Some(ref temp_dir) = temp_dir {
-                    let dst_temp = temp_dir.path().join(
-                        path.dst
-                            .strip_prefix(metadata.project_path())
-                            .into_diagnostic()?,
-                    );
-                    let map_temp = temp_dir.path().join(
-                        path.map
-                            .strip_prefix(metadata.project_path())
-                            .into_diagnostic()?,
-                    );
+                    let output_dir = metadata.output_dir();
+                    let dst_temp = temp_dir
+                        .path()
+                        .join(path.dst.strip_prefix(&output_dir).into_diagnostic()?);
+                    let map_temp = temp_dir
+                        .path()
+                        .join(path.map.strip_prefix(&output_dir).into_diagnostic()?);
                     (dst_temp, map_temp)
                 } else {
                     (path.dst.clone(), path.map.clone())
@@ -252,13 +250,16 @@ impl CmdBuild {
     }
 
     fn gen_filelist_line(&self, metadata: &Metadata, path: &Path) -> Result<String> {
-        let base_path = metadata.project_path();
+        let base_path = metadata.output_dir();
         let path = path.canonicalize().into_diagnostic()?;
-        let relative = path.strip_prefix(&base_path).into_diagnostic()?;
         Ok(match metadata.build.filelist_type {
             FilelistType::Absolute => format!("{}\n", path.to_string_lossy()),
-            FilelistType::Relative => format!("{}\n", relative.to_string_lossy()),
+            FilelistType::Relative => {
+                let relative = path.strip_prefix(&base_path).into_diagnostic()?;
+                format!("{}\n", relative.to_string_lossy())
+            }
             FilelistType::Flgen => {
+                let relative = path.strip_prefix(&base_path).into_diagnostic()?;
                 format!("source_file '{}'\n", relative.to_string_lossy())
             }
         })
@@ -272,7 +273,7 @@ impl CmdBuild {
         include_tests: bool,
     ) -> Result<()> {
         let filelist_path = metadata.filelist_path();
-        let base_path = metadata.project_path();
+        let base_path = metadata.output_dir();
 
         let paths = Self::sort_filelist(metadata, paths, include_tests);
 
@@ -289,6 +290,11 @@ impl CmdBuild {
                 text.push_str(&fs::read_to_string(&dst).into_diagnostic()?);
             }
 
+            if let Some(parent) = target_path.parent()
+                && !parent.exists()
+            {
+                std::fs::create_dir_all(parent).into_diagnostic()?;
+            }
             let written = utils::write_file_if_changed(&target_path, text.as_bytes())?;
             if written {
                 debug!("Output file ({})", target_path.to_string_lossy());
@@ -306,6 +312,11 @@ impl CmdBuild {
             text
         };
 
+        if let Some(parent) = filelist_path.parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent).into_diagnostic()?;
+        }
         utils::write_file_if_changed(&filelist_path, text.as_bytes())?;
 
         info!("Output filelist ({})", filelist_path.to_string_lossy());
@@ -406,5 +417,144 @@ impl CmdBuild {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static BUILD_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct CurrentDirGuard {
+        path: PathBuf,
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.path).unwrap();
+        }
+    }
+
+    fn set_current_dir(path: &Path) -> CurrentDirGuard {
+        let current = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        CurrentDirGuard { path: current }
+    }
+
+    fn create_project(root: &Path, name: &str, filelist_type: FilelistType) -> (Metadata, PathBuf) {
+        let project_path = root.join(name);
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+
+        let filelist_type = match filelist_type {
+            FilelistType::Absolute => "absolute",
+            FilelistType::Relative => "relative",
+            FilelistType::Flgen => "flgen",
+        };
+        fs::write(
+            project_path.join("Veryl.toml"),
+            format!(
+                r#"[project]
+name = "{name}"
+version = "0.1.0"
+
+[build]
+sources = ["src"]
+target = {{type = "directory", path = "target"}}
+filelist_type = "{filelist_type}"
+sourcemap_target = {{type = "none"}}
+exclude_std = true
+"#
+            ),
+        )
+        .unwrap();
+        fs::write(src_path.join("foo.veryl"), "module Foo {}\n").unwrap();
+
+        let metadata = Metadata::load(project_path.join("Veryl.toml")).unwrap();
+        (metadata, project_path)
+    }
+
+    fn run_build(metadata: &mut Metadata, out_dir: Option<PathBuf>) {
+        Analyzer::new(metadata).clear();
+
+        let build = CmdBuild::new(OptBuild {
+            files: Vec::new(),
+            check: false,
+            out_dir,
+        });
+        build
+            .exec(metadata, false, true, None, None, &[])
+            .expect("build should succeed");
+
+        Analyzer::new(metadata).clear();
+    }
+
+    #[test]
+    fn build_without_out_dir_uses_project_output_dir() {
+        let _lock = BUILD_TEST_LOCK.lock().unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let (mut metadata, project_path) =
+            create_project(tempdir.path(), "default_out", FilelistType::Absolute);
+
+        run_build(&mut metadata, None);
+
+        assert!(project_path.join("target/foo.sv").exists());
+        assert!(project_path.join("default_out.f").exists());
+        assert!(project_path.join("dependencies").is_dir());
+    }
+
+    #[test]
+    fn build_with_absolute_out_dir_moves_generated_outputs() {
+        let _lock = BUILD_TEST_LOCK.lock().unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let (mut metadata, project_path) =
+            create_project(tempdir.path(), "absolute_out", FilelistType::Absolute);
+        let out_dir = tempdir.path().join("outside-project");
+
+        run_build(&mut metadata, Some(out_dir.clone()));
+
+        let out_dir = out_dir.canonicalize().unwrap();
+        let generated = out_dir.join("target/foo.sv");
+        let filelist = out_dir.join("absolute_out.f");
+        assert!(generated.exists());
+        assert!(filelist.exists());
+        assert!(out_dir.join("dependencies").is_dir());
+        assert!(!project_path.join("target/foo.sv").exists());
+        assert!(!project_path.join("absolute_out.f").exists());
+        assert!(!project_path.join("dependencies").exists());
+
+        let filelist_text = fs::read_to_string(filelist).unwrap();
+        assert!(
+            filelist_text
+                .lines()
+                .any(|line| line == generated.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn build_with_relative_out_dir_resolves_from_current_dir() {
+        let _lock = BUILD_TEST_LOCK.lock().unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let (mut metadata, project_path) =
+            create_project(tempdir.path(), "relative_out", FilelistType::Relative);
+        let _guard = set_current_dir(&project_path);
+
+        run_build(&mut metadata, Some(PathBuf::from("build-output")));
+
+        let out_dir = project_path.join("build-output");
+        let filelist = out_dir.join("relative_out.f");
+        assert!(out_dir.join("target/foo.sv").exists());
+        assert!(filelist.exists());
+        assert!(out_dir.join("dependencies").is_dir());
+
+        let filelist_text = fs::read_to_string(filelist).unwrap();
+        let relative_path = Path::new("target").join("foo.sv");
+        assert!(
+            filelist_text
+                .lines()
+                .any(|line| line == relative_path.to_string_lossy())
+        );
     }
 }

--- a/crates/veryl/src/cmd_build.rs
+++ b/crates/veryl/src/cmd_build.rs
@@ -37,6 +37,18 @@ impl CmdBuild {
         test_filter: Option<&str>,
         defines: &[String],
     ) -> Result<bool> {
+        if let Some(ref base_dir) = self.opt.base_dir {
+            let base_dir = if base_dir.is_absolute() {
+                base_dir.clone()
+            } else {
+                std::env::current_dir()
+                    .into_diagnostic()
+                    .wrap_err("")?
+                    .join(base_dir)
+            };
+            metadata.output_base_override = Some(base_dir);
+        }
+
         let paths = metadata.paths(&self.opt.files, true, true)?;
 
         let mut check_error = CheckError::new(metadata.build.error_count_limit);

--- a/crates/veryl/src/cmd_test.rs
+++ b/crates/veryl/src/cmd_test.rs
@@ -94,6 +94,7 @@ impl CmdTest {
         let build = CmdBuild::new(OptBuild {
             files: self.opt.files.clone(),
             check: false,
+            base_dir: None,
         });
 
         // Mutate metadata so external simulator runners (which read

--- a/crates/veryl/src/cmd_test.rs
+++ b/crates/veryl/src/cmd_test.rs
@@ -94,7 +94,7 @@ impl CmdTest {
         let build = CmdBuild::new(OptBuild {
             files: self.opt.files.clone(),
             check: false,
-            base_dir: None,
+            out_dir: None,
         });
 
         // Mutate metadata so external simulator runners (which read

--- a/crates/veryl/src/lib.rs
+++ b/crates/veryl/src/lib.rs
@@ -143,6 +143,12 @@ pub struct OptBuild {
     /// Run build in check mode
     #[arg(long)]
     pub check: bool,
+
+    /// Base directory for build outputs, overriding the project path
+    /// derived from Veryl.toml. Relative paths resolve against the
+    /// current working directory.
+    #[arg(long, value_name = "DIR")]
+    pub base_dir: Option<PathBuf>,
 }
 
 /// Clean-up the current project

--- a/crates/veryl/src/lib.rs
+++ b/crates/veryl/src/lib.rs
@@ -144,11 +144,11 @@ pub struct OptBuild {
     #[arg(long)]
     pub check: bool,
 
-    /// Base directory for build outputs, overriding the project path
-    /// derived from Veryl.toml. Relative paths resolve against the
-    /// current working directory.
+    /// Directory for build outputs, overriding the project path derived
+    /// from Veryl.toml. Relative paths resolve against the current
+    /// working directory.
     #[arg(long, value_name = "DIR")]
-    pub base_dir: Option<PathBuf>,
+    pub out_dir: Option<PathBuf>,
 }
 
 /// Clean-up the current project


### PR DESCRIPTION
## Summary
`veryl build --base-dir <DIR>` redirects build outputs (generated `.sv`, `.sv.map`) to a caller-specified directory while sources keep resolving against the project path. Without the flag, behavior is byte-for-byte unchanged.

## Why this matters
#2685 asks for a way to direct `veryl build` output when integrating with external build systems (xmake, build.rs), and dalance steered toward this exact option: "The second option (`--base-dir`) is probably easier to consider. This should integrate seamlessly into the current structure."

Implementation follows that seamless-integration framing:
- `OptBuild` gains an optional `--base-dir <DIR>` (`crates/veryl/src/lib.rs`); `cmd_build` resolves relative paths against the current working directory and stores the result as `Metadata::output_base_override` (a `#[serde(skip)]` field, never read from Veryl.toml)
- `Metadata::paths` computes destinations against the override when present: `Target::Directory` and `Target::Bundle` swap their project-path base for the override, and `Target::Source` (normally emits next to each source) preserves the source-relative layout under the override; sourcemap paths follow the same rule
- `cmd_test` passes `base_dir: None`, so `veryl test` is untouched

## Testing
Verified on a fresh `veryl new` project (target `{type = "directory", path = "target"}`) with the built binary:
- no flag: `target/hello.sv` exactly as before
- `--base-dir /abs/path`: emits `/abs/path/target/hello.sv` + `.sv.map`; project tree gets no new outputs
- `--base-dir relout` (relative): emits `<cwd>/relout/target/hello.sv`
- the generated filelist references the redirected destinations
- `cargo check -p veryl -p veryl-metadata`, `cargo fmt --check`, and `cargo test -p veryl-metadata` pass

The filelist itself still lands at the project path; happy to redirect it too if you'd prefer everything out-of-tree.

Closes #2685
