### PR TITLE
Fix aliasing symbol path including package with generic consts

### DIFF
--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -363,7 +363,7 @@ impl Symbol {
     }
 
     pub fn generic_map(&self, id: Option<SymbolId>, arguments: &[GenericSymbolPath]) -> GenericMap {
-        let map = if arguments.is_empty() {
+        let map = if arguments.is_empty() && !self.has_generic_consts() {
             HashMap::default()
         } else {
             self.generic_table(arguments)
@@ -604,6 +604,20 @@ impl Symbol {
                 symbol.generic_consts()
             }
             _ => Vec::new(),
+        }
+    }
+
+    pub fn has_generic_consts(&self) -> bool {
+        match &self.kind {
+            SymbolKind::Function(x) => !x.generic_consts.is_empty(),
+            SymbolKind::Module(x) => !x.generic_consts.is_empty(),
+            SymbolKind::Interface(x) => !x.generic_consts.is_empty(),
+            SymbolKind::Package(x) => !x.generic_consts.is_empty(),
+            SymbolKind::GenericInstance(x) => {
+                let symbol = symbol_table::get(x.base).unwrap();
+                symbol.has_generic_consts()
+            }
+            _ => false,
         }
     }
 

--- a/crates/analyzer/src/symbol_path.rs
+++ b/crates/analyzer/src/symbol_path.rs
@@ -521,7 +521,8 @@ impl GenericSymbolPath {
                 }
 
                 if let Ok(ref symbol) = symbol
-                    && matches!(&symbol.found.kind, SymbolKind::GenericInstance(_))
+                    && (matches!(&symbol.found.kind, SymbolKind::GenericInstance(_))
+                        || symbol.found.has_generic_consts())
                 {
                     let map = symbol
                         .found

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -6206,6 +6206,31 @@ fn undefined_identifier() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package a_proto_pkg {
+        const WIDTH: u32;
+    }
+    package a_pkg::<W: u32> for a_proto_pkg {
+        const WIDTH: u32 = W;
+    }
+    interface b_if::<PKG: a_proto_pkg> {
+        var b: logic<PKG::WIDTH>;
+        modport mp {
+            b: input,
+        }
+    }
+    package c_pkg {
+        gen W: u32 = 1 + 1;
+        alias package a = a_pkg::<W>;
+    }
+    module d_module (
+        bif: modport b_if::<c_pkg::a>::mp,
+    ) {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2921

Generic consts defined in a non generic package are not considered when analysing a symbol path including such package.Due to this, reoslving such symbol path is fialed.
