### PR TITLE
Treat parent symbols with generic consts as generic components

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -532,7 +532,7 @@ impl ReferenceTable {
     ) {
         fn get_parent_generic_component(namespace: &Namespace) -> Option<Symbol> {
             let target = namespace.get_symbol()?;
-            if target.has_generic_paramters() {
+            if target.has_generic_paramters() || target.has_generic_consts() {
                 Some(target)
             } else {
                 get_parent_generic_component(&target.namespace)

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -340,7 +340,9 @@ impl Symbol {
     pub fn generic_maps(&self) -> Vec<GenericMap> {
         let mut ret = Vec::new();
 
-        let generic_instances = if matches!(self.kind, SymbolKind::GenericInstance(_)) {
+        let generic_instances = if matches!(self.kind, SymbolKind::GenericInstance(_))
+            || (!self.has_generic_paramters() && self.has_generic_consts())
+        {
             &vec![self.id]
         } else {
             &self.generic_instances

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -6231,6 +6231,26 @@ fn undefined_identifier() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto package a_proto_pkg {
+        type T;
+    }
+    package a_pkg::<W: u32> for a_proto_pkg {
+        type T = logic<W>;
+    }
+    package b_pkg {
+        gen W: u32 = 1 + 1;
+        alias package a = a_pkg::<W>;
+    }
+    package c_pkg {
+        import b_pkg::a::T;
+        const C: T = 0 as T;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2921

Currently, components which have no generic params but generic consts are not treated as generic components.
Due to this, generic instances within such components are not inserted and the error shown in https://github.com/veryl-lang/veryl/issues/2921#issuecomment-4830880018 occurs.
