### PR TITLE
Support Cargo-like external subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5949,6 +5949,7 @@ dependencies = [
  "fern",
  "futures",
  "handlebars",
+ "libc",
  "log",
  "mdbook-driver",
  "mdbook-preprocessor",

--- a/crates/veryl/Cargo.toml
+++ b/crates/veryl/Cargo.toml
@@ -30,6 +30,7 @@ console             = {workspace = true}
 fern                = "0.7.0"
 futures             = {workspace = true}
 handlebars          = {workspace = true}
+libc                = "0.2"
 log                 = {workspace = true}
 once_cell           = {workspace = true}
 mdbook-driver       = {workspace = true}

--- a/crates/veryl/src/external_subcommand.rs
+++ b/crates/veryl/src/external_subcommand.rs
@@ -1,0 +1,94 @@
+mod help;
+
+pub use help::print_command_list;
+
+use miette::{IntoDiagnostic, Result, bail};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+pub(crate) const OFFICIAL_NON_SUBCOMMAND_SUFFIXES: &[&str] = &["ls"];
+
+pub(crate) fn is_official_non_subcommand_suffix(name: &str) -> bool {
+    OFFICIAL_NON_SUBCOMMAND_SUFFIXES.contains(&name)
+}
+
+pub fn dispatch(args: Vec<OsString>) -> Result<ExitCode> {
+    let Some((name, forwarded_args)) = args.split_first() else {
+        bail!("external subcommand name is empty");
+    };
+
+    let binary_name = binary_name(name)?;
+    let Some(binary_path) = find_on_path(&binary_name) else {
+        bail!(
+            "external subcommand `{}` was not found on PATH; install `{}` directly or make sure a `veryl-{}` executable is available on PATH",
+            name.to_string_lossy(),
+            binary_name.to_string_lossy(),
+            name.to_string_lossy(),
+        );
+    };
+
+    let status = Command::new(binary_path)
+        .args(forwarded_args)
+        .status()
+        .into_diagnostic()?;
+    if let Some(code) = status.code() {
+        Ok(exit_code_from_i32(code))
+    } else {
+        eprintln!(
+            "external subcommand `{}` terminated without an exit code",
+            binary_name.to_string_lossy()
+        );
+        Ok(ExitCode::FAILURE)
+    }
+}
+
+fn binary_name(name: &OsStr) -> Result<OsString> {
+    let name = name.to_string_lossy();
+    if name.is_empty() {
+        bail!("external subcommand name is empty");
+    }
+    if name.contains('/') || name.contains('\\') || name.contains(std::path::MAIN_SEPARATOR) {
+        bail!("external subcommand `{name}` must not contain path separators");
+    }
+    if is_official_non_subcommand_suffix(&name) {
+        bail!("`veryl-{name}` is an official Veryl binary, not an external subcommand");
+    }
+
+    Ok(OsString::from(format!("veryl-{name}")))
+}
+
+fn find_on_path(binary_name: &OsStr) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|path| {
+        std::env::split_paths(&path)
+            .map(|dir| dir.join(binary_name))
+            .find(|path| is_executable_file(path))
+    })
+}
+
+pub(super) fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        path.metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn exit_code_from_i32(code: i32) -> ExitCode {
+    match u8::try_from(code) {
+        Ok(code) => ExitCode::from(code),
+        Err(_) => ExitCode::FAILURE,
+    }
+}

