### PR TITLE
Add cache for result of `eval_type`

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -2,9 +2,9 @@ use crate::analyzer_error::{AnalyzerError, ExceedLimitKind};
 use crate::conv::conv_profiler::{ConvProfile, ConvProfileGuard};
 use crate::conv::instance::{InstanceHistory, InstanceHistoryError};
 use crate::ir::{
-    Component, Comptime, Declaration, Expression, FfClock, FfReset, FuncPath, Function, Interface,
-    IrResult, ShapeRef, Signature, Type, VarId, VarIndex, VarKind, VarPath, VarSelect, Variable,
-    VariableInfo,
+    self, Component, Comptime, Declaration, Expression, FfClock, FfReset, FuncPath, Function,
+    Interface, IrResult, ShapeRef, Signature, Type, VarId, VarIndex, VarKind, VarPath, VarSelect,
+    Variable, VariableInfo,
 };
 use crate::namespace::Namespace;
 use crate::namespace_table;
@@ -62,6 +62,7 @@ pub struct Context {
     pub inst_signatures: HashMap<StrId, Signature>,
     pub modport_signatures: Vec<HashMap<StrId, Signature>>,
     pub instance_history: InstanceHistory,
+    pub types: HashMap<Signature, ir::Type>,
     pub select_paths: Vec<(VarPath, GenericSymbolPath)>,
     pub select_dims: Vec<usize>,
     pub ignore_var_func: bool,
@@ -99,6 +100,7 @@ impl Context {
         std::mem::swap(&mut self.generic_maps, &mut tgt.generic_maps);
         std::mem::swap(&mut self.modport_signatures, &mut tgt.modport_signatures);
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
+        std::mem::swap(&mut self.types, &mut tgt.types);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
         std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);
         self.disalbe_const_opt = tgt.disalbe_const_opt;

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1002,6 +1002,7 @@ pub fn eval_type(
     path: &GenericSymbolPath,
     pos: TypePosition,
 ) -> IrResult<ir::Type> {
+    let mut cache_key = None;
     let mut width = Shape::default();
     let mut array = Shape::default();
     let mut signed = false;
@@ -1032,8 +1033,18 @@ pub fn eval_type(
         let mut path = context.resolve_path(path.clone());
         check_generic_refereence(context, &path);
 
-        let map = path.to_generic_maps();
         if let Ok(symbol) = symbol_table::resolve(&path) {
+            if !context.in_generic
+                && let Some(mut sig) = Signature::from_path(context, path.clone())
+            {
+                sig.normalize();
+                if let Some(r#type) = context.types.get(&sig).cloned() {
+                    return Ok(r#type);
+                }
+
+                cache_key = Some(sig);
+            }
+
             let type_error = match pos {
                 TypePosition::Variable => !symbol.found.is_variable_type(),
                 TypePosition::Cast => !symbol.found.is_casting_type(),
@@ -1052,6 +1063,7 @@ pub fn eval_type(
                 ));
             }
 
+            let map = path.to_generic_maps();
             match &symbol.found.kind {
                 SymbolKind::Struct(x) => {
                     context.push_generic_map(map.clone());
@@ -1344,6 +1356,11 @@ pub fn eval_type(
     } else {
         r#type.set_concrete_width(width);
     }
+
+    if let Some(key) = cache_key {
+        context.types.insert(key, r#type.clone());
+    }
+
     Ok(r#type)
 }
 

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -41,6 +41,10 @@ impl Signature {
     }
 
     pub fn from_path(context: &mut Context, mut path: GenericSymbolPath) -> Option<Self> {
+        if !path.is_resolvable() {
+            return None;
+        }
+
         let namespace = namespace_table::get(path.paths[0].base.id).unwrap();
         path.resolve_imported(&namespace, None);
         path.unalias(None);
@@ -53,9 +57,13 @@ impl Signature {
             | SymbolKind::Interface(_)
             | SymbolKind::Modport(_)
             | SymbolKind::Function(_)
+            | SymbolKind::Struct(_)
+            | SymbolKind::Union(_)
+            | SymbolKind::TypeDef(_)
+            | SymbolKind::Enum(_)
             | SymbolKind::SystemVerilog => Self::new(symbol.found.id),
             SymbolKind::ModportFunctionMember(x) => Self::new(x.function),
-            SymbolKind::GenericParameter(_) => {
+            SymbolKind::GenericParameter(_) | SymbolKind::GenericConst(_) => {
                 let path = context.resolve_path(path.clone());
                 let symbol = symbol_table::resolve(&path).ok()?;
                 if let SymbolKind::GenericParameter(x) = &symbol.found.kind {
@@ -88,6 +96,12 @@ impl Signature {
             }
             _ => return None,
         };
+
+        if matches!(symbol.found.kind, SymbolKind::SystemVerilog)
+            && symbol_table::get(symbol.found.id).is_none()
+        {
+            symbol_table::update((*symbol.found).clone());
+        }
 
         if !context.in_generic {
             // Apply default value


### PR DESCRIPTION
Add cache for result of `eval_type` to improve analyzer performance.

before
```
[DEBUG]     Executed parse/analyze_pass1 (20675 milliseconds, 745 files)
[DEBUG]     Executed analyze_post_pass1 (8983 milliseconds)
[DEBUG]     Executed analyze_pass2 (96805 milliseconds)
[DEBUG]     Executed analyze_post_pass2 (1314 milliseconds)
[DEBUG]      Elapsed time (130622 milliseconds
```

after
```
[DEBUG]     Executed parse/analyze_pass1 (12747 milliseconds, 745 files)
[DEBUG]     Executed analyze_post_pass1 (5146 milliseconds)
[DEBUG]     Executed analyze_pass2 (29384 milliseconds)
[DEBUG]     Executed analyze_post_pass2 (1010 milliseconds)
[DEBUG]      Elapsed time (50686 milliseconds)
```