### PR TITLE
fix: cyclic type dependency false positive

### DIFF
--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1076,6 +1076,24 @@ fn cyclic_type_dependency() {
 
     let errors = analyze_multiple_inputs(&inputs);
     assert!(errors.is_empty());
+
+    // A const in a function body initialized by a call to a sibling function in
+    // the same package must not be reported as a cyclic dependency of the
+    // package with itself (regression of #2865, issue #2867).
+    let code = r#"
+    package a_pkg {
+        function f0() -> u32 {
+            return 1;
+        }
+        function f1() -> u32 {
+            const C: u32 = f0();
+            return C;
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -220,6 +220,16 @@ impl TypeDag {
                     } else {
                         base_symbol
                     };
+                    // When the parent and the base resolve to the same enclosing
+                    // component, the dependency is purely intra-component (e.g. a
+                    // const in a function body referencing a sibling function in
+                    // the same package). Bubbling both sides up to that component
+                    // would otherwise create a spurious self-edge and report a
+                    // false `cyclic_type_dependency` (see issue #2867, a
+                    // regression of #2865).
+                    if parent_symbol.id == base_symbol.id {
+                        continue;
+                    }
                     let recursive_ref = namespace.included(&base_symbol.inner_namespace());
                     self.insert_path_symbols(
                         &parent_symbol,


### PR DESCRIPTION
## Summary

Fixes a false-positive `cyclic_type_dependency` error reported when a `const`
inside a function body is initialized by a call to a sibling function in the
same package.

In `TypeDag::insert_path`, when a function-body-local symbol references a
symbol that lives outside its local namespace, both the referencing symbol and
the referenced symbol are bubbled up to their enclosing component via
`get_parent_component()`. After #2865, a `Function` symbol now resolves its
parent component all the way up to the enclosing package. As a result, a
function-local `const` referencing a sibling function ends up bubbled to the
same package node on both sides, creating a spurious package self-edge that the
DAG reports as `Cyclic dependency between a_pkg and a_pkg`.

The fix skips inserting the edge when the parent and base symbols resolve to the
same enclosing component, because such a reference is purely intra-component and
carries no cross-component dependency. Genuine package self-cycles (for example
`import PackageA::*` inside `PackageA`) reach `insert_edge` through the
non-bubbling path and are unaffected.

## Why this matters

This is a regression introduced by #2865 ("Fix parent component resolution for
symbol defined in function"). Valid Veryl code that compiled before now fails
analysis, as reported in #2867. The minimal reproduction is a package with one
function returning a value and a second function whose body declares a `const`
initialized by calling the first function.

## Testing

- Added a regression test in `crates/analyzer/src/tests::cyclic_type_dependency`
  mirroring the reported reproduction. The test fails on the current `master`
  (the analyzer reports `CyclicTypeDependency`) and passes with this fix.
- `cargo test -p veryl-analyzer` — all 345 tests pass.
- `cargo fmt -p veryl-analyzer --check` and `cargo clippy -p veryl-analyzer` are
  clean.
- Verified existing cyclic-detection cases still error as expected: package
  self-import (`import PackageA::*`), self-referential `struct`/`union` members,
  and cross-package module instantiation cycles.

Fixes #2867
