### PR TITLE
fix(analyzer): report an error for a bare for-loop range

### DIFF
--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -1997,6 +1997,7 @@ impl AnalyzerError {
             AnalyzerError::InvalidEmbedIdentifier { input, .. } => input,
             AnalyzerError::InvalidEnumVariant { input, .. } => input,
             AnalyzerError::InvalidFactor { input, .. } => input,
+            AnalyzerError::InvalidForRange { input, .. } => input,
             AnalyzerError::InvalidForStep { input, .. } => input,
             AnalyzerError::InvalidIdentifier { input, .. } => input,
             AnalyzerError::InvalidImport { input, .. } => input,

--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -709,6 +709,21 @@ pub enum AnalyzerError {
 
     #[diagnostic(
         severity(Error),
+        code(invalid_for_range),
+        help("use a range with `..` or `..=`, e.g. `0..N`"),
+        url("https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#{}", self.code().unwrap())
+    )]
+    #[error("for-loop range must use `..` or `..=`; a bare expression is not a valid range")]
+    InvalidForRange {
+        #[source_code]
+        input: MultiSources,
+        #[label("Error location")]
+        error_location: SourceSpan,
+        token_source: TokenSource,
+    },
+
+    #[diagnostic(
+        severity(Error),
         code(invalid_for_step),
         help("make the step strictly advance the induction variable toward the end of the range"),
         url("https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#{}", self.code().unwrap())
@@ -2109,6 +2124,7 @@ impl AnalyzerError {
             AnalyzerError::InvalidRangeAssign { token_source, .. } => *token_source,
             AnalyzerError::NonConstantSelectWidth { token_source, .. } => *token_source,
             AnalyzerError::InvalidStatement { token_source, .. } => *token_source,
+            AnalyzerError::InvalidForRange { token_source, .. } => *token_source,
             AnalyzerError::InvalidForStep { token_source, .. } => *token_source,
             AnalyzerError::InvalidTbUsage { token_source, .. } => *token_source,
             AnalyzerError::MissingTbPort { token_source, .. } => *token_source,
@@ -2559,6 +2575,13 @@ impl AnalyzerError {
     pub fn invalid_statement(kind: &str, token: &TokenRange) -> Self {
         AnalyzerError::InvalidStatement {
             kind: kind.to_string(),
+            input: source(token),
+            error_location: token.into(),
+            token_source: token.source(),
+        }
+    }
+    pub fn invalid_for_range(token: &TokenRange) -> Self {
+        AnalyzerError::InvalidForRange {
             input: source(token),
             error_location: token.into(),
             token_source: token.source(),

--- a/crates/analyzer/src/handlers/check_statement.rs
+++ b/crates/analyzer/src/handlers/check_statement.rs
@@ -2,6 +2,7 @@ use crate::analyzer_error::AnalyzerError;
 use crate::attribute::Attribute;
 use crate::attribute_table;
 use veryl_parser::ParolError;
+use veryl_parser::token_range::TokenRange;
 use veryl_parser::veryl_grammar_trait::*;
 use veryl_parser::veryl_walker::{Handler, HandlerPoint};
 
@@ -116,10 +117,26 @@ impl VerylGrammarTrait for CheckStatement {
         Ok(())
     }
 
-    fn for_statement(&mut self, _arg: &ForStatement) -> Result<(), ParolError> {
+    fn for_statement(&mut self, arg: &ForStatement) -> Result<(), ParolError> {
         match self.point {
-            HandlerPoint::Before => self.statement_depth_in_loop += 1,
+            HandlerPoint::Before => {
+                self.statement_depth_in_loop += 1;
+                if arg.range.range_opt.is_none() {
+                    let token: TokenRange = arg.range.as_ref().into();
+                    self.errors.push(AnalyzerError::invalid_for_range(&token));
+                }
+            }
             HandlerPoint::After => self.statement_depth_in_loop -= 1,
+        }
+        Ok(())
+    }
+
+    fn generate_for_declaration(&mut self, arg: &GenerateForDeclaration) -> Result<(), ParolError> {
+        if let HandlerPoint::Before = self.point
+            && arg.range.range_opt.is_none()
+        {
+            let token: TokenRange = arg.range.as_ref().into();
+            self.errors.push(AnalyzerError::invalid_for_range(&token));
         }
         Ok(())
     }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1899,6 +1899,67 @@ fn invalid_statement() {
 }
 
 #[test]
+fn invalid_for_range() {
+    let code = r#"
+    module ModuleA {
+        always_comb {
+            for i in 4 {
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::InvalidForRange { .. })),
+        "{errors:?}"
+    );
+
+    let code = r#"
+    module ModuleA {
+        for i in 4 :blk {
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::InvalidForRange { .. })),
+        "{errors:?}"
+    );
+
+    let code = r#"
+    module ModuleA (
+        o: output logic<32>,
+    ) {
+        always_comb {
+            var acc: logic<32>;
+            acc = 0;
+            for i in 0..4 {
+                acc += i;
+            }
+            for j in 0..=4 {
+                acc += j;
+            }
+            o = acc;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::InvalidForRange { .. })),
+        "{errors:?}"
+    );
+}
+
+#[test]
 fn invalid_modport_item() {
     let code = r#"
     interface InterfaceA {

--- a/crates/tests/src/snapshots/invalid_for_range.snap
+++ b/crates/tests/src/snapshots/invalid_for_range.snap
@@ -1,0 +1,15 @@
+---
+source: crates/tests/src/lib.rs
+expression: out
+---
+invalid_for_range (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#invalid_for_range)
+
+  × for-loop range must use `..` or `..=`; a bare expression is not a valid range
+   ╭─[../../testcases/error/invalid_for_range.veryl:5:18]
+ 4 │         a = 0;
+ 5 │         for i in 4 {
+   ·                  ┬
+   ·                  ╰── Error location
+ 6 │             a += i;
+   ╰────
+  help: use a range with `..` or `..=`, e.g. `0..N`

--- a/testcases/error/invalid_for_range.veryl
+++ b/testcases/error/invalid_for_range.veryl
@@ -1,0 +1,9 @@
+module invalid_for_range {
+    var a: logic<32>;
+    always_comb {
+        a = 0;
+        for i in 4 {
+            a += i;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reports an analyzer error when a for-loop range is a bare expression with no range operator (`for i in N`).

The grammar defines `ForStatement: For Identifier In [Rev] Range ...` where `Range: Expression [RangeOperator Expression]`, so the parser accepts a bare expression as a "range". Semantically this has no valid loop meaning, but it was previously accepted silently. This change adds a new `invalid_for_range` analyzer error that fires when a for-loop's `Range` has no `..`/`..=` operator, for both the procedural for-statement and the `for ... :blk` generate-for declaration.

The separately-discussed idea of treating `for i in N` as sugar for `0..N` is intentionally not implemented here; this PR only rejects the bare form, which is the issue's standing ask.

## Why this matters

`for i in N` looks like a count-based loop but is parsed as a single-scalar "range" that cannot describe an iteration, so it should be a compile-time error rather than silently-accepted, meaningless code. See #2543.

## Testing

- `cargo test -p veryl-analyzer` (345 passing, including the new `invalid_for_range` test)
- Full workspace test suite green (663 tests across parser, analyzer, emitter, and integration)
- `cargo fmt --check`
- `cargo clippy -p veryl-analyzer -- -D warnings`

The new test covers the error path for both the statement form (`for i in 4 { }`) and the generate-for form (`for i in 4 :blk { }`), plus the happy path for `0..4` and `0..=4` ranges.

Fixes #2543
