### PR TITLE
fix(analyzer): report mutually recursive functions as cyclic type dependency instead of overflowing

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -52,6 +52,10 @@ pub struct Context {
     pub var_id: VarId,
     pub var_paths: HashMap<VarPath, (VarId, Comptime)>,
     pub func_paths: HashMap<FuncPath, VarId>,
+    /// Symbols whose function bodies are mid-conversion. Carried (via `inherit`)
+    /// across the fresh per-call contexts that mutual recursion creates, so
+    /// re-entry is detected and the IR conversion doesn't overflow.
+    pub converting_funcs: Vec<SymbolId>,
     pub variables: HashMap<VarId, Variable>,
     pub functions: HashMap<VarId, Function>,
     pub port_types: HashMap<VarPath, (Type, ClockDomain)>,
@@ -100,6 +104,7 @@ impl Context {
         std::mem::swap(&mut self.generic_maps, &mut tgt.generic_maps);
         std::mem::swap(&mut self.modport_signatures, &mut tgt.modport_signatures);
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
+        std::mem::swap(&mut self.converting_funcs, &mut tgt.converting_funcs);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
         std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);
         self.disalbe_const_opt = tgt.disalbe_const_opt;

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -1050,6 +1050,12 @@ fn conv_function(
         // The given function has already been added through function reference before definition.
         return Ok(());
     }
+    // Re-entry while mid-conversion is a call cycle (mutual recursion
+    // `f0 -> f1 -> f0`) that the same-context `func_paths` guard above misses,
+    // since it recurses through fresh contexts. Bail; `type_dag` reports it.
+    if context.converting_funcs.contains(&symbol.id) {
+        return Ok(());
+    }
     let id = context.insert_func_path(path.clone());
 
     let proeprty = match &symbol.kind {
@@ -1084,6 +1090,9 @@ fn conv_function(
     };
     let arity = ports.len();
 
+    // Mark in-progress for the body conversion only (where recursion lands);
+    // kept below the `?`-bearing setup so an early error leaves no stale entry.
+    context.converting_funcs.push(symbol.id);
     context.push_affiliation(Affiliation::Function);
     context.push_hierarchy(name);
     context.push_namespace(namespace);
@@ -1192,6 +1201,7 @@ fn conv_function(
     context.pop_affiliation();
     context.pop_hierarchy();
     context.pop_namespace();
+    context.converting_funcs.pop();
 
     let (args, body) = func?;
     let func = ir::Function {

--- a/crates/analyzer/src/symbol_table/function.rs
+++ b/crates/analyzer/src/symbol_table/function.rs
@@ -4,11 +4,11 @@ use crate::symbol_table;
 
 pub fn resolve_function(list: &[Symbol]) {
     for symbol in list {
-        resolve_constantable(symbol);
+        resolve_constantable(symbol, &mut Vec::new());
     }
 }
 
-fn resolve_constantable(symbol: &Symbol) -> bool {
+fn resolve_constantable(symbol: &Symbol, visited: &mut Vec<SymbolId>) -> bool {
     match &symbol.kind {
         SymbolKind::Function(func) | SymbolKind::ProtoFunction(func) => {
             if let Some(constantable) = func.constantable {
@@ -18,6 +18,14 @@ fn resolve_constantable(symbol: &Symbol) -> bool {
         _ => {}
     }
 
+    // Already in progress: a call cycle (mutual recursion `f0 -> f1 -> f0`),
+    // not constant-evaluable and would overflow on re-entry. `type_dag` reports
+    // the cycle; self-recursion is skipped earlier in `is_constantable_function`.
+    if visited.contains(&symbol.id) {
+        return false;
+    }
+    visited.push(symbol.id);
+
     let namespace = symbol.inner_namespace();
     let mut symbol = symbol.clone();
     let func = match &mut symbol.kind {
@@ -25,16 +33,23 @@ fn resolve_constantable(symbol: &Symbol) -> bool {
         _ => unreachable!(),
     };
 
-    let constantable = is_constantable_function(func, symbol.id, &namespace);
+    let constantable = is_constantable_function(func, symbol.id, &namespace, visited);
     func.constantable = Some(constantable);
     func.reference_paths.clear();
 
     symbol_table::update(symbol);
 
+    visited.pop();
+
     constantable
 }
 
-fn is_constantable_function(func: &FunctionProperty, id: SymbolId, namespace: &Namespace) -> bool {
+fn is_constantable_function(
+    func: &FunctionProperty,
+    id: SymbolId,
+    namespace: &Namespace,
+    visited: &mut Vec<SymbolId>,
+) -> bool {
     if func.ret.is_none() {
         // constant function should have a return value.
         return false;
@@ -66,7 +81,7 @@ fn is_constantable_function(func: &FunctionProperty, id: SymbolId, namespace: &N
             {
                 return false;
             }
-            SymbolKind::Function(_) if !resolve_constantable(&symbol.found) => {
+            SymbolKind::Function(_) if !resolve_constantable(&symbol.found, visited) => {
                 return false;
             }
             SymbolKind::Instance(_) => return false,

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -1079,7 +1079,7 @@ fn cyclic_type_dependency() {
 
     // A const in a function body initialized by a call to a sibling function in
     // the same package must not be reported as a cyclic dependency of the
-    // package with itself (regression of #2865, issue #2867).
+    // package with itself.
     let code = r#"
     package a_pkg {
         function f0() -> u32 {
@@ -1094,6 +1094,26 @@ fn cyclic_type_dependency() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    // Mutual recursion between sibling functions is a genuine cycle and must
+    // still be reported (not overflow) — the sibling-call fix above must not
+    // over-suppress it.
+    let code = r#"
+    package a_pkg {
+        function f0() -> u32 {
+            return f1();
+        }
+        function f1() -> u32 {
+            return f0();
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::CyclicTypeDependency { .. }
+    ));
 }
 
 #[test]

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -220,13 +220,11 @@ impl TypeDag {
                     } else {
                         base_symbol
                     };
-                    // When the parent and the base resolve to the same enclosing
-                    // component, the dependency is purely intra-component (e.g. a
-                    // const in a function body referencing a sibling function in
-                    // the same package). Bubbling both sides up to that component
-                    // would otherwise create a spurious self-edge and report a
-                    // false `cyclic_type_dependency` (see issue #2867, a
-                    // regression of #2865).
+                    // Both sides bubbled up to the same component: an
+                    // intra-component reference (e.g. a const calling a sibling
+                    // function), whose self-edge would be a false
+                    // `cyclic_type_dependency`. Real cross-function cycles keep
+                    // distinct endpoints (`else` below).
                     if parent_symbol.id == base_symbol.id {
                         continue;
                     }


### PR DESCRIPTION
This PR is the follow-up to #2870 