### PR TITLE
fix(synthesizer): reject oversized flip-flop arrays to avoid OOM

### DIFF
--- a/crates/metadata/src/synth.rs
+++ b/crates/metadata/src/synth.rs
@@ -28,6 +28,10 @@ pub struct Synth {
     /// Largest number of distinct write sites a RAM-inferred array may have.
     #[serde(default = "default_ram_max_write_ports")]
     pub ram_max_write_ports: usize,
+    /// Largest array, in stored bits, expanded into flip-flops after failing RAM
+    /// inference; a larger dynamically-indexed array is rejected, not expanded.
+    #[serde(default = "default_ram_max_ff_bits")]
+    pub ram_max_ff_bits: usize,
 }
 
 /// Built-in PDK library identifiers. Each variant maps to a hard-coded
@@ -80,4 +84,8 @@ fn default_ram_max_read_ports() -> usize {
 
 fn default_ram_max_write_ports() -> usize {
     8
+}
+
+fn default_ram_max_ff_bits() -> usize {
+    1 << 16
 }

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -293,6 +293,7 @@ fn synth_ram_thresholds_default_and_override() {
     assert_eq!(metadata.synth.ram_min_bits, 1024);
     assert_eq!(metadata.synth.ram_max_read_ports, 16);
     assert_eq!(metadata.synth.ram_max_write_ports, 8);
+    assert_eq!(metadata.synth.ram_max_ff_bits, 1 << 16);
 
     // Explicit values in `[synth]` override the defaults.
     let toml = r#"
@@ -304,11 +305,13 @@ version = "0.1.0"
 ram_min_bits = 256
 ram_max_read_ports = 4
 ram_max_write_ports = 2
+ram_max_ff_bits = 4096
 "#;
     let metadata: Metadata = toml::from_str(toml).unwrap();
     assert_eq!(metadata.synth.ram_min_bits, 256);
     assert_eq!(metadata.synth.ram_max_read_ports, 4);
     assert_eq!(metadata.synth.ram_max_write_ports, 2);
+    assert_eq!(metadata.synth.ram_max_ff_bits, 4096);
 }
 
 #[test]

--- a/crates/synthesizer/src/conv.rs
+++ b/crates/synthesizer/src/conv.rs
@@ -97,6 +97,20 @@ pub fn convert_module(
     if env::var_os("VERYL_SYNTH_NO_RAM").is_none() {
         ctx.ram_vars = phase!("infer_ram_vars", ram::infer_ram_vars(module, &ram));
     }
+    // Reject a too-large dynamically-indexed array that RAM inference declined
+    // (e.g. it has a reset) before it expands into an OOM-sized flip-flop +
+    // decode bank (#2941).
+    if let Some((vid, bits)) = ram::oversized_ff_array(module, &ctx.ram_vars, &ram) {
+        let var = &module.variables[&vid];
+        return Err(SynthesizerError::unsupported(
+            UnsupportedKind::ArrayTooLargeForFf {
+                path: var.path.to_string(),
+                bits,
+                limit: ram.max_ff_bits,
+            },
+            &var.token,
+        ));
+    }
     phase!("allocate_variables", ctx.allocate_variables(module)?);
     phase!("classify_drivers", ctx.classify_drivers(module)?);
 

--- a/crates/synthesizer/src/conv/ram.rs
+++ b/crates/synthesizer/src/conv/ram.rs
@@ -24,6 +24,10 @@
 //!
 //! Partial / sub-word writes remain out of scope and keep the array as
 //! flip-flops.
+//!
+//! A dynamically-indexed array that fails inference but exceeds `max_ff_bits`
+//! is rejected rather than expanded into the `O(depth × width)` gates that
+//! would exhaust memory ([`oversized_ff_array`], issue #2941).
 
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -101,6 +105,101 @@ pub(crate) fn infer_ram_vars(
             )
         })
         .collect()
