### PR TITLE
Fix false positive of `mismatch_assignment` warning

### DIFF
--- a/crates/analyzer/src/conv/checker/generic.rs
+++ b/crates/analyzer/src/conv/checker/generic.rs
@@ -165,10 +165,10 @@ fn is_referable_symbol(symbol: &Symbol, base: Option<&Symbol>) -> bool {
     false
 }
 
-fn check_generic_type_arg(arg: &Comptime) -> Option<AnalyzerError> {
+fn check_generic_type_arg(arg: &Comptime, in_generic: bool) -> Option<AnalyzerError> {
     let dst = Type::new(crate::ir::TypeKind::Type);
 
-    if dst.compatible(arg) {
+    if dst.compatible(arg, in_generic) {
         None
     } else {
         let src_type = arg.r#type.to_string();
@@ -276,7 +276,7 @@ fn check_generic_proto_arg(
         }
         ProtoBound::FactorType(r) => {
             let param_type = r.to_ir_type(context, TypePosition::Generic).ok()?;
-            if param_type.compatible(arg) {
+            if param_type.compatible(arg, context.in_generic) {
                 None
             } else {
                 Some((format!("{}", r), None))
@@ -368,7 +368,7 @@ pub fn check_generic_refereence(context: &mut Context, path: &GenericSymbolPath)
 
                 if let Some(expr) = eval_generic_arg(context, &arg).as_ref() {
                     let error = match bound {
-                        GenericBoundKind::Type => check_generic_type_arg(expr),
+                        GenericBoundKind::Type => check_generic_type_arg(expr, context.in_generic),
                         GenericBoundKind::Inst(_) => {
                             check_generic_inst_arg(expr, bound, &symbol.found.namespace)
                         }
@@ -410,7 +410,7 @@ pub fn check_generic_expression(
     };
 
     let error = match bound {
-        GenericBoundKind::Type => check_generic_type_arg(&expression),
+        GenericBoundKind::Type => check_generic_type_arg(&expression, context.in_generic),
         GenericBoundKind::Inst(_) => check_generic_inst_arg(&expression, bound, bound_namespace),
         GenericBoundKind::Proto(_) => {
             check_generic_proto_arg(context, &expression, bound, bound_namespace)

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -3364,7 +3364,7 @@ pub fn check_compatibility(
         check_implicit_clock_conversion(context, dst, src, token);
         return;
     }
-    if !dst.compatible(src) {
+    if !dst.compatible(src, context.in_generic) {
         let src_type = src.r#type.to_string();
         let dst_type = dst.to_string();
         context.insert_error(AnalyzerError::mismatch_assignment(

--- a/crates/analyzer/src/ir/comptime.rs
+++ b/crates/analyzer/src/ir/comptime.rs
@@ -633,7 +633,7 @@ impl Type {
         self.array.total()
     }
 
-    pub fn compatible(&self, src: &Comptime) -> bool {
+    pub fn compatible(&self, src: &Comptime, in_generic: bool) -> bool {
         // TODO type compatible check
         if self.is_unknown()
             | self.is_systemverilog()
@@ -642,15 +642,18 @@ impl Type {
         {
             true
         } else if let Some(mut dst_sig) = self.kind.signature() {
-            dst_sig.parameters.clear();
             if let Some(mut src_sig) = src.r#type.kind.signature() {
-                src_sig.parameters.clear();
+                dst_sig.normalize();
+                src_sig.normalize();
+                // In generic components, signatures are compared by using symbol only
+                // becuase they may not have generic args.
+                let match_sig = dst_sig.is_compatible(&src_sig, true, in_generic);
                 if let TypeKind::Modport(_, dst_mp) = self.kind
                     && let TypeKind::Modport(_, src_mp) = src.r#type.kind
                 {
-                    dst_mp == src_mp && dst_sig.to_string() == src_sig.to_string()
+                    match_sig && dst_mp == src_mp
                 } else {
-                    dst_sig.to_string() == src_sig.to_string()
+                    match_sig
                 }
             } else {
                 false

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -27,6 +27,24 @@ impl Signature {
         }
     }
 
+    pub fn is_compatible(
+        &self,
+        x: &Signature,
+        ignore_params: bool,
+        ignore_generic_params: bool,
+    ) -> bool {
+        if self.symbol != x.symbol {
+            return false;
+        }
+        if !ignore_params && self.parameters != x.parameters {
+            return false;
+        }
+        if !ignore_generic_params && self.generic_parameters != x.generic_parameters {
+            return false;
+        }
+        true
+    }
+
     pub fn add_parameter(&mut self, id: StrId, value: ValueVariant) {
         self.parameters.push((id, value));
     }

--- a/crates/analyzer/src/ir/system_function.rs
+++ b/crates/analyzer/src/ir/system_function.rs
@@ -94,7 +94,7 @@ fn create_input(
     // eval_comptime is required for width propagation, not just the type check.
     let comptime = expr.eval_comptime(context, None);
     if let Some(r#type) = r#type
-        && !r#type.compatible(comptime)
+        && !r#type.compatible(comptime, context.in_generic)
     {
         context.insert_error(AnalyzerError::mismatch_function_arg(
             &name.to_string(),
@@ -121,7 +121,7 @@ fn create_output(
 
     if let Some(r#type) = r#type {
         let comptime = expr.eval_comptime(context, None);
-        if !r#type.compatible(comptime) {
+        if !r#type.compatible(comptime, context.in_generic) {
             context.insert_error(AnalyzerError::mismatch_function_arg(
                 &name.to_string(),
                 &comptime.r#type.to_string(),

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4807,6 +4807,35 @@ fn mismatch_assignment() {
     let errors = analyze(code);
     assert!(errors.is_empty());
 
+    let code = r#"
+    interface a_if::<W: u32> {
+        var a: logic<W>;
+        modport mp {
+          a: input,
+        }
+    }
+    module b_module (
+        a: modport a_if::<32>::mp,
+    ) {
+        inst u: c_module (
+            a: a,
+        );
+    }
+    module c_module (
+        a: modport a_if::<32>::mp,
+    ) {}
+    module d_module::<D: u32> {
+        inst a: a_if::<32>;
+        assign a.a = 0;
+        inst b: b_module (
+            a: a,
+        );
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
+
     //let code = r#"
     //interface InterfaceA {
     //    var a: logic;


### PR DESCRIPTION
fix veryl-lang/veryl#2942

This warning is reported during analyzing module `b_module` triggered from module `d_module`.
`d_module` is a generic module so signatures created during anayzing it have no generic args.

On the other hand, conversion result of `c_module` has already been cached and sigatures in this module have generic args.

This diffrenece cauess the issue.
To resolve it, generic args should be ignored when compareing signatures in generic components.