### PR TITLE
Fix reset value of FFs in `delay` module

### DIFF
--- a/crates/std/veryl/src/delay/delay.veryl
+++ b/crates/std/veryl/src/delay/delay.veryl
@@ -23,7 +23,7 @@ pub module delay #(
         always_ff (i_clk, i_rst) {
             if_reset {
                 for i in 0..DELAY {
-                    delay[i] = '0;
+                    delay[i] = 0 as TYPE;
                 }
             } else {
                 delay[0] = i_d;


### PR DESCRIPTION
`ENUMASSIGN` warning is reported when the specified type is an enum.

```
Warning-[ENUMASSIGN] Illegal assignment to enum variable
/home/ishitani/workspace/sarugaku/hw/sim/dmac_rtl_uvm/sim_binary/dependencies/std/delay/delay.sv, 26
__std_delay, "g_delay.delay[i] <= '0;"
  Only expressions of the enum type can be assigned to an enum variable.
  The type bit [0:0] is incompatible with the enum 'pzdma_direction'
  Expression: '0
  Use the static cast operator to convert the expression to enum type.
```

This PR is to fix the reset value.