### PR TITLE
Fix compatibility check between modports

### DIFF
--- a/crates/analyzer/src/ir/comptime.rs
+++ b/crates/analyzer/src/ir/comptime.rs
@@ -645,7 +645,13 @@ impl Type {
             dst_sig.parameters.clear();
             if let Some(mut src_sig) = src.r#type.kind.signature() {
                 src_sig.parameters.clear();
-                dst_sig.to_string() == src_sig.to_string()
+                if let TypeKind::Modport(_, dst_mp) = self.kind
+                    && let TypeKind::Modport(_, src_mp) = src.r#type.kind
+                {
+                    dst_mp == src_mp && dst_sig.to_string() == src_sig.to_string()
+                } else {
+                    dst_sig.to_string() == src_sig.to_string()
+                }
             } else {
                 false
             }
@@ -1027,7 +1033,7 @@ impl fmt::Display for TypeKind {
             TypeKind::Enum(x) => x.fmt(f),
             TypeKind::Module(x) => format!("module {x}").fmt(f),
             TypeKind::Interface(x) => format!("interface {x}").fmt(f),
-            TypeKind::Modport(x, _) => format!("modport {x}").fmt(f),
+            TypeKind::Modport(sig, mp) => format!("modport {sig}::{mp}").fmt(f),
             TypeKind::Package(x) => format!("package {x}").fmt(f),
             TypeKind::Instance(x, _) => format!("instance {x}").fmt(f),
             TypeKind::AbstractInterface(x) => {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4755,6 +4755,64 @@ fn mismatch_assignment() {
         AnalyzerError::MismatchAssignment { .. }
     ));
 
+    let code = r#"
+    interface a_if {
+        var a: logic;
+        var b: logic;
+        modport mp_a {
+            a: input,
+        }
+        modport mp_ab {
+            a: input,
+            b: input,
+        }
+    }
+    module b_module (
+        a: modport a_if::mp_a
+    ) {
+        inst c: c_module (
+            ab: a,
+        );
+    }
+    module c_module (
+        ab: modport a_if::mp_ab,
+    ) {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(
+        errors[0],
+        AnalyzerError::MismatchAssignment { .. }
+    ));
+
+    let code = r#"
+    interface a_if {
+        var a: logic;
+        var b: logic;
+        modport mp_a {
+            a: input,
+        }
+        modport mp_ab {
+            a: input,
+            b: input,
+        }
+    }
+    module b_module () {
+        inst a: a_if();
+        assign a.a = '0;
+        assign a.b = '0;
+        inst c: c_module (
+            ab: a,
+        );
+    }
+    module c_module (
+        ab: modport a_if::mp_ab,
+    ) {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
     //let code = r#"
     //interface InterfaceA {
     //    var a: logic;


### PR DESCRIPTION
fix veryl-lang/veryl#2944

When checking compatiblity between moports, both of moport names should be compared but currently not.
This causes #2944.