### PR TITLE
Fix part select position calcuration for user defined type

### DIFF
--- a/crates/analyzer/src/ir/comptime.rs
+++ b/crates/analyzer/src/ir/comptime.rs
@@ -75,13 +75,12 @@ impl PartSelectPath {
                 select = &select[select_dims..];
 
                 // If select dimension doesn't satisfy type dimension,
-                // additional select is necessary
+                // calculate index using only the selected (outer) dimensions
+                // so that `width * index` gives the correct bit position
                 if remaining_dims != 0 {
-                    let mut sel = sel.to_vec();
-                    for _ in 0..remaining_dims {
-                        sel.push(Expression::create_value(Value::new(0, 32, false), token));
-                    }
-                    x.r#type.width.calc_index_expr(&sel)?
+                    let outer_width = x.r#type.width.as_shape_ref();
+                    let outer_width = ShapeRef::new(&outer_width[0..select_dims]);
+                    outer_width.calc_index_expr(sel)?
                 } else {
                     x.r#type.width.calc_index_expr(sel)?
                 }
@@ -110,15 +109,11 @@ impl PartSelectPath {
             // pos += x.pos + width * index;
             let x_pos = Expression::create_value(Value::new(x.pos as u64, 32, false), token);
 
-            let expr = if remaining_dims != 0 {
-                // If remaining_dims exists, width is already considered by index
-                Expression::Binary(Box::new(x_pos), Op::Add, Box::new(index), comptime.clone())
-            } else {
-                let expr = Expression::create_value(Value::new(width as u64, 32, false), token);
-                let expr =
-                    Expression::Binary(Box::new(expr), Op::Mul, Box::new(index), comptime.clone());
-                Expression::Binary(Box::new(x_pos), Op::Add, Box::new(expr), comptime.clone())
-            };
+            let expr = Expression::create_value(Value::new(width as u64, 32, false), token);
+            let expr =
+                Expression::Binary(Box::new(expr), Op::Mul, Box::new(index), comptime.clone());
+            let expr =
+                Expression::Binary(Box::new(x_pos), Op::Add, Box::new(expr), comptime.clone());
 
             if let Some((pos, _, _)) = pos_width {
                 let expr =

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1548,6 +1548,23 @@ fn multiple_assignment() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    module ModuleA {
+        struct struct_a {
+            a: logic<2>,
+        }
+        var _a: struct_a<2, 2>;
+        for i in 0..2 :g {
+            always_comb {
+            _a[i] = '0;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2767

Currenlty, width of user defined is not considered when unselected width portion are remained.
This caused #2767.

Thi PR is to fix the above bug.