### PR TITLE
Skip IR conversion of module body for instances in generic modules

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -514,12 +514,16 @@ impl Context {
         self.instance_history.get_current_signature()
     }
 
-    pub fn get_instance_history(&self, sig: &Signature) -> Option<Arc<Component>> {
+    pub fn get_instance_history(&self, sig: &Signature) -> Option<(Arc<Component>, bool)> {
         self.instance_history.get(sig)
     }
 
     pub fn set_instance_history(&mut self, sig: &Signature, component: Arc<Component>) {
-        self.instance_history.set(sig, component);
+        self.instance_history.set(sig, component, self.in_generic);
+    }
+
+    pub fn remove_instance_history(&mut self, sig: &Signature) {
+        self.instance_history.remove(sig);
     }
 
     pub fn push_hierarchy(&mut self, x: StrId) {

--- a/crates/analyzer/src/conv/instance.rs
+++ b/crates/analyzer/src/conv/instance.rs
@@ -8,18 +8,22 @@ pub struct InstanceHistory {
     pub hierarchy: Vec<Signature>,
     /// `Arc`-wrapped so repeated `get` hands out references instead of
     /// deep-cloning the component tree — matters on testbench-heavy designs.
-    full: HashMap<Signature, Option<Arc<Component>>>,
+    full: HashMap<Signature, Option<(Arc<Component>, bool)>>,
 }
 
 impl InstanceHistory {
-    pub fn get(&self, sig: &Signature) -> Option<Arc<Component>> {
+    pub fn get(&self, sig: &Signature) -> Option<(Arc<Component>, bool)> {
         self.full.get(sig).cloned().flatten()
     }
 
-    pub fn set(&mut self, sig: &Signature, component: Arc<Component>) {
+    pub fn set(&mut self, sig: &Signature, component: Arc<Component>, in_generic: bool) {
         if let Some(x) = self.full.get_mut(sig) {
-            *x = Some(component);
+            *x = Some((component, in_generic));
         }
+    }
+
+    pub fn remove(&mut self, sig: &Signature) {
+        self.full.remove(sig);
     }
 
     pub fn get_current_signature(&self) -> Option<&Signature> {

--- a/crates/analyzer/src/conv/ir.rs
+++ b/crates/analyzer/src/conv/ir.rs
@@ -155,6 +155,14 @@ fn conv_global_function(context: &mut Context, value: &FunctionDeclaration) {
 
 impl Conv<&ModuleDeclaration> for ir::Module {
     fn conv(context: &mut Context, value: &ModuleDeclaration) -> IrResult<Self> {
+        Conv::conv(context, (value, false))
+    }
+}
+
+impl Conv<(&ModuleDeclaration, bool)> for ir::Module {
+    fn conv(context: &mut Context, value: (&ModuleDeclaration, bool)) -> IrResult<Self> {
+        let (module_declaration, header_only) = value;
+
         let mut declarations = vec![];
 
         // each top-level component has independent context
@@ -162,12 +170,12 @@ impl Conv<&ModuleDeclaration> for ir::Module {
         let mut context = Context::default();
         context.inherit(upper_context);
 
-        let _guard = context.conv_profile_guard(value.identifier.text());
+        let _guard = context.conv_profile_guard(module_declaration.identifier.text());
 
         // pop_affiliation is not necessary because the local `context` will be dropped
         context.push_affiliation(Affiliation::Module);
 
-        if let Ok(symbol) = symbol_table::resolve(value.identifier.as_ref())
+        if let Ok(symbol) = symbol_table::resolve(module_declaration.identifier.as_ref())
             && let SymbolKind::Module(x) = &symbol.found.kind
             && !x.is_proto
         {
@@ -182,11 +190,11 @@ impl Conv<&ModuleDeclaration> for ir::Module {
                 context.set_default_reset(path, x);
             }
         } else {
-            let token: TokenRange = value.identifier.as_ref().into();
+            let token: TokenRange = module_declaration.identifier.as_ref().into();
             return Err(ir_error!(token));
         }
 
-        if let Some(x) = &value.module_declaration_opt {
+        if let Some(x) = &module_declaration.module_declaration_opt {
             check_generic_bound(&mut context, &x.with_generic_parameter);
             let items: Vec<_> = x
                 .with_generic_parameter
@@ -198,11 +206,15 @@ impl Conv<&ModuleDeclaration> for ir::Module {
             }
         }
 
-        if let Some(x) = &value.module_declaration_opt0 {
-            check_proto(&mut context, &value.identifier, &x.scoped_identifier);
+        if let Some(x) = &module_declaration.module_declaration_opt0 {
+            check_proto(
+                &mut context,
+                &module_declaration.identifier,
+                &x.scoped_identifier,
+            );
         }
 
-        if let Some(x) = &value.module_declaration_opt1
+        if let Some(x) = &module_declaration.module_declaration_opt1
             && let Some(x) = &x.with_parameter.with_parameter_opt
         {
             let items: Vec<_> = x.with_parameter_list.as_ref().into();
@@ -211,7 +223,7 @@ impl Conv<&ModuleDeclaration> for ir::Module {
             }
         }
 
-        if let Some(x) = &value.module_declaration_opt2
+        if let Some(x) = &module_declaration.module_declaration_opt2
             && let Some(x) = &x.port_declaration.port_declaration_opt
         {
             let items: Vec<_> = x.port_declaration_list.as_ref().into();
@@ -220,14 +232,16 @@ impl Conv<&ModuleDeclaration> for ir::Module {
             }
         }
 
-        for x in &value.module_declaration_list {
-            let items: Vec<_> = x.module_group.as_ref().into();
-            for item in &items {
-                let ret: IrResult<ir::DeclarationBlock> =
-                    Conv::conv(&mut context, item.generate_item.as_ref());
+        if !header_only {
+            for x in &module_declaration.module_declaration_list {
+                let items: Vec<_> = x.module_group.as_ref().into();
+                for item in &items {
+                    let ret: IrResult<ir::DeclarationBlock> =
+                        Conv::conv(&mut context, item.generate_item.as_ref());
 
-                if let Ok(mut block) = ret {
-                    declarations.append(&mut block.0);
+                    if let Ok(mut block) = ret {
+                        declarations.append(&mut block.0);
+                    }
                 }
             }
         }
@@ -240,7 +254,7 @@ impl Conv<&ModuleDeclaration> for ir::Module {
                 &mut context,
                 &clock.0.comptime,
                 &reset.0.comptime,
-                &value.module.module_token.token,
+                &module_declaration.module.module_token.token,
             );
         }
 
@@ -261,8 +275,8 @@ impl Conv<&ModuleDeclaration> for ir::Module {
         upper_context.inherit(&mut context);
 
         Ok(ir::Module {
-            name: value.identifier.text(),
-            token: value.identifier.as_ref().into(),
+            name: module_declaration.identifier.text(),
+            token: module_declaration.identifier.as_ref().into(),
             ports,
             port_types,
             variables,

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -2605,8 +2605,16 @@ pub fn get_component(
     sig.normalize();
     let sig = &sig;
 
-    if let Some(component) = context.get_instance_history(sig) {
-        Ok(component)
+    if let Some((component, in_generic)) = context.get_instance_history(sig) {
+        if in_generic && !context.in_generic {
+            // The IR result gotten from the cache may be incomplete
+            // if the `in_generic` flag is set.
+            // Such result should be removed from the cache and be created again.
+            context.remove_instance_history(sig);
+            get_component(context, sig, token)
+        } else {
+            Ok(component)
+        }
     } else {
         let symbol = symbol_table::get(sig.symbol).unwrap();
 
@@ -2653,7 +2661,8 @@ pub fn get_component(
                     unreachable!()
                 };
 
-                let component: IrResult<ir::Module> = Conv::conv(c, x);
+                let header_only = c.in_generic;
+                let component: IrResult<ir::Module> = Conv::conv(c, (x, header_only));
                 match component {
                     Ok(mut component) => {
                         if !c.config.retain_component_body {


### PR DESCRIPTION
## Summary

When a module is instantiated inside a generic module, only the header part of its IR is required. This PR skips the IR conversion of the unnecessary (body) part in that case.

In addition, an IR result that is cached during the conversion of a generic component may be incomplete. Such a cached result is now invalidated and rebuilt when it is required again in a non-generic context.

## Changes

- Add a `header_only` mode to the module IR conversion so that the body is skipped for modules instantiated within generic modules.
- Track whether a cached component was produced in a generic context (`in_generic` flag) in InstanceHistory, and regenerate it when it is later needed outside a generic context.

This change also improves analyzer performance.

```
local
[DEBUG]     Executed parse/analyze_pass1 (9029 milliseconds, 767 files)
[DEBUG]     Executed analyze_post_pass1 (3859 milliseconds)
[DEBUG]     Executed analyze_pass2 (64183 milliseconds)
[DEBUG]     Executed analyze_post_pass2 (856 milliseconds)
[DEBUG]      Elapsed time (78631 milliseconds)

nightly
[DEBUG]     Executed parse/analyze_pass1 (12741 milliseconds, 767 files)
[DEBUG]     Executed analyze_post_pass1 (4312 milliseconds)
[DEBUG]     Executed analyze_pass2 (88733 milliseconds)
[DEBUG]     Executed analyze_post_pass2 (985 milliseconds)
[DEBUG]      Elapsed time (107714 milliseconds)
```