### PR TITLE
Propagate expr_context for aggregate expressions used as operands

### DIFF
--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -354,9 +354,15 @@ impl Expression {
                 op.eval_type_ternary(context, x.comptime(), y.comptime(), z.comptime(), comptime);
                 comptime.evaluated = true;
             }
-            Expression::Concatenation(_, _) => (),
-            Expression::StructConstructor(_, _, _) => (),
-            Expression::ArrayLiteral(_, _) => (),
+            Expression::Concatenation(_, comptime)
+            | Expression::StructConstructor(_, _, comptime)
+            | Expression::ArrayLiteral(_, comptime) => {
+                // These are evaluated in `gather_context`, but their context (e.g.
+                // is_const/is_global) must still be recorded so a parent reading
+                // `comptime().expr_context` after `apply_context` (such as an `as`
+                // cast) sees the gathered values instead of the default.
+                comptime.expr_context = expr_context
+            }
         }
     }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9964,6 +9964,15 @@ fn unevaluable_value_const_value() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package a_pkg {
+        const A: bit<4> = {2'b00, 2'b00} as 4;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2931

`is_const` flag of a binary op is propagated from `expr_context` of its operands.
However, `expr_context` of aggregated expressions (e.g. concat expression) is not updated. Due to this, binary operatoins with such operands are not treated as `const` expression.