--- a/crates/veryl/src/external_subcommand/help.rs
+++ b/crates/veryl/src/external_subcommand/help.rs
@@ -1,0 +1,271 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command as ProcessCommand, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+use clap::Command as ClapCommand;
+use miette::{IntoDiagnostic, Result};
+
+use super::{is_executable_file, is_official_non_subcommand_suffix};
+
+const MAX_INFO_DESCRIPTION_CHARS: usize = 160;
+const MAX_INFO_DESCRIPTION_BYTES: usize = MAX_INFO_DESCRIPTION_CHARS * 4 + 2;
+const INFO_TIMEOUT: Duration = Duration::from_millis(500);
+const INFO_KILL_GRACE: Duration = Duration::from_millis(200);
+const EXTERNAL_FALLBACK_DESCRIPTION: &str = "External Veryl subcommand from PATH";
+const HELP_DESCRIPTION: &str = "Print this message or the help of the given subcommand(s)";
+
+enum CommandInfo {
+    BuiltIn { description: String },
+    External { binary_name: String, path: PathBuf },
+}
+
+pub fn print_command_list(command: ClapCommand) -> Result<()> {
+    let list = render_command_list(command);
+    std::io::stdout()
+        .write_all(list.as_bytes())
+        .into_diagnostic()?;
+    Ok(())
+}
+
+fn render_command_list(command: ClapCommand) -> String {
+    let mut commands = discover_external_commands();
+    insert_builtin_commands(&mut commands, command);
+    commands.insert(
+        "help".to_owned(),
+        CommandInfo::BuiltIn {
+            description: HELP_DESCRIPTION.to_owned(),
+        },
+    );
+
+    let mut output = String::from("Available Commands:\n");
+    for (name, info) in commands {
+        let description = match info {
+            CommandInfo::BuiltIn { description } => description,
+            CommandInfo::External { binary_name, path } => probe_info_description(&path)
+                .unwrap_or_else(|| format!("{EXTERNAL_FALLBACK_DESCRIPTION} ({binary_name})")),
+        };
+        output.push_str(&format!("  {name:<12} {description}\n"));
+    }
+    output
+}
+
+fn insert_builtin_commands(commands: &mut BTreeMap<String, CommandInfo>, command: ClapCommand) {
+    for subcommand in command.get_subcommands() {
+        if subcommand.is_hide_set() {
+            continue;
+        }
+
+        commands.insert(
+            subcommand.get_name().to_owned(),
+            CommandInfo::BuiltIn {
+                description: subcommand
+                    .get_about()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            },
+        );
+    }
+}
+
+fn discover_external_commands() -> BTreeMap<String, CommandInfo> {
+    let Some(path) = std::env::var_os("PATH") else {
+        return BTreeMap::new();
+    };
+
+    discover_from_path_entries(std::env::split_paths(&path))
+}
+
+fn discover_from_path_entries<P>(
+    path_entries: impl IntoIterator<Item = P>,
+) -> BTreeMap<String, CommandInfo>
+where
+    P: AsRef<Path>,
+{
+    let mut discovered = BTreeMap::new();
+    for dir in path_entries {
+        let Ok(entries) = fs::read_dir(dir.as_ref()) else {
+            continue;
+        };
+
+        for entry in entries.filter_map(std::result::Result::ok) {
+            let path = entry.path();
+            if !is_executable_file(&path) {
+                continue;
+            }
+
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                continue;
+            };
+            let Some(suffix) = file_name.strip_prefix("veryl-") else {
+                continue;
+            };
+            if valid_external_suffix(suffix) {
+                discovered
+                    .entry(suffix.to_owned())
+                    .or_insert_with(|| CommandInfo::External {
+                        binary_name: file_name.to_owned(),
+                        path: path.clone(),
+                    });
+            }
+        }
+    }
+
+    discovered
+}
+
+fn valid_external_suffix(suffix: &str) -> bool {
+    !suffix.is_empty()
+        && !suffix.contains('/')
+        && !suffix.contains('\\')
+        && !suffix.contains(std::path::MAIN_SEPARATOR)
+        && !is_official_non_subcommand_suffix(suffix)
+}
+
+fn probe_info_description(path: &Path) -> Option<String> {
+    let mut command = ProcessCommand::new(path);
+    command
+        .arg("--info")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    configure_info_probe_command(&mut command);
+
+    let mut child = command.spawn().ok()?;
+    let stdout = child.stdout.take()?;
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let limit = u64::try_from(MAX_INFO_DESCRIPTION_BYTES + 1).unwrap_or(u64::MAX);
+        let stdout = match stdout.take(limit).read_to_end(&mut bytes) {
+            Ok(_) if bytes.len() <= MAX_INFO_DESCRIPTION_BYTES => String::from_utf8(bytes).ok(),
+            Ok(_) | Err(_) => None,
+        };
+        let _ = stdout_tx.send(stdout);
+    });
+
+    let started = Instant::now();
+    let mut child_exited_successfully = false;
+    let mut stdout = None;
+    loop {
+        if stdout.is_none() {
+            match stdout_rx.try_recv() {
+                Ok(Some(output)) => stdout = Some(output),
+                Ok(None) | Err(mpsc::TryRecvError::Disconnected) => {
+                    terminate_info_probe(&mut child);
+                    return None;
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
+        }
+
+        if child_exited_successfully && let Some(stdout) = stdout {
+            return parse_info_description(&stdout);
+        }
+
+        if !child_exited_successfully {
+            let Some(status) = child.try_wait().ok()? else {
+                if started.elapsed() >= INFO_TIMEOUT {
+                    terminate_info_probe(&mut child);
+                    return None;
+                }
+
+                std::thread::sleep(Duration::from_millis(10));
+                continue;
+            };
+
+            if !status.success() {
+                terminate_info_probe(&mut child);
+                return None;
+            }
+
+            child_exited_successfully = true;
+        }
+
+        if started.elapsed() >= INFO_TIMEOUT {
+            terminate_info_probe(&mut child);
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn configure_info_probe_command(command: &mut ProcessCommand) {
+    #[cfg(unix)]
+    {
+        command.process_group(0);
+    }
+}
+
+fn terminate_info_probe(child: &mut Child) {
+    #[cfg(unix)]
+    terminate_info_probe_group(child);
+
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+#[cfg(unix)]
+fn terminate_info_probe_group(child: &mut Child) {
+    let process_group = child.id();
+    if let Ok(process_group) = i32::try_from(process_group) {
+        kill_process_group(process_group, libc::SIGKILL);
+        let _ = child.wait();
+
+        let started = Instant::now();
+        while process_group_exists(process_group) && started.elapsed() < INFO_KILL_GRACE {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    } else {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+#[cfg(unix)]
+fn kill_process_group(process_group: i32, signal: i32) {
+    // SAFETY: Category 8 - FFI boundary. libc::kill is called with a negative
+    // process-group id created by CommandExt::process_group(0) for this probe.
+    // The call does not pass Rust references or memory across the FFI boundary.
+    unsafe {
+        libc::kill(-process_group, signal);
+    }
+}
+
+#[cfg(unix)]
+fn process_group_exists(process_group: i32) -> bool {
+    // SAFETY: Category 8 - FFI boundary. Signal 0 performs only an OS existence
+    // check for the process group id; no Rust memory or aliasing invariants cross
+    // the FFI boundary.
+    unsafe { libc::kill(-process_group, 0) == 0 }
+}
+
+fn parse_info_description(stdout: &str) -> Option<String> {
+    let line = stdout
+        .strip_suffix("\r\n")
+        .or_else(|| stdout.strip_suffix('\n'))
+        .unwrap_or(stdout);
+
+    if line.contains('\n') || line.contains('\r') || line.chars().any(char::is_control) {
+        return None;
+    }
+
+    let line = line.trim();
+    if line.is_empty() || line.chars().count() > MAX_INFO_DESCRIPTION_CHARS {
+        return None;
+    }
+
+    Some(line.to_owned())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/veryl/src/external_subcommand/help/tests.rs
+++ b/crates/veryl/src/external_subcommand/help/tests.rs
@@ -1,0 +1,234 @@
+use super::*;
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
+fn write_file(dir: &Path, name: &OsStr, mode: u32) {
+    let path = dir.join(Path::new(name));
+    fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(mode);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(unix)]
+fn write_executable(dir: &Path, name: &OsStr) {
+    write_file(dir, name, 0o755);
+}
+
+#[cfg(unix)]
+fn write_non_executable(dir: &Path, name: &OsStr) {
+    write_file(dir, name, 0o644);
+}
+
+#[test]
+#[cfg(unix)]
+fn discover_subcommands_keeps_valid_utf8_executable_suffixes_sorted() {
+    // Given: duplicate valid external subcommands exist across PATH entries.
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_executable(first.path(), OsStr::new("veryl-import"));
+    write_executable(second.path(), OsStr::new("veryl-import"));
+    write_executable(second.path(), OsStr::new("veryl-flist"));
+
+    // When: discovery scans those PATH entries.
+    let discovered = discover_from_path_entries([first.path(), second.path()]);
+
+    // Then: names are deduped and sorted by Rust String ordering.
+    assert_eq!(names(&discovered), ["flist", "import"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn discover_subcommands_ignores_official_non_subcommand_suffixes() {
+    // Given: PATH contains an official Veryl binary that uses the `veryl-` prefix.
+    let dir = tempfile::tempdir().unwrap();
+    write_executable(dir.path(), OsStr::new("veryl-ls"));
+    write_executable(dir.path(), OsStr::new("veryl-import"));
+
+    // When: discovery scans that PATH entry.
+    let discovered = discover_from_path_entries([dir.path()]);
+
+    // Then: only real external subcommands remain.
+    assert_eq!(names(&discovered), ["import"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn discover_subcommands_ignores_non_executable_non_directory_and_malformed_entries() {
+    // Given: PATH includes malformed candidates, a plain file entry, and one valid command.
+    let dir = tempfile::tempdir().unwrap();
+    let plain_file = tempfile::NamedTempFile::new().unwrap();
+    write_executable(dir.path(), OsStr::new("veryl-flist"));
+    write_executable(dir.path(), OsStr::new("veryl-"));
+    write_executable(dir.path(), OsStr::new("veryl-bad\\name"));
+    #[cfg(not(target_os = "macos"))]
+    write_executable(dir.path(), OsStr::from_bytes(b"veryl-im\xffort"));
+    write_non_executable(dir.path(), OsStr::new("veryl-import"));
+
+    // When: discovery scans all entries.
+    let discovered = discover_from_path_entries([dir.path(), plain_file.path()]);
+
+    // Then: only valid executable suffixes survive.
+    assert_eq!(names(&discovered), ["flist"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn discover_subcommands_ignores_unreadable_path_entries() {
+    // Given: PATH includes an unreadable directory before a readable external command directory.
+    let unreadable = tempfile::tempdir().unwrap();
+    let readable = tempfile::tempdir().unwrap();
+    let mut permissions = fs::metadata(unreadable.path()).unwrap().permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(unreadable.path(), permissions).unwrap();
+    write_executable(readable.path(), OsStr::new("veryl-import"));
+
+    // When: discovery scans all entries.
+    let discovered = discover_from_path_entries([unreadable.path(), readable.path()]);
+
+    let mut permissions = fs::metadata(unreadable.path()).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(unreadable.path(), permissions).unwrap();
+
+    // Then: unreadable PATH entries do not fail discovery.
+    assert_eq!(names(&discovered), ["import"]);
+}
+
+#[test]
+fn parse_info_description_accepts_short_single_line_utf8() {
+    // Given: an external command prints one concise UTF-8 line.
+    let stdout = "Import Veryl modules\n";
+
+    // When: the summary is parsed.
+    let description = parse_info_description(stdout);
+
+    // Then: the trimmed line is accepted.
+    assert_eq!(description.as_deref(), Some("Import Veryl modules"));
+}
+
+#[test]
+fn parse_info_description_rejects_invalid_output() {
+    let long = "x".repeat(MAX_INFO_DESCRIPTION_CHARS + 1);
+    for stdout in ["", "\n", "first\nsecond\n", "bad\tcontrol\n", &long] {
+        // Given: invalid stdout for the one-line `--info` protocol.
+        // When: the summary is parsed.
+        let description = parse_info_description(stdout);
+
+        // Then: the caller will fall back to the generic external description.
+        assert!(description.is_none(), "accepted invalid stdout: {stdout:?}");
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn probe_info_description_rejects_hanging_commands() {
+    // Given: an external command hangs while answering `--info`.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("veryl-slow");
+    fs::write(
+        &path,
+        "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then sleep 2; fi\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+
+    // When: the list-summary probe runs.
+    let description = probe_info_description(&path);
+
+    // Then: the probe times out and the caller will use fallback text.
+    assert!(description.is_none());
+}
+
+#[test]
+#[cfg(unix)]
+fn probe_info_description_rejects_oversized_output_without_waiting_for_process_exit() {
+    // Given: an external command emits one byte past the accepted summary limit and keeps stdout open.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("veryl-verbose");
+    let oversized_bytes = MAX_INFO_DESCRIPTION_BYTES + 1;
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then printf '%*s' {oversized_bytes} '' | tr ' ' x; sleep 2; fi\n",
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+
+    // When: the list-summary probe runs.
+    let started = Instant::now();
+    let description = probe_info_description(&path);
+    let elapsed = started.elapsed();
+
+    // Then: oversized output falls back immediately after the bounded read, not after the deadline.
+    assert!(description.is_none());
+    assert!(
+        elapsed < INFO_TIMEOUT / 2,
+        "expected oversized output to fall back before waiting for process exit; elapsed: {elapsed:?}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn probe_info_description_times_out_when_descendant_inherits_stdout() {
+    // Given: the direct `--info` process exits but a descendant keeps stdout open.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("veryl-zhold");
+    let pid_file = dir.path().join("zhold.pid");
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then bash -c 'exec -a veryl-zhold-inherited-stdout-regression sleep 60' & printf '%s\\n' \"$!\" > {}; printf 'held stdout\\n'; exit 0; fi\n",
+            pid_file.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+
+    // When: the list-summary probe runs.
+    let description = probe_info_description(&path);
+
+    let pid = fs::read_to_string(&pid_file).unwrap();
+    let descendant_alive = process_is_alive(pid.trim());
+    if descendant_alive {
+        let _ = Command::new("kill").arg("-TERM").arg(pid.trim()).status();
+    }
+
+    // Then: inherited stdout does not block past the probe deadline and the process tree is cleaned.
+    assert!(description.is_none());
+    assert!(
+        !descendant_alive,
+        "expected inherited-stdout descendant pid {} to be dead before test cleanup",
+        pid.trim()
+    );
+}
+
+fn names(discovered: &BTreeMap<String, CommandInfo>) -> Vec<&str> {
+    discovered.keys().map(String::as_str).collect()
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: &str) -> bool {
+    Command::new("kill")
+        .arg("-0")
+        .arg(pid)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}

--- a/crates/veryl/src/lib.rs
+++ b/crates/veryl/src/lib.rs
@@ -35,6 +35,7 @@ pub use stopwatch::StopWatch;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(override_usage = "veryl [OPTIONS] <COMMAND>")]
+#[command(after_help = "\n... See all commands with --list")]
 #[command(propagate_version = true)]
 #[clap(version(veryl_metadata::VERYL_VERSION))]
 #[clap(long_version(veryl_metadata::VERYL_VERSION))]

--- a/crates/veryl/src/lib.rs
+++ b/crates/veryl/src/lib.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub mod cmd_build;
@@ -19,6 +20,7 @@ pub mod cmd_update;
 pub mod context;
 pub mod diff;
 pub mod doc;
+pub mod external_subcommand;
 pub mod incremental;
 pub mod pipeline;
 pub mod runner;
@@ -32,6 +34,7 @@ pub use stopwatch::StopWatch;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
+#[command(override_usage = "veryl [OPTIONS] <COMMAND>")]
 #[command(propagate_version = true)]
 #[clap(version(veryl_metadata::VERYL_VERSION))]
 #[clap(long_version(veryl_metadata::VERYL_VERSION))]
@@ -52,8 +55,12 @@ pub struct Opt {
     #[arg(long, global = true, hide = true)]
     pub completion: Option<CompletionShell>,
 
+    /// List all commands
+    #[arg(long)]
+    pub list: bool,
+
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Option<Commands>,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -83,6 +90,8 @@ pub enum Commands {
     Test(OptTest),
     Synth(OptSynth),
     Translate(OptTranslate),
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
 }
 
 /// Translate SystemVerilog files into Veryl source

--- a/crates/veryl/src/main.rs
+++ b/crates/veryl/src/main.rs
@@ -6,8 +6,6 @@ use fern::Dispatch;
 use log::debug;
 use log::{Level, LevelFilter};
 use miette::{IntoDiagnostic, Result};
-use std::ffi::{OsStr, OsString};
-use std::io::Write;
 use std::process::ExitCode;
 use veryl_metadata::Metadata;
 
@@ -21,11 +19,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 // ---------------------------------------------------------------------------------------------------------------------
 
 fn main() -> Result<ExitCode> {
-    if root_help_requested(std::env::args_os()) {
-        print_root_help()?;
-        return Ok(ExitCode::SUCCESS);
-    }
-
     let opt = Opt::parse();
 
     if opt.list {
@@ -164,24 +157,4 @@ fn main() -> Result<ExitCode> {
     } else {
         Ok(ExitCode::FAILURE)
     }
-}
-
-fn root_help_requested(args: impl IntoIterator<Item = OsString>) -> bool {
-    let mut args = args.into_iter();
-    let _program = args.next();
-    let Some(flag) = args.next() else {
-        return false;
-    };
-
-    args.next().is_none()
-        && (flag == OsStr::new("-h") || flag == OsStr::new("--help") || flag == OsStr::new("help"))
-}
-
-fn print_root_help() -> Result<()> {
-    let mut command = Opt::command();
-    command.print_help().into_diagnostic()?;
-    std::io::stdout()
-        .write_all(b"\n\n... See all commands with --list\n")
-        .into_diagnostic()?;
-    Ok(())
 }

--- a/crates/veryl/src/main.rs
+++ b/crates/veryl/src/main.rs
@@ -1,3 +1,4 @@
+use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
 use clap_complete::aot::Shell;
 use console::Style;
@@ -5,6 +6,8 @@ use fern::Dispatch;
 use log::debug;
 use log::{Level, LevelFilter};
 use miette::{IntoDiagnostic, Result};
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
 use std::process::ExitCode;
 use veryl_metadata::Metadata;
 
@@ -18,7 +21,17 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 // ---------------------------------------------------------------------------------------------------------------------
 
 fn main() -> Result<ExitCode> {
+    if root_help_requested(std::env::args_os()) {
+        print_root_help()?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
     let opt = Opt::parse();
+
+    if opt.list {
+        external_subcommand::print_command_list(Opt::command())?;
+        return Ok(ExitCode::SUCCESS);
+    }
 
     if let Some(shell) = opt.completion {
         let shell = match shell {
@@ -31,6 +44,15 @@ fn main() -> Result<ExitCode> {
         clap_complete::generate(shell, &mut Opt::command(), "veryl", &mut std::io::stdout());
         return Ok(ExitCode::SUCCESS);
     }
+
+    let Some(command) = opt.command else {
+        Opt::command()
+            .error(
+                ErrorKind::MissingSubcommand,
+                "'veryl' requires a subcommand but one was not provided",
+            )
+            .exit();
+    };
 
     let level = if opt.trace {
         LevelFilter::Trace
@@ -79,11 +101,16 @@ fn main() -> Result<ExitCode> {
         .apply()
         .into_diagnostic()?;
 
-    let (mut metadata, dot_build_lock) = match opt.command {
+    if let Commands::External(args) = &command {
+        return external_subcommand::dispatch(args.clone());
+    }
+
+    let (mut metadata, dot_build_lock) = match command {
         Commands::New(_) | Commands::Init(_) | Commands::Translate(_) => {
             // dummy metadata
             (Metadata::create_default("dummy").unwrap(), None)
         }
+        Commands::External(_) => unreachable!(),
         _ => {
             let metadata_path = Metadata::search_from_current()?;
             let metadata = Metadata::load(metadata_path)?;
@@ -96,7 +123,7 @@ fn main() -> Result<ExitCode> {
 
     let mut stopwatch = StopWatch::new();
 
-    let ret = match opt.command {
+    let ret = match command {
         Commands::New(x) => cmd_new::CmdNew::new(x).exec(),
         Commands::Init(x) => cmd_init::CmdInit::new(x).exec(),
         Commands::Fmt(x) => cmd_fmt::CmdFmt::new(x).exec(&mut metadata, opt.quiet),
@@ -122,6 +149,7 @@ fn main() -> Result<ExitCode> {
         }
         Commands::Synth(x) => cmd_synth::CmdSynth::new(x).exec(&mut metadata),
         Commands::Translate(x) => cmd_translate::CmdTranslate::new(x).exec(),
+        Commands::External(_) => unreachable!(),
     };
 
     if let Some(dot_build_lock) = dot_build_lock {
@@ -136,4 +164,24 @@ fn main() -> Result<ExitCode> {
     } else {
         Ok(ExitCode::FAILURE)
     }
+}
+
+fn root_help_requested(args: impl IntoIterator<Item = OsString>) -> bool {
+    let mut args = args.into_iter();
+    let _program = args.next();
+    let Some(flag) = args.next() else {
+        return false;
+    };
+
+    args.next().is_none()
+        && (flag == OsStr::new("-h") || flag == OsStr::new("--help") || flag == OsStr::new("help"))
+}
+
+fn print_root_help() -> Result<()> {
+    let mut command = Opt::command();
+    command.print_help().into_diagnostic()?;
+    std::io::stdout()
+        .write_all(b"\n\n... See all commands with --list\n")
+        .into_diagnostic()?;
+    Ok(())
 }

--- a/crates/veryl/tests/external_subcommand.rs
+++ b/crates/veryl/tests/external_subcommand.rs
@@ -1,0 +1,167 @@
+// The mock external binaries are POSIX shell scripts, so these CLI dispatch tests run on Linux CI.
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn veryl() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_veryl"))
+}
+
+fn write_mock(dir: &Path, script: &str) {
+    write_mock_named(dir, OsStr::new("veryl-import"), script);
+}
+
+fn write_mock_named(dir: &Path, name: &OsStr, script: &str) {
+    let path = dir.join(Path::new(name));
+    fs::write(&path, script).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn run_with_path(work_dir: &Path, path_dir: &Path, args: &[&str]) -> Output {
+    let path = match std::env::var_os("PATH") {
+        Some(path) => std::env::join_paths(
+            std::iter::once(path_dir.to_path_buf()).chain(std::env::split_paths(&path)),
+        )
+        .unwrap(),
+        None => path_dir.as_os_str().to_os_string(),
+    };
+
+    veryl()
+        .current_dir(work_dir)
+        .env("PATH", path)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn external_command_executes_from_path() {
+    let temp = tempfile::tempdir().unwrap();
+    write_mock(temp.path(), "#!/bin/sh\nprintf 'mock import ran\\n'\n");
+
+    let output = run_with_path(temp.path(), temp.path(), &["import"]);
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "mock import ran\n");
+}
+
+#[test]
+fn external_command_forwards_arguments_unchanged() {
+    let temp = tempfile::tempdir().unwrap();
+    let args_file = temp.path().join("args.txt");
+    write_mock(
+        temp.path(),
+        &format!(
+            "#!/bin/sh\nfor arg in \"$@\"; do printf '<%s>\\n' \"$arg\"; done > {}\n",
+            args_file.display()
+        ),
+    );
+
+    let output = run_with_path(
+        temp.path(),
+        temp.path(),
+        &["import", "--target", "syn", "two words"],
+    );
+
+    assert!(output.status.success());
+    assert_eq!(
+        fs::read_to_string(args_file).unwrap(),
+        "<--target>\n<syn>\n<two words>\n"
+    );
+}
+
+#[test]
+fn external_command_exit_code_is_preserved() {
+    let temp = tempfile::tempdir().unwrap();
+    write_mock(temp.path(), "#!/bin/sh\nexit 17\n");
+
+    let output = run_with_path(temp.path(), temp.path(), &["import"]);
+
+    assert_eq!(output.status.code(), Some(17));
+}
+
+#[test]
+fn missing_external_binary_reports_actionable_diagnostic() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let output = veryl()
+        .current_dir(temp.path())
+        .env("PATH", temp.path())
+        .args(["import", "--target", "syn"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("veryl-import"));
+    assert!(stderr.contains("install"));
+    assert!(stderr.contains("PATH"));
+}
+
+#[test]
+fn external_command_does_not_require_metadata_or_create_build_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    write_mock(temp.path(), "#!/bin/sh\nprintf 'no metadata\\n'\n");
+
+    let output = run_with_path(temp.path(), temp.path(), &["import", "--target", "syn"]);
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "no metadata\n");
+    assert!(!temp.path().join(".build").exists());
+    assert!(!temp.path().join("Veryl.toml").exists());
+}
+
+#[test]
+fn external_command_dispatch_does_not_probe_info() {
+    let temp = tempfile::tempdir().unwrap();
+    let info_marker = temp.path().join("info-probed");
+    write_mock(
+        temp.path(),
+        &format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then touch {}; exit 0; fi\nprintf 'dispatch ran\\n'\n",
+            info_marker.display()
+        ),
+    );
+
+    let output = run_with_path(temp.path(), temp.path(), &["import", "--target", "syn"]);
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "dispatch ran\n");
+    assert!(
+        !info_marker.exists(),
+        "expected ordinary dispatch not to run `veryl-import --info`"
+    );
+}
+
+#[test]
+fn official_ls_suffix_is_not_dispatched_as_external_subcommand() {
+    // Given: PATH contains an executable that looks like a Veryl external `ls` command.
+    let temp = tempfile::tempdir().unwrap();
+    let marker = temp.path().join("veryl-ls-executed");
+    write_mock_named(
+        temp.path(),
+        OsStr::new("veryl-ls"),
+        &format!("#!/bin/sh\ntouch {}\nexit 0\n", marker.display()),
+    );
+
+    // When: the `ls` suffix is requested through the CLI.
+    let output = run_with_path(temp.path(), temp.path(), &["ls"]);
+
+    // Then: the official non-subcommand suffix policy prevents dispatch to PATH.
+    assert!(
+        !output.status.success(),
+        "expected `veryl ls` to fail instead of executing PATH `veryl-ls`; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !marker.exists(),
+        "expected `veryl ls` not to execute PATH `veryl-ls`"
+    );
+}

--- a/crates/veryl/tests/help_external_subcommand.rs
+++ b/crates/veryl/tests/help_external_subcommand.rs
@@ -1,0 +1,318 @@
+// The mock external binaries are POSIX shell scripts, so these CLI help tests run on Linux CI.
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output};
+
+#[cfg(not(target_os = "macos"))]
+use std::os::unix::ffi::OsStringExt;
+
+fn veryl() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_veryl"))
+}
+
+fn write_executable(dir: &Path, name: &str) {
+    write_executable_with_body(dir, OsStr::new(name), "#!/bin/sh\nexit 0\n");
+}
+
+fn write_executable_with_body(dir: &Path, name: &OsStr, body: &str) {
+    let path = dir.join(Path::new(name));
+    std::fs::write(&path, body).unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).unwrap();
+}
+
+fn run_with_path(work_dir: &Path, path_dirs: &[&Path], args: &[&str]) -> Output {
+    let path = std::env::join_paths(path_dirs.iter().map(|path| path.to_path_buf())).unwrap();
+
+    veryl()
+        .current_dir(work_dir)
+        .env("PATH", path)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn run_success(work_dir: &Path, path_dirs: &[&Path], args: &[&str]) -> String {
+    let output = run_with_path(work_dir, path_dirs, args);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let command = format!("veryl {}", args.join(" "));
+
+    assert!(
+        output.status.success(),
+        "expected `{command}` to succeed; status: {:?}\nstderr:\n{stderr}\nstdout:\n{stdout}",
+        output.status.code()
+    );
+    assert!(
+        stderr.is_empty(),
+        "expected `{command}` to keep stderr empty; stderr:\n{stderr}"
+    );
+
+    stdout.into_owned()
+}
+
+fn root_help(work_dir: &Path, path_dirs: &[&Path], flag: &str) -> String {
+    run_success(work_dir, path_dirs, &[flag])
+}
+
+fn command_list(work_dir: &Path, path_dirs: &[&Path]) -> String {
+    run_success(work_dir, path_dirs, &["--list"])
+}
+
+fn command_line_count(output: &str, name: &str) -> usize {
+    output
+        .lines()
+        .filter(|line| line.split_whitespace().next() == Some(name))
+        .count()
+}
+
+fn command_line<'a>(output: &'a str, name: &str) -> &'a str {
+    output
+        .lines()
+        .find(|line| line.split_whitespace().next() == Some(name))
+        .unwrap_or("")
+}
+
+fn assert_output_lists_commands(label: &str, output: &str, expected: &[&str]) {
+    for name in expected {
+        assert_eq!(
+            command_line_count(output, name),
+            1,
+            "expected `{label}` to list command `{name}` exactly once; output:\n{output}"
+        );
+    }
+}
+
+fn assert_output_omits_commands(label: &str, output: &str, omitted: &[&str]) {
+    for name in omitted {
+        assert!(
+            command_line_count(output, name) == 0,
+            "expected `{label}` to omit command `{name}`; output:\n{output}"
+        );
+    }
+}
+
+fn assert_required_command_usage(output: &str) {
+    assert!(
+        output.contains("Usage: veryl [OPTIONS] <COMMAND>"),
+        "expected usage to keep required subcommand marker `<COMMAND>`; output:\n{output}"
+    );
+    assert!(
+        !output.contains("Usage: veryl [OPTIONS] [COMMAND]"),
+        "expected usage not to show optional subcommand marker `[COMMAND]`; output:\n{output}"
+    );
+}
+
+fn assert_list_hint(output: &str) {
+    assert!(
+        output.contains("--list") && output.contains("See all commands"),
+        "expected root help to show the `--list` discovery hint; output:\n{output}"
+    );
+}
+
+#[test]
+fn root_help_omits_external_commands_and_points_to_list() {
+    // Given: executable external Veryl subcommands are available on PATH.
+    let temp = tempfile::tempdir().unwrap();
+    write_executable(temp.path(), "veryl-import");
+    write_executable(temp.path(), "veryl-flist");
+
+    // When: root help is requested through both help flags and exact `help`.
+    let short_help = root_help(temp.path(), &[temp.path()], "-h");
+    let long_help = root_help(temp.path(), &[temp.path()], "--help");
+    let help_command = run_success(temp.path(), &[temp.path()], &["help"]);
+
+    // Then: root help stays cheap, keeps required-command usage, and advertises explicit discovery.
+    for (label, output) in [
+        ("veryl -h", short_help.as_str()),
+        ("veryl --help", long_help.as_str()),
+        ("veryl help", help_command.as_str()),
+    ] {
+        assert_output_omits_commands(label, output, &["flist", "import"]);
+        assert_required_command_usage(output);
+        assert_list_hint(output);
+    }
+}
+
+#[test]
+#[cfg(not(target_os = "macos"))]
+fn root_help_ignores_non_utf8_external_suffixes() {
+    // Given: PATH contains a valid external command and a veryl-prefixed executable with a non-UTF-8 suffix.
+    let temp = tempfile::tempdir().unwrap();
+    write_executable(temp.path(), "veryl-flist");
+    let non_utf8_name = std::ffi::OsString::from_vec(vec![
+        b'v', b'e', b'r', b'y', b'l', b'-', b'i', b'm', 0xff, b'o', b'r', b't',
+    ]);
+    write_executable_with_body(
+        temp.path(),
+        non_utf8_name.as_os_str(),
+        "#!/bin/sh\nexit 0\n",
+    );
+
+    // When: root help is requested.
+    let help = root_help(temp.path(), &[temp.path()], "-h");
+
+    // Then: root help omits both valid and malformed external suffixes.
+    assert_output_omits_commands("-h", &help, &["flist", "im\u{fffd}ort"]);
+    assert_list_hint(&help);
+}
+
+#[test]
+fn bare_cli_reports_missing_required_subcommand_usage() {
+    // Given: PATH is controlled and contains no command candidates.
+    let temp = tempfile::tempdir().unwrap();
+
+    // When: the CLI is invoked without a subcommand.
+    let output = veryl()
+        .current_dir(temp.path())
+        .env("PATH", temp.path())
+        .output()
+        .unwrap();
+
+    // Then: it fails as a missing-subcommand error and keeps `<COMMAND>` in usage.
+    assert!(
+        !output.status.success(),
+        "expected bare `veryl` to fail; status: {:?}",
+        output.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("requires a subcommand") || stderr.contains("subcommand"),
+        "expected missing-subcommand style error; stderr:\n{stderr}"
+    );
+    assert_required_command_usage(&stderr);
+}
+
+#[test]
+fn root_help_intercept_requires_exact_help_flag() {
+    // Given: an executable external Veryl subcommand is available on PATH.
+    let temp = tempfile::tempdir().unwrap();
+    write_executable(temp.path(), "veryl-import");
+
+    // When: `-h` is accompanied by another argument.
+    let path = std::env::join_paths([temp.path()]).unwrap();
+    let output = veryl()
+        .current_dir(temp.path())
+        .env("PATH", path)
+        .args(["-h", "extra"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Then: normal clap handling answers, not the augmented exact-root-help path.
+    assert!(
+        output.status.success(),
+        "expected clap help to succeed; status: {:?}",
+        output.status.code()
+    );
+    assert_output_omits_commands("-h extra", &stdout, &["import"]);
+    assert_required_command_usage(&stdout);
+}
+
+#[test]
+fn list_reports_external_commands_from_path() {
+    // Given: executable external Veryl subcommands are available on PATH.
+    let temp = tempfile::tempdir().unwrap();
+    write_executable(temp.path(), "veryl-import");
+    write_executable(temp.path(), "veryl-flist");
+
+    // When: the explicit command list is requested.
+    let list = command_list(temp.path(), &[temp.path()]);
+
+    // Then: external subcommands are listed only on the explicit discovery surface.
+    assert_output_lists_commands("veryl --list", &list, &["flist", "import"]);
+}
+
+#[test]
+fn list_uses_info_description_for_surviving_external_commands_only() {
+    // Given: external commands provide valid and invalid `--info` responses.
+    let temp = tempfile::tempdir().unwrap();
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-import"),
+        "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then printf 'Import source files\\n'; exit 0; fi\nexit 0\n",
+    );
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-flist"),
+        "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then printf 'first line\\nsecond line\\n'; exit 0; fi\nexit 0\n",
+    );
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-build"),
+        "#!/bin/sh\nif [ \"$1\" = \"--info\" ]; then printf 'External build should not be probed\\n'; exit 0; fi\nexit 0\n",
+    );
+
+    // When: the explicit command list is requested.
+    let list = command_list(temp.path(), &[temp.path()]);
+
+    // Then: final external entries use valid summaries, invalid summaries fall back, and built-in collisions are not probed.
+    assert!(
+        command_line(&list, "import").contains("Import source files"),
+        "expected valid `--info` output to describe import; output:\n{list}"
+    );
+    assert!(
+        command_line(&list, "flist").contains("External Veryl subcommand from PATH"),
+        "expected invalid multiline `--info` output to fall back; output:\n{list}"
+    );
+    assert!(
+        !list.contains("External build should not be probed"),
+        "expected overwritten built-in collision not to run `--info`; output:\n{list}"
+    );
+}
+
+#[test]
+fn list_uses_builtin_rows_for_builtin_help_and_official_suffix_collisions() {
+    // Given: PATH contains external-looking binaries that collide with built-ins, help, and `ls`.
+    let temp = tempfile::tempdir().unwrap();
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-build"),
+        "#!/bin/sh\nprintf 'PATH veryl-build should not be listed\\n'\n",
+    );
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-check"),
+        "#!/bin/sh\nprintf 'PATH veryl-check should not be listed\\n'\n",
+    );
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-help"),
+        "#!/bin/sh\nprintf 'PATH veryl-help should not be listed\\n'\n",
+    );
+    write_executable_with_body(
+        temp.path(),
+        OsStr::new("veryl-ls"),
+        "#!/bin/sh\nprintf 'PATH veryl-ls should not be listed\\n'\n",
+    );
+    write_executable(temp.path(), "veryl-import");
+
+    // When: the explicit command list is requested.
+    let list = command_list(temp.path(), &[temp.path()]);
+
+    // Then: built-ins and help win through list merge order, and `ls` is excluded centrally.
+    assert_output_lists_commands("veryl --list", &list, &["build", "check", "help", "import"]);
+    assert_output_omits_commands("veryl --list", &list, &["ls"]);
+    for name in ["build", "check", "help"] {
+        let line = command_line(&list, name);
+        assert!(
+            !line.contains("External"),
+            "expected `{name}` to be rendered as a built-in list row; line:\n{line}\nfull list:\n{list}"
+        );
+    }
+    for forbidden in [
+        "PATH veryl-build should not be listed",
+        "PATH veryl-check should not be listed",
+        "PATH veryl-help should not be listed",
+        "PATH veryl-ls should not be listed",
+    ] {
+        assert!(
+            !list.contains(forbidden),
+            "expected list output not to contain external collision text `{forbidden}`; output:\n{list}"
+        );
+    }
+}

--- a/crates/veryl/tests/help_external_subcommand.rs
+++ b/crates/veryl/tests/help_external_subcommand.rs
@@ -188,7 +188,7 @@ fn bare_cli_reports_missing_required_subcommand_usage() {
 }
 
 #[test]
-fn root_help_intercept_requires_exact_help_flag() {
+fn root_help_with_extra_argument_uses_clap_handling() {
     // Given: an executable external Veryl subcommand is available on PATH.
     let temp = tempfile::tempdir().unwrap();
     write_executable(temp.path(), "veryl-import");
@@ -203,7 +203,7 @@ fn root_help_intercept_requires_exact_help_flag() {
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Then: normal clap handling answers, not the augmented exact-root-help path.
+    // Then: normal clap handling answers.
     assert!(
         output.status.success(),
         "expected clap help to succeed; status: {:?}",


### PR DESCRIPTION
## Summary
- dispatch unknown Veryl subcommands to `veryl-<subcommand>` executables found on `PATH`
- preserve forwarded arguments and external command exit status
- list discoverable external subcommands in root help, including optional sidecar descriptions

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p veryl --test external_subcommand --test help_external_subcommand`

Closes #2933