### PR TITLE
Pass verilator args to cocotb runner

### DIFF
--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -1,4 +1,5 @@
 use crate::runner::{Runner, copy_wave};
+//use fern::meta;
 use futures::prelude::*;
 use log::{error, info};
 use miette::{IntoDiagnostic, Result, WrapErr};

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -169,7 +169,7 @@ impl Runner for Cocotb {
         let module = format!("{}_{}", metadata.project.name, top.unwrap());
 
         let (py_waves, build_args) = match wave.then_some(metadata.test.waveform_format) {
-            Some(WaveFormFormat::Vcd) => ("True", "['--trace']"),
+            Some(WaveFormFormat::Vcd) => ("True", "['--trace-vcd']"),
             Some(WaveFormFormat::Fst) => ("True", "['--trace-fst', '--trace-structs']"),
             None => ("False", "[]"),
         };

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -168,7 +168,7 @@ impl Runner for Cocotb {
         sources = format!("[{}]", sources.strip_suffix(',').unwrap());
 
         let module = format!("{}_{}", metadata.project.name, top.unwrap());
-    
+
         // Create storage for build and test arguments
         let mut vec_build_args = Vec::new();
         let mut vec_test_args = Vec::new();
@@ -197,26 +197,24 @@ impl Runner for Cocotb {
         if !vec_build_args.is_empty() {
             for arg in &vec_build_args {
                 build_args.push_str(&format!("'{arg}',"));
-            }   
+            }
             // If wave_args isn't empty, add it to the build args.
             if wave_args != "" {
                 build_args.push_str(&wave_args);
             }
             build_args = format!("[{}]", build_args.strip_suffix(',').unwrap());
-        }
-        else {
+        } else {
             build_args.push_str("[]");
         }
 
         if !vec_test_args.is_empty() {
             for arg in &vec_test_args {
                 test_args.push_str(&format!("'{arg}',"));
-            }   
+            }
             test_args = format!("[{}]", test_args.strip_suffix(',').unwrap());
-        }   
-        else {
+        } else {
             test_args.push_str("[]");
-        }     
+        }
 
         let runner_path = temp_dir.path().join("runner.py");
         let runner_text = format!(

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -168,12 +168,56 @@ impl Runner for Cocotb {
         sources = format!("[{}]", sources.strip_suffix(',').unwrap());
 
         let module = format!("{}_{}", metadata.project.name, top.unwrap());
+    
+        // Create storage for build and test arguments
+        let mut vec_build_args = Vec::new();
+        let mut vec_test_args = Vec::new();
 
-        let (py_waves, build_args) = match wave.then_some(metadata.test.waveform_format) {
-            Some(WaveFormFormat::Vcd) => ("True", "['--trace-vcd']"),
-            Some(WaveFormFormat::Fst) => ("True", "['--trace-fst', '--trace-structs']"),
-            None => ("False", "[]"),
+        // Parse wave arguments
+        let (py_waves, wave_args) = match wave.then_some(metadata.test.waveform_format) {
+            Some(WaveFormFormat::Vcd) => ("True", "'--trace-vcd'"),
+            Some(WaveFormFormat::Fst) => ("True", "'--trace-fst', '--trace-structs'"),
+            None => ("False", ""),
         };
+
+        // Parse verilator compile arguments (verilate)
+        for item in &metadata.test.verilator.compile_args {
+            vec_build_args.push(item);
+        }
+
+        // Parse verilator run arguments (calling generated binary)
+        for item in &metadata.test.verilator.simulate_args {
+            vec_test_args.push(item);
+        }
+
+        // Format arguments for cocotb
+        let mut build_args = String::new();
+        let mut test_args = String::new();
+
+        if !vec_build_args.is_empty() {
+            for arg in &vec_build_args {
+                build_args.push_str(&format!("'{arg}',"));
+            }   
+            // If wave_args isn't empty, add it to the build args.
+            if wave_args != "" {
+                build_args.push_str(&wave_args);
+            }
+            build_args = format!("[{}]", build_args.strip_suffix(',').unwrap());
+        }
+        else {
+            build_args.push_str("[]");
+        }
+
+        if !vec_test_args.is_empty() {
+            for arg in &vec_test_args {
+                test_args.push_str(&format!("'{arg}',"));
+            }   
+            test_args = format!("[{}]", test_args.strip_suffix(',').unwrap());
+        }   
+        else {
+            test_args.push_str("[]");
+        }     
+
         let runner_path = temp_dir.path().join("runner.py");
         let runner_text = format!(
             r#"
@@ -205,6 +249,7 @@ if cocotb_version.startswith("2."):
         hdl_toplevel="{module}",
         test_module="{test},",
         waves={py_waves},
+        test_args={test_args},
     )
 elif cocotb_version.startswith("1.9."):
     import cocotb.runner
@@ -224,6 +269,7 @@ elif cocotb_version.startswith("1.9."):
         hdl_toplevel="{module}",
         test_module="{test},",
         waves={py_waves},
+        test_args={test_args},
     )
 else:
     raise RuntimeError("unsupported cocotb version")

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -199,8 +199,8 @@ impl Runner for Cocotb {
                 build_args.push_str(&format!("'{arg}',"));
             }
             // If wave_args isn't empty, add it to the build args.
-            if wave_args != "" {
-                build_args.push_str(&wave_args);
+            if !wave_args.is_empty() {
+                build_args.push_str(wave_args);
             }
             build_args = format!("[{}]", build_args.strip_suffix(',').unwrap());
         } else {

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -168,7 +168,7 @@ impl Runner for Cocotb {
 
         let module = format!("{}_{}", metadata.project.name, top.unwrap());
 
-        let (py_waves, args) = match wave.then_some(metadata.test.waveform_format) {
+        let (py_waves, build_args) = match wave.then_some(metadata.test.waveform_format) {
             Some(WaveFormFormat::Vcd) => ("True", "['--trace']"),
             Some(WaveFormFormat::Fst) => ("True", "['--trace-fst', '--trace-structs']"),
             None => ("False", "[]"),
@@ -197,7 +197,7 @@ if cocotb_version.startswith("2."):
         hdl_toplevel="{module}",
         always=True,
         waves={py_waves},
-        build_args={args},
+        build_args={build_args},
     )
 
     runner.test(
@@ -216,7 +216,7 @@ elif cocotb_version.startswith("1.9."):
         hdl_toplevel="{module}",
         always=True,
         waves={py_waves},
-        build_args={args},
+        build_args={build_args},
     )
 
     runner.test(

--- a/crates/veryl/src/runner/cocotb.rs
+++ b/crates/veryl/src/runner/cocotb.rs
@@ -175,8 +175,8 @@ impl Runner for Cocotb {
 
         // Parse wave arguments
         let (py_waves, wave_args) = match wave.then_some(metadata.test.waveform_format) {
-            Some(WaveFormFormat::Vcd) => ("True", "'--trace-vcd'"),
-            Some(WaveFormFormat::Fst) => ("True", "'--trace-fst', '--trace-structs'"),
+            Some(WaveFormFormat::Vcd) => ("True", "'--trace-vcd',"),
+            Some(WaveFormFormat::Fst) => ("True", "'--trace-fst', '--trace-structs',"),
             None => ("False", ""),
         };
 


### PR DESCRIPTION
This PR applies [test.verilator] arguments to cocotb  `runner.build(build_args)` and `runner.test(test_args)` parameters.

A better solution would be to create a [test.cocotb] section, as verilator might not be the only backend in the future.

I've tested it by providing two verilog files to compile_args and nothing to simulate_args:

```toml
[test.verilator]
# Replace "~/home/{user}/Tools/oss-cad-suite/share/yosys" with the output of "yosys-config --datdir" command
compile_args = ["/home/{user}/Tools/oss-cad-suite/share/yosys/gatemate/cells_sim.v",
                "/home/{user}/Tools/oss-cad-suite/share/yosys/gatemate/cells_bb.v"]
```