### PR TITLE
Expose resolved dependency metadata for external tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,6 +6102,7 @@ dependencies = [
  "regex",
  "semver",
  "serde",
+ "serde_json",
  "serde_regex",
  "spdx",
  "tempfile",

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -39,6 +39,7 @@ miette         = {workspace = true, features = ["fancy"]}
 which          = "8.0"
 
 [dev-dependencies]
+serde_json     = {workspace = true}
 tempfile       = {workspace = true}
 
 [features]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -8,6 +8,7 @@ mod lockfile;
 mod lockfile_compat;
 mod metadata;
 mod metadata_error;
+mod metadata_output;
 mod project;
 mod pubfile;
 mod publish;
@@ -24,6 +25,9 @@ pub use lint::{Case, Lint};
 pub use lockfile::{LockSource, Lockfile};
 pub use metadata::{BumpKind, Metadata, UrlPath};
 pub use metadata_error::MetadataError;
+pub use metadata_output::{
+    MetadataDependencyV2, MetadataOutputV2, MetadataProjectV2, MetadataSourceV2,
+};
 pub use project::Project;
 pub use pubfile::{Pubfile, Release};
 pub use publish::Publish;

--- a/crates/metadata/src/lockfile.rs
+++ b/crates/metadata/src/lockfile.rs
@@ -93,35 +93,15 @@ impl LockSource {
 #[serde(deny_unknown_fields)]
 pub struct LockSourceRepository {
     uuid: Uuid,
-    url: UrlPath,
-    path: PathBuf,
-    project: String,
-    version: Version,
-    revision: String,
+    pub url: UrlPath,
+    pub path: PathBuf,
+    pub project: String,
+    pub version: Version,
+    pub revision: String,
     r#override: Option<PathBuf>,
 }
 
 impl LockSourceRepository {
-    pub fn url(&self) -> &UrlPath {
-        &self.url
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    pub fn project(&self) -> &str {
-        &self.project
-    }
-
-    pub fn version(&self) -> &Version {
-        &self.version
-    }
-
-    pub fn revision(&self) -> &str {
-        &self.revision
-    }
-
     pub fn local_path(&self) -> Result<PathBuf, MetadataError> {
         Ok(Lockfile::dependency_path(&self.url, &self.path, &self.revision)?.join(&self.path))
     }

--- a/crates/metadata/src/lockfile.rs
+++ b/crates/metadata/src/lockfile.rs
@@ -73,6 +73,20 @@ impl LockSource {
             LockSource::Path(_) => None,
         }
     }
+
+    pub fn project(&self) -> Option<&str> {
+        match self {
+            LockSource::Repository(x) => Some(&x.project),
+            LockSource::Path(_) => None,
+        }
+    }
+
+    pub fn local_path(&self, root_path: &Path) -> Result<PathBuf, MetadataError> {
+        match self {
+            LockSource::Repository(x) => x.local_path(),
+            LockSource::Path(path) => Ok(root_path.join(path)),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -85,6 +99,32 @@ pub struct LockSourceRepository {
     version: Version,
     revision: String,
     r#override: Option<PathBuf>,
+}
+
+impl LockSourceRepository {
+    pub fn url(&self) -> &UrlPath {
+        &self.url
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn project(&self) -> &str {
+        &self.project
+    }
+
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+
+    pub fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    pub fn local_path(&self) -> Result<PathBuf, MetadataError> {
+        Ok(Lockfile::dependency_path(&self.url, &self.path, &self.revision)?.join(&self.path))
+    }
 }
 
 impl PartialOrd for LockSource {
@@ -131,6 +171,16 @@ pub struct LockDependency {
 }
 
 impl Lockfile {
+    pub fn projects(&self) -> Vec<&Lock> {
+        let mut ret = self
+            .lock_table
+            .values()
+            .flat_map(|locks| locks.iter())
+            .collect::<Vec<_>>();
+        ret.sort_by(|x, y| x.name.cmp(&y.name).then(x.source.cmp(&y.source)));
+        ret
+    }
+
     pub fn load(metadata: &Metadata) -> Result<Self, MetadataError> {
         let path = metadata
             .lockfile_path
@@ -595,7 +645,7 @@ impl Lockfile {
         Ok(dependencies_dir.join(uuid.simple().encode_lower(&mut Uuid::encode_buffer())))
     }
 
-    fn get_metadata(&self, source: &LockSource) -> Result<Metadata, MetadataError> {
+    pub(crate) fn get_metadata(&self, source: &LockSource) -> Result<Metadata, MetadataError> {
         // try to load from local path
         let path = match source {
             LockSource::Path(x) => Some(x.clone()),

--- a/crates/metadata/src/metadata.rs
+++ b/crates/metadata/src/metadata.rs
@@ -54,6 +54,8 @@ pub struct Metadata {
     pub synth: Synth,
     #[serde(default)]
     pub dependencies: HashMap<String, Dependency>,
+    #[serde(default)]
+    pub metadata: HashMap<String, toml::Value>,
     #[serde(skip)]
     pub metadata_path: PathBuf,
     #[serde(skip)]

--- a/crates/metadata/src/metadata_output.rs
+++ b/crates/metadata/src/metadata_output.rs
@@ -1,0 +1,123 @@
+use crate::lockfile::{Lock, LockSource};
+use crate::metadata::Metadata;
+use crate::metadata_error::MetadataError;
+use semver::Version;
+use serde::Serialize;
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct MetadataOutputV2 {
+    pub format_version: usize,
+    pub root: MetadataProjectV2,
+    pub dependencies: Vec<MetadataDependencyV2>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct MetadataProjectV2 {
+    pub name: String,
+    pub version: Option<Version>,
+    pub local_path: PathBuf,
+    pub metadata: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct MetadataDependencyV2 {
+    pub id: String,
+    pub name: String,
+    pub project: String,
+    pub source: MetadataSourceV2,
+    pub local_path: PathBuf,
+    pub metadata: BTreeMap<String, toml::Value>,
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MetadataSourceV2 {
+    Path {
+        path: PathBuf,
+    },
+    Repository {
+        url: String,
+        project: String,
+        version: Version,
+        revision: String,
+        path: PathBuf,
+    },
+}
+
+impl MetadataOutputV2 {
+    pub fn from_metadata(metadata: &Metadata) -> Result<Self, MetadataError> {
+        let project_path = metadata.project_path();
+        let locks = metadata.lockfile.projects();
+        let dependency_ids = locks
+            .iter()
+            .map(|lock| (lock.source.clone(), format!("dep:{}", lock.name)))
+            .collect::<HashMap<_, _>>();
+        let mut dependencies = locks
+            .iter()
+            .map(|lock| MetadataDependencyV2::from_lock(lock, metadata, &dependency_ids))
+            .collect::<Result<Vec<_>, _>>()?;
+        dependencies.sort_by(|x, y| x.id.cmp(&y.id));
+
+        Ok(Self {
+            format_version: 2,
+            root: MetadataProjectV2 {
+                name: metadata.project.name.clone(),
+                version: metadata.project.version.clone(),
+                local_path: project_path,
+                metadata: metadata.metadata.clone().into_iter().collect(),
+            },
+            dependencies,
+        })
+    }
+}
+
+impl MetadataDependencyV2 {
+    fn from_lock(
+        lock: &Lock,
+        root_metadata: &Metadata,
+        dependency_ids: &HashMap<LockSource, String>,
+    ) -> Result<Self, MetadataError> {
+        let source = MetadataSourceV2::from_lock_source(&lock.source);
+        let metadata = root_metadata.lockfile.get_metadata(&lock.source)?;
+        let mut dependencies = lock
+            .dependencies
+            .iter()
+            .map(|dependency| {
+                dependency_ids
+                    .get(&dependency.source)
+                    .cloned()
+                    .unwrap_or_else(|| format!("dep:{}", dependency.name))
+            })
+            .collect::<Vec<_>>();
+        dependencies.sort();
+
+        Ok(Self {
+            // Lock names are conflict-disambiguated during lock generation, so they are stable ids.
+            id: format!("dep:{}", lock.name),
+            name: lock.name.clone(),
+            project: metadata.project.name.clone(),
+            local_path: metadata.project_path(),
+            metadata: metadata.metadata.into_iter().collect(),
+            source,
+            dependencies,
+        })
+    }
+}
+
+impl MetadataSourceV2 {
+    fn from_lock_source(source: &LockSource) -> Self {
+        match source {
+            LockSource::Path(path) => Self::Path { path: path.clone() },
+            LockSource::Repository(repository) => Self::Repository {
+                url: repository.url().to_string(),
+                project: repository.project().to_string(),
+                version: repository.version().clone(),
+                revision: repository.revision().to_string(),
+                path: repository.path().to_path_buf(),
+            },
+        }
+    }
+}

--- a/crates/metadata/src/metadata_output.rs
+++ b/crates/metadata/src/metadata_output.rs
@@ -112,11 +112,11 @@ impl MetadataSourceV2 {
         match source {
             LockSource::Path(path) => Self::Path { path: path.clone() },
             LockSource::Repository(repository) => Self::Repository {
-                url: repository.url().to_string(),
-                project: repository.project().to_string(),
-                version: repository.version().clone(),
-                revision: repository.revision().to_string(),
-                path: repository.path().to_path_buf(),
+                url: repository.url.to_string(),
+                project: repository.project.clone(),
+                version: repository.version.clone(),
+                revision: repository.revision.clone(),
+                path: repository.path.clone(),
             },
         }
     }

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -356,6 +356,7 @@ fn reject_unknown_top_level_table() {
 fn metadata_output_v2_simple_project() {
     let tempdir = tempfile::tempdir().unwrap();
     let metadata = create_project(tempdir.path(), "test", EXTENSION_EXTERNAL_TOOL_TOML, false);
+    let project_path = tempdir.path().join("test").canonicalize().unwrap();
 
     let output = MetadataOutputV2::from_metadata(&metadata).unwrap();
     let encoded = serde_json::to_string(&output).unwrap();
@@ -365,7 +366,7 @@ fn metadata_output_v2_simple_project() {
     assert_eq!(value["format_version"], 2);
     assert_eq!(output.root.name, "test");
     assert_eq!(output.root.version, Some(Version::parse("0.1.0").unwrap()));
-    assert_eq!(output.root.local_path, tempdir.path().join("test"));
+    assert_eq!(output.root.local_path, project_path);
     assert_eq!(
         output
             .root
@@ -388,7 +389,7 @@ fn metadata_output_v2_simple_project() {
     assert_eq!(value["root"]["name"], "test");
     assert_eq!(
         value["root"]["local_path"].as_str().unwrap(),
-        tempdir.path().join("test").to_string_lossy().as_ref()
+        project_path.to_string_lossy().as_ref()
     );
     assert_eq!(
         value["root"]["metadata"]["external_tool"]["attrs"]["role"],

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -25,6 +25,34 @@ target = {type = "source"}
 indent_width = 4
 "#;
 
+const EXTENSION_EXTERNAL_TOOL_TOML: &str = r#"
+[project]
+name = "test"
+version = "0.1.0"
+
+[metadata.external_tool]
+files = ["src/**/*.v"]
+attrs = { role = "core" }
+"#;
+
+const EXTENSION_OTHER_TOOL_TOML: &str = r#"
+[project]
+name = "test"
+version = "0.1.0"
+
+[metadata.other_tool]
+enabled = true
+"#;
+
+const UNKNOWN_TOP_LEVEL_TOML: &str = r#"
+[project]
+name = "test"
+version = "0.1.0"
+
+[unknown]
+value = true
+"#;
+
 const MAIN_TOML: &str = r#"
 [project]
 name = "main"
@@ -256,6 +284,191 @@ fn check_toml() {
     assert!(metadata.build.reset_low_prefix.is_none());
     assert_eq!(metadata.build.reset_low_suffix.unwrap(), "_n");
     assert_eq!(metadata.format.indent_width, 4);
+}
+
+#[test]
+fn load_extension_namespace_metadata() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let toml_path = tempdir.path().join("Veryl.toml");
+    fs::write(&toml_path, EXTENSION_EXTERNAL_TOOL_TOML).unwrap();
+
+    let metadata = Metadata::load(&toml_path).unwrap();
+    let external_tool = metadata
+        .metadata
+        .get("external_tool")
+        .unwrap()
+        .as_table()
+        .unwrap();
+
+    assert_eq!(
+        external_tool.get("files").unwrap().as_array().unwrap()[0]
+            .as_str()
+            .unwrap(),
+        "src/**/*.v"
+    );
+    assert_eq!(
+        external_tool
+            .get("attrs")
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .get("role")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        "core"
+    );
+}
+
+#[test]
+fn load_extension_namespace_other_tool() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let toml_path = tempdir.path().join("Veryl.toml");
+    fs::write(&toml_path, EXTENSION_OTHER_TOOL_TOML).unwrap();
+
+    let metadata = Metadata::load(&toml_path).unwrap();
+
+    assert!(metadata.metadata.contains_key("other_tool"));
+    assert!(
+        metadata
+            .metadata
+            .get("other_tool")
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .get("enabled")
+            .unwrap()
+            .as_bool()
+            .unwrap()
+    );
+}
+
+#[test]
+fn reject_unknown_top_level_table() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let toml_path = tempdir.path().join("Veryl.toml");
+    fs::write(&toml_path, UNKNOWN_TOP_LEVEL_TOML).unwrap();
+
+    assert!(Metadata::load(&toml_path).is_err());
+}
+
+#[test]
+fn metadata_output_v2_simple_project() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let metadata = create_project(tempdir.path(), "test", EXTENSION_EXTERNAL_TOOL_TOML, false);
+
+    let output = MetadataOutputV2::from_metadata(&metadata).unwrap();
+    let encoded = serde_json::to_string(&output).unwrap();
+    let value = serde_json::to_value(&output).unwrap();
+
+    assert_eq!(output.format_version, 2);
+    assert_eq!(value["format_version"], 2);
+    assert_eq!(output.root.name, "test");
+    assert_eq!(output.root.version, Some(Version::parse("0.1.0").unwrap()));
+    assert_eq!(output.root.local_path, tempdir.path().join("test"));
+    assert_eq!(
+        output
+            .root
+            .metadata
+            .get("external_tool")
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .get("attrs")
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .get("role")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        "core"
+    );
+    assert!(output.dependencies.is_empty());
+    assert_eq!(value["root"]["name"], "test");
+    assert_eq!(
+        value["root"]["local_path"].as_str().unwrap(),
+        tempdir.path().join("test").to_string_lossy().as_ref()
+    );
+    assert_eq!(
+        value["root"]["metadata"]["external_tool"]["attrs"]["role"],
+        "core"
+    );
+    assert!(value.get("metadata").is_none());
+    assert!(!encoded.contains("metadata_path"));
+    assert!(!encoded.contains("lockfile_path"));
+    assert!(!encoded.contains("pubfile_path"));
+    assert!(!encoded.contains("build_info"));
+}
+
+#[test]
+fn metadata_output_v2_multi_dependency_deterministic() {
+    let (mut metadata, _tempdir) = create_metadata_multi();
+    metadata.update_lockfile().unwrap();
+
+    let output = MetadataOutputV2::from_metadata(&metadata).unwrap();
+    let repeated = MetadataOutputV2::from_metadata(&metadata).unwrap();
+    let encoded = serde_json::to_string(&output).unwrap();
+    let repeated_encoded = serde_json::to_string(&repeated).unwrap();
+    let value = serde_json::to_value(&output).unwrap();
+    let ids = output
+        .dependencies
+        .iter()
+        .map(|dependency| dependency.id.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(encoded, repeated_encoded);
+    assert_eq!(value["format_version"], 2);
+    assert!(!output.dependencies.is_empty());
+    assert!(ids.windows(2).all(|window| window[0] <= window[1]));
+    assert!(ids.contains(&"dep:sub1"));
+    assert!(ids.contains(&"dep:sub2"));
+    assert!(ids.contains(&"dep:sub2_0"));
+    assert!(output.dependencies.iter().any(|dependency| {
+        dependency.id == "dep:sub1" && dependency.dependencies.contains(&"dep:sub2_0".to_string())
+    }));
+    assert!(output.dependencies.iter().any(|dependency| {
+        matches!(dependency.source, MetadataSourceV2::Repository { .. })
+            && !dependency.local_path.as_os_str().is_empty()
+    }));
+    assert!(output.dependencies.iter().any(|dependency| {
+        matches!(dependency.source, MetadataSourceV2::Path { .. })
+            && !dependency.local_path.as_os_str().is_empty()
+    }));
+    assert!(
+        output
+            .dependencies
+            .iter()
+            .all(|dependency| dependency.local_path.is_absolute())
+    );
+    assert!(
+        output
+            .dependencies
+            .iter()
+            .all(|dependency| dependency.metadata.is_empty())
+    );
+    assert!(
+        output
+            .dependencies
+            .iter()
+            .all(|dependency| !dependency.local_path.as_os_str().is_empty())
+    );
+    assert!(
+        value["dependencies"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|dependency| {
+                dependency
+                    .get("local_path")
+                    .and_then(|local_path| local_path.as_str())
+                    .is_some_and(|local_path| !local_path.is_empty())
+            })
+    );
+    assert!(!encoded.contains("metadata_path"));
+    assert!(!encoded.contains("lockfile_path"));
+    assert!(!encoded.contains("pubfile_path"));
+    assert!(!encoded.contains("build_info"));
 }
 
 #[test]

--- a/crates/veryl/src/cmd_metadata.rs
+++ b/crates/veryl/src/cmd_metadata.rs
@@ -1,6 +1,6 @@
 use crate::{Format, OptMetadata};
-use miette::{IntoDiagnostic, Result};
-use veryl_metadata::Metadata;
+use miette::{IntoDiagnostic, Result, bail};
+use veryl_metadata::{Metadata, MetadataOutputV2};
 
 pub struct CmdMetadata {
     opt: OptMetadata,
@@ -11,14 +11,261 @@ impl CmdMetadata {
         Self { opt }
     }
 
-    pub fn exec(&self, metadata: &Metadata) -> Result<bool> {
-        let text = match self.opt.format {
-            Format::Json => serde_json::to_string(metadata).into_diagnostic()?,
-            Format::Pretty => format!("{metadata:#?}"),
-        };
+    pub fn exec(&self, metadata: &mut Metadata) -> Result<bool> {
+        let text = self.format_metadata(metadata)?;
 
         println!("{text}");
 
         Ok(true)
+    }
+
+    fn format_metadata(&self, metadata: &mut Metadata) -> Result<String> {
+        match (self.opt.format, self.opt.format_version) {
+            (Format::Json, None) => serde_json::to_string(metadata).into_diagnostic(),
+            (Format::Pretty, None) => Ok(format!("{metadata:#?}")),
+            (Format::Json, Some(1)) => serde_json::to_string(metadata).into_diagnostic(),
+            (Format::Json, Some(2)) => {
+                metadata.update_lockfile()?;
+                let output = MetadataOutputV2::from_metadata(metadata)?;
+                serde_json::to_string(&output).into_diagnostic()
+            }
+            (Format::Pretty, Some(_)) => {
+                bail!("--format-version is only supported with --format json")
+            }
+            (Format::Json, Some(version)) => {
+                bail!("unsupported --format-version {version}; supported versions: 1, 2")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const TEST_TOML: &str = r#"
+[project]
+name = "test"
+version = "0.1.0"
+
+[metadata.external_tool]
+files = ["src/**/*.v"]
+"#;
+
+    fn load_metadata() -> (Metadata, tempfile::TempDir) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let project_dir = tempdir.path().join("test");
+        fs::create_dir(&project_dir).unwrap();
+        let toml_path = project_dir.join("Veryl.toml");
+        fs::write(&toml_path, TEST_TOML).unwrap();
+        let metadata = Metadata::load(&toml_path).unwrap();
+        (metadata, tempdir)
+    }
+
+    fn load_metadata_with_path_dependency() -> (Metadata, tempfile::TempDir) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root_dir = tempdir.path().join("root");
+        let dependency_dir = tempdir.path().join("dep");
+        fs::create_dir(&root_dir).unwrap();
+        fs::create_dir(&dependency_dir).unwrap();
+        fs::write(
+            root_dir.join("Veryl.toml"),
+            r#"
+[project]
+name = "root"
+version = "0.1.0"
+
+[dependencies]
+dep = {path = "../dep"}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dependency_dir.join("Veryl.toml"),
+            r#"
+[project]
+name = "real_dep"
+version = "0.1.0"
+
+[metadata.external_tool]
+role = "dependency"
+"#,
+        )
+        .unwrap();
+        let metadata = Metadata::load(root_dir.join("Veryl.toml")).unwrap();
+        (metadata, tempdir)
+    }
+
+    fn command(format: Format, format_version: Option<u32>) -> CmdMetadata {
+        CmdMetadata::new(OptMetadata {
+            format,
+            format_version,
+        })
+    }
+
+    #[test]
+    fn json_format_version_1_preserves_internal_metadata_shape() {
+        // Given: project metadata with extension-owned metadata.
+        let (mut metadata, _tempdir) = load_metadata();
+
+        // When: JSON metadata is formatted with legacy format version 1.
+        let versioned_text = command(Format::Json, Some(1))
+            .format_metadata(&mut metadata)
+            .unwrap();
+        let unversioned_text = command(Format::Json, None)
+            .format_metadata(&mut metadata)
+            .unwrap();
+        let versioned_value: serde_json::Value = serde_json::from_str(&versioned_text).unwrap();
+        let unversioned_value: serde_json::Value = serde_json::from_str(&unversioned_text).unwrap();
+
+        // Then: version 1 is the same legacy/internal JSON shape as unversioned JSON.
+        assert_eq!(versioned_value, unversioned_value);
+        assert!(versioned_value.get("format_version").is_none());
+        assert!(versioned_value.get("root").is_none());
+        assert!(versioned_value.get("project").is_some());
+        assert_eq!(
+            versioned_value["metadata"]["external_tool"]["files"][0],
+            "src/**/*.v"
+        );
+    }
+
+    #[test]
+    fn json_format_version_2_emits_stable_graph_metadata_shape() {
+        // Given: project metadata with extension-owned metadata.
+        let (mut metadata, _tempdir) = load_metadata();
+
+        // When: JSON metadata is formatted with stable graph format version 2.
+        let text = command(Format::Json, Some(2)).format_metadata(&mut metadata);
+
+        // Then: version 2 uses the stable graph metadata contract.
+        assert!(
+            text.as_ref().is_ok(),
+            "format version 2 should be supported: {:?}",
+            text.as_ref().err()
+        );
+        let value: serde_json::Value = serde_json::from_str(&text.unwrap()).unwrap();
+        assert_eq!(value["format_version"], 2);
+        assert_eq!(value["root"]["name"], "test");
+        assert_eq!(
+            value["root"]["metadata"]["external_tool"]["files"][0],
+            "src/**/*.v"
+        );
+        assert!(value["dependencies"].as_array().unwrap().is_empty());
+        assert!(value.get("metadata").is_none());
+        assert!(value.get("project").is_none());
+    }
+
+    #[test]
+    fn unversioned_json_preserves_internal_metadata_shape() {
+        // Given: project metadata with extension-owned metadata.
+        let (mut metadata, _tempdir) = load_metadata();
+
+        // When: JSON metadata is formatted without an explicit version.
+        let text = command(Format::Json, None)
+            .format_metadata(&mut metadata)
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        // Then: unversioned JSON preserves the existing internal metadata shape.
+        assert!(value.get("format_version").is_none());
+        assert!(value.get("root").is_none());
+        assert!(value.get("project").is_some());
+    }
+
+    #[test]
+    fn pretty_format_version_is_rejected() {
+        // Given: project metadata and pretty output with explicit format versions.
+        let (mut metadata, _tempdir) = load_metadata();
+
+        for version in [1, 2] {
+            // When: pretty metadata is formatted with an explicit version.
+            let error = command(Format::Pretty, Some(version))
+                .format_metadata(&mut metadata)
+                .unwrap_err();
+
+            // Then: pretty format rejects every explicit version.
+            assert!(
+                error
+                    .to_string()
+                    .contains("--format-version is only supported with --format json")
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_format_version_is_rejected() {
+        // Given: project metadata.
+        let (mut metadata, _tempdir) = load_metadata();
+
+        // When: JSON metadata is formatted with an unsupported version.
+        let error = command(Format::Json, Some(3))
+            .format_metadata(&mut metadata)
+            .unwrap_err();
+
+        // Then: the error reports all supported versions.
+        assert!(error.to_string().contains("unsupported --format-version 3"));
+        assert!(error.to_string().contains("supported versions: 1, 2"));
+    }
+
+    #[test]
+    fn json_format_version_2_resolves_missing_lockfile() {
+        // Given: project metadata with a path dependency and no existing lockfile.
+        let (mut metadata, _tempdir) = load_metadata_with_path_dependency();
+        assert!(!metadata.lockfile_path.exists());
+
+        // When: JSON metadata is formatted with stable graph format version 2.
+        let text = command(Format::Json, Some(2))
+            .format_metadata(&mut metadata)
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        // Then: version 2 creates the lockfile and emits resolved dependencies.
+        assert!(metadata.lockfile_path.exists());
+        assert_eq!(value["format_version"], 2);
+        assert_eq!(value["root"]["metadata"], serde_json::json!({}));
+        assert_eq!(value["dependencies"][0]["name"], "dep");
+        assert_eq!(value["dependencies"][0]["project"], "real_dep");
+        assert_eq!(value["dependencies"][0]["source"]["kind"], "path");
+        assert!(
+            value["dependencies"][0]["local_path"]
+                .as_str()
+                .unwrap()
+                .starts_with('/')
+        );
+        assert_eq!(
+            value["dependencies"][0]["metadata"]["external_tool"]["role"],
+            "dependency"
+        );
+    }
+
+    #[test]
+    fn legacy_json_does_not_resolve_missing_lockfile() {
+        // Given: project metadata with a path dependency and no existing lockfile.
+        let (mut metadata, _tempdir) = load_metadata_with_path_dependency();
+        assert!(!metadata.lockfile_path.exists());
+
+        // When: legacy JSON metadata is formatted.
+        let _text = command(Format::Json, Some(1))
+            .format_metadata(&mut metadata)
+            .unwrap();
+
+        // Then: legacy JSON keeps the existing debug behavior and does not create a lockfile.
+        assert!(!metadata.lockfile_path.exists());
+    }
+
+    #[test]
+    fn unversioned_json_does_not_resolve_missing_lockfile() {
+        // Given: project metadata with a path dependency and no existing lockfile.
+        let (mut metadata, _tempdir) = load_metadata_with_path_dependency();
+        assert!(!metadata.lockfile_path.exists());
+
+        // When: unversioned JSON metadata is formatted.
+        let _text = command(Format::Json, None)
+            .format_metadata(&mut metadata)
+            .unwrap();
+
+        // Then: unversioned JSON keeps the existing debug behavior and does not create a lockfile.
+        assert!(!metadata.lockfile_path.exists());
     }
 }

--- a/crates/veryl/src/cmd_metadata.rs
+++ b/crates/veryl/src/cmd_metadata.rs
@@ -42,7 +42,7 @@ impl CmdMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::{fs, path::Path};
 
     const TEST_TOML: &str = r#"
 [project]
@@ -227,12 +227,8 @@ role = "dependency"
         assert_eq!(value["dependencies"][0]["name"], "dep");
         assert_eq!(value["dependencies"][0]["project"], "real_dep");
         assert_eq!(value["dependencies"][0]["source"]["kind"], "path");
-        assert!(
-            value["dependencies"][0]["local_path"]
-                .as_str()
-                .unwrap()
-                .starts_with('/')
-        );
+        let local_path = value["dependencies"][0]["local_path"].as_str().unwrap();
+        assert!(Path::new(local_path).is_absolute());
         assert_eq!(
             value["dependencies"][0]["metadata"]["external_tool"]["role"],
             "dependency"

--- a/crates/veryl/src/lib.rs
+++ b/crates/veryl/src/lib.rs
@@ -305,6 +305,10 @@ pub struct OptMetadata {
     /// output format
     #[arg(long, value_enum, default_value_t)]
     pub format: Format,
+
+    /// metadata output format version
+    #[arg(long = "format-version")]
+    pub format_version: Option<u32>,
 }
 
 #[derive(Clone, Copy, Default, Debug, ValueEnum)]

--- a/crates/veryl/src/main.rs
+++ b/crates/veryl/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> Result<ExitCode> {
         Commands::Publish(x) => cmd_publish::CmdPublish::new(x).exec(&mut metadata),
         Commands::Migrate(x) => cmd_migrate::CmdMigrate::new(x).exec(&mut metadata, opt.quiet),
         Commands::Doc(x) => cmd_doc::CmdDoc::new(x).exec(&mut metadata),
-        Commands::Metadata(x) => cmd_metadata::CmdMetadata::new(x).exec(&metadata),
+        Commands::Metadata(x) => cmd_metadata::CmdMetadata::new(x).exec(&mut metadata),
         Commands::Dump(x) => cmd_dump::CmdDump::new(x).exec(&mut metadata),
         Commands::Test(x) => {
             let ret = cmd_test::CmdTest::new(x).exec(&mut metadata);


### PR DESCRIPTION
## Summary
- add a versioned metadata JSON output shape for resolved project graphs
- include root and dependency metadata, source identity, and local paths for external tools
- reserve and preserve external tool metadata from `Veryl.toml`

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p veryl-metadata`
- `cargo test -p veryl cmd_metadata`

Closes #2648