+}
+
+/// The first array that would blow up if expanded into flip-flops: dynamically
+/// indexed, over `ram.max_ff_bits` stored bits, and not inferred as RAM — so the
+/// caller can reject it (#2941) instead of building `depth × width` gates.
+/// Only 1-D: a dynamic multi-dim index errors elsewhere, and static indexing
+/// gives a flat FF bank (linear, no decode). `VarId` order for determinism.
+pub(crate) fn oversized_ff_array(
+    module: &air::Module,
+    ram_vars: &HashMap<air::VarId, RamCandidate>,
+    ram: &RamConfig,
+) -> Option<(air::VarId, usize)> {
+    let limit = ram.max_ff_bits;
+    let mut ids: Vec<air::VarId> = module.variables.keys().copied().collect();
+    ids.sort();
+
+    for vid in ids {
+        if ram_vars.contains_key(&vid) {
+            continue;
+        }
+        let Some(var) = module.variables.get(&vid) else {
+            continue;
+        };
+        let Some(width) = var.r#type.total_width() else {
+            continue;
+        };
+        let Some(depth) = var.r#type.array.total() else {
+            continue;
+        };
+        if depth < 2 || width == 0 || var.r#type.array.dims() != 1 {
+            continue;
+        }
+        let bits = width * depth;
+        if bits <= limit {
+            continue;
+        }
+        if is_dynamically_indexed(module, vid) {
+            return Some((vid, bits));
+        }
+    }
+    None
+}
+
+/// Does `vid` have any dynamic (non-constant) array-index access?
+fn is_dynamically_indexed(module: &air::Module, vid: air::VarId) -> bool {
+    let is_dyn = |index: &air::VarIndex| !index.0.is_empty() && !index.is_const();
+
+    for decl in &module.declarations {
+        let mut dynamic = false;
+        match decl {
+            Declaration::Ff(ff) => {
+                for st in &ff.statements {
+                    walk_writes(st, vid, false, &mut |dst, _, _| {
+                        if is_dyn(&dst.index) {
+                            dynamic = true;
+                        }
+                    });
+                }
+            }
+            Declaration::Comb(comb) => {
+                for st in &comb.statements {
+                    walk_writes(st, vid, false, &mut |dst, _, _| {
+                        if is_dyn(&dst.index) {
+                            dynamic = true;
+                        }
+                    });
+                }
+            }
+            // An inst-output `foo.o: arr[i]` writes at a dynamic index that
+            // `flatten_inst` expands like any clocked/comb write.
+            Declaration::Inst(inst) => {
+                for o in &inst.outputs {
+                    for d in &o.dst {
+                        if d.id == vid && is_dyn(&d.index) {
+                            dynamic = true;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        if dynamic {
+            return true;
+        }
+    }
+
+    let mut dynamic = false;
+    for decl in &module.declarations {
+        for_each_read_in_decl(decl, vid, &mut |index, _select| {
+            if is_dyn(index) {
+                dynamic = true;
+            }
+        });
+    }
+    dynamic
 }
 
 /// Does any statement in `stmts` (recursively) write a RAM-inferred variable?

--- a/crates/synthesizer/src/lib.rs
+++ b/crates/synthesizer/src/lib.rs
@@ -30,6 +30,7 @@ pub struct RamConfig {
     pub min_bits: usize,
     pub max_read_ports: usize,
     pub max_write_ports: usize,
+    pub max_ff_bits: usize,
 }
 
 impl From<&Synth> for RamConfig {
@@ -38,6 +39,7 @@ impl From<&Synth> for RamConfig {
             min_bits: s.ram_min_bits,
             max_read_ports: s.ram_max_read_ports,
             max_write_ports: s.ram_max_write_ports,
+            max_ff_bits: s.ram_max_ff_bits,
         }
     }
 }

--- a/crates/synthesizer/src/synthesizer_error.rs
+++ b/crates/synthesizer/src/synthesizer_error.rs
@@ -59,13 +59,29 @@ pub enum UnsupportedKind {
     UnknownFactor,
     SystemFunctionCall,
     PowOperator,
-    DynamicRangeSelect { what: String },
-    DynamicRangeEnd { what: String },
-    MultiDimDynamicSelect { what: String },
-    DynamicMultiDimIndex { what: String },
+    DynamicRangeSelect {
+        what: String,
+    },
+    DynamicRangeEnd {
+        what: String,
+    },
+    MultiDimDynamicSelect {
+        what: String,
+    },
+    DynamicMultiDimIndex {
+        what: String,
+    },
     ForStatement,
-    UnsupportedVariableType { path: String, type_kind: String },
+    UnsupportedVariableType {
+        path: String,
+        type_kind: String,
+    },
     SystemVerilogBlackbox,
+    ArrayTooLargeForFf {
+        path: String,
+        bits: usize,
+        limit: usize,
+    },
 }
 
 impl fmt::Display for UnsupportedKind {
@@ -93,6 +109,14 @@ impl fmt::Display for UnsupportedKind {
                 write!(f, "variable '{}' has unsupported {} type", path, type_kind)
             }
             Self::SystemVerilogBlackbox => "SystemVerilog blackbox instantiation".fmt(f),
+            Self::ArrayTooLargeForFf { path, bits, limit } => write!(
+                f,
+                "array '{}' is too large to synthesize as flip-flops ({} bits > {} limit); \
+                 a dynamically-indexed array this large should be a memory — write it as a \
+                 reset-less clocked array so it is inferred as RAM, or raise ram_max_ff_bits \
+                 in the [synth] section of Veryl.toml",
+                path, bits, limit
+            ),
         }
     }
 }

--- a/crates/synthesizer/tests/integration.rs
+++ b/crates/synthesizer/tests/integration.rs
@@ -7,6 +7,7 @@ use veryl_parser::resource_table;
 use veryl_synthesizer::ir::{CellKind, NetDriver};
 use veryl_synthesizer::{
     Library, RamConfig, build_gate_ir, build_gate_ir_with, compute_power, library_for, synthesize,
+    synthesize_with,
 };
 
 #[track_caller]
@@ -2727,6 +2728,123 @@ fn small_reset_array_stays_flip_flops() {
 }
 
 #[test]
+fn oversized_reset_array_is_rejected_not_ooming() {
+    // A large reset register file: RAM inference declines it (reset), and
+    // expanding it into a flip-flop + decoder bank would OOM (#2941), so it must
+    // be rejected instead.
+    let code = r#"
+        module Big (
+            clk:   input  clock     ,
+            rst:   input  reset     ,
+            we:    input  logic     ,
+            waddr: input  logic<12> ,
+            wdata: input  logic<64> ,
+            raddr: input  logic<12> ,
+            rdata: output logic<64> ,
+        ) {
+            var arr: logic<64> [4096];
+            always_ff (clk, rst) {
+                if_reset {
+                    for i in 0..4096 {
+                        arr[i] = 0;
+                    }
+                } else {
+                    if we {
+                        arr[waddr] = wdata;
+                    }
+                }
+            }
+            assign rdata = arr[raddr];
+        }
+    "#;
+    let (ir, top) = analyze(code, "Big");
+    let err = synthesize(&ir, top, Library::default())
+        .err()
+        .expect("oversized reset array must be rejected, not synthesized");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("too large to synthesize as flip-flops"),
+        "expected the array-too-large diagnostic, got: {msg}"
+    );
+    // 64 × 4096 = 262144 stored bits, above the default 65536 limit.
+    assert!(
+        msg.contains("262144"),
+        "diagnostic should report the bit count: {msg}"
+    );
+    assert!(
+        msg.contains("arr"),
+        "diagnostic should name the array: {msg}"
+    );
+}
+
+#[test]
+fn oversized_array_via_dynamic_inst_output_is_rejected() {
+    // Regression: the guard must also see dynamic-index writes arriving through
+    // an inst-output connection (`u.o: arr[sel]`), not just Ff/Comb writes.
+    let code = r#"
+        module Sub (
+            o: output logic<64> ,
+        ) {
+            assign o = 0;
+        }
+        module Top (
+            sel:  input  logic<12> ,
+            dout: output logic<64> ,
+        ) {
+            var arr: logic<64> [4096];
+            inst u: Sub (
+                o: arr[sel] ,
+            );
+            assign dout = arr[0];
+        }
+    "#;
+    let (ir, top) = analyze(code, "Top");
+    let err = synthesize(&ir, top, Library::default())
+        .err()
+        .expect("dynamic inst-output write to an oversized array must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("too large to synthesize as flip-flops"),
+        "expected the array-too-large diagnostic, got: {msg}"
+    );
+}
+
+#[test]
+fn large_reset_less_array_still_infers_ram() {
+    // Reset-less, the same shape infers as a RAM macro, so the size limit never
+    // fires.
+    let code = r#"
+        module Big (
+            clk:   input  clock     ,
+            we:    input  logic     ,
+            waddr: input  logic<12> ,
+            wdata: input  logic<64> ,
+            raddr: input  logic<12> ,
+            rdata: output logic<64> ,
+        ) {
+            var arr: logic<64> [4096];
+            always_ff (clk) {
+                if we {
+                    arr[waddr] = wdata;
+                }
+            }
+            assign rdata = arr[raddr];
+        }
+    "#;
+    let (ir, top) = analyze(code, "Big");
+    let result = synthesize(&ir, top, Library::default()).expect("synthesize");
+    let m = &result.gate_ir.module;
+    assert_eq!(
+        m.ram_blocks.len(),
+        1,
+        "reset-less large array must infer as RAM"
+    );
+    assert_eq!(m.ram_blocks[0].depth, 4096);
+    assert_eq!(m.ram_blocks[0].width, 64);
+    assert_eq!(m.ffs.len(), 0, "RAM array must not expand to flip-flops");
+}
+
+#[test]
 fn ram_min_bits_config_lowers_inference_floor() {
     // A 512-bit array is below the default 1024-bit floor. Lowering `min_bits`
     // makes it infer as a RAM instead of flip-flops.
@@ -2767,6 +2885,57 @@ fn ram_min_bits_config_lowers_inference_floor() {
         "with min_bits lowered, the 512-bit array must infer as RAM"
     );
     assert_eq!(lowered.module.ffs.len(), 0);
+}
+
+#[test]
+fn ram_max_ff_bits_config_tightens_rejection() {
+    // A 2048-bit reset array expands to flip-flops by default. Tightening
+    // `max_ff_bits` below its size rejects it instead.
+    let code = r#"
+        module RegArray (
+            clk:   input  clock     ,
+            rst:   input  reset     ,
+            we:    input  logic     ,
+            waddr: input  logic<6>  ,
+            wdata: input  logic<32> ,
+            raddr: input  logic<6>  ,
+            rdata: output logic<32> ,
+        ) {
+            var arr: logic<32> [64];
+            always_ff (clk, rst) {
+                if_reset {
+                    for i in 0..64 {
+                        arr[i] = 0;
+                    }
+                } else {
+                    if we {
+                        arr[waddr] = wdata;
+                    }
+                }
+            }
+            assign rdata = arr[raddr];
+        }
+    "#;
+    let (ir, top) = analyze(code, "RegArray");
+
+    let default = synthesize(&ir, top, Library::default()).expect("synthesize");
+    assert!(
+        default.gate_ir.module.ram_blocks.is_empty() && !default.gate_ir.module.ffs.is_empty(),
+        "2048-bit reset array stays flip-flops under the default limit"
+    );
+
+    let cfg = RamConfig {
+        max_ff_bits: 1024,
+        ..RamConfig::default()
+    };
+    let err = synthesize_with(&ir, top, Library::default(), cfg)
+        .err()
+        .expect("tightened max_ff_bits must reject the 2048-bit array");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("too large to synthesize as flip-flops") && msg.contains("2048 bits > 1024"),
+        "diagnostic should report the configured limit: {msg}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #2941