### PR TITLE
Fix interface parameter overrides dropped through modport ports

### DIFF
--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -478,7 +478,10 @@ impl Context {
         self.inst_signatures.insert(identifier.text(), sig.clone());
     }
 
-    pub fn collect_modport_signatures(&mut self, inst: &ComponentInstantiation) {
+    pub fn collect_modport_signatures(
+        &mut self,
+        inst: &ComponentInstantiation,
+    ) -> HashMap<StrId, Signature> {
         let mut signatures = HashMap::default();
         if !self.inst_signatures.is_empty()
             && let Some(ref opt2) = inst.component_instantiation_opt2
@@ -502,7 +505,8 @@ impl Context {
             }
         }
 
-        self.modport_signatures.push(signatures);
+        self.modport_signatures.push(signatures.clone());
+        signatures
     }
 
     pub fn pop_modport_signatures(&mut self) {

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -514,13 +514,18 @@ impl Conv<&PortDeclarationItem> for () {
                 Direction::Modport => {
                     match &r#type.kind {
                         ir::TypeKind::Modport(sig, name) => {
-                            let component = if let Some(sig) =
-                                context.get_modport_signature(&value.identifier)
-                            {
-                                get_component(context, &sig, token)?
-                            } else {
-                                get_component(context, sig, token)?
-                            };
+                            // The effective interface signature: the connected
+                            // instance's signature if the instantiation site
+                            // provided one, the port type's otherwise.
+                            let effective_sig = context
+                                .get_modport_signature(&value.identifier)
+                                .unwrap_or_else(|| sig.clone());
+                            let component = get_component(context, &effective_sig, token)?;
+                            // Register the port under its effective signature so
+                            // inner instances connecting this port (interface
+                            // pass-through) key their cache entries on it.
+                            context
+                                .insert_inst_signature(value.identifier.as_ref(), &effective_sig);
                             let base = value.identifier.text();
                             let ir::Component::Interface(component) = component.as_ref() else {
                                 return Err(ir_error!(token));
@@ -1548,9 +1553,17 @@ impl Conv<&InstDeclaration> for ir::Declaration {
                 sig.add_parameter(x.name, value.0.value.clone());
             }
         }
-
         context.push_override(overridden_params);
-        context.collect_modport_signatures(value);
+        let modport_signatures = context.collect_modport_signatures(value);
+
+        // The interfaces connected to this instance's modport ports are part of
+        // the instantiated body (their parameters size its members), so they
+        // must distinguish the instance cache entry.
+        let mut modport_signatures: Vec<_> = modport_signatures.into_iter().collect();
+        modport_signatures.sort();
+        for (port_name, modport_sig) in modport_signatures {
+            sig.add_modport_signature(port_name, modport_sig);
+        }
 
         let component = context.block(|c| get_component(c, &sig, token));
 

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1775,7 +1775,7 @@ pub fn build_for_statement(
 
     let body: ir::StatementBlock = Conv::conv(context, value.statement_block.as_ref())?;
 
-    Ok(ir::StatementBlock(vec![ir::Statement::For(
+    Ok(ir::StatementBlock(vec![ir::Statement::For(Box::new(
         ir::ForStatement {
             var_id: loop_var_id,
             var_name,
@@ -1784,7 +1784,7 @@ pub fn build_for_statement(
             body: body.0,
             token,
         },
-    )]))
+    ))]))
 }
 
 pub fn eval_function_call(
@@ -1942,7 +1942,11 @@ pub fn eval_struct_constructor(
         }
 
         let comptime = Box::new(Comptime::create_unknown(token));
-        Ok(ir::Expression::StructConstructor(r#type, ret, comptime))
+        Ok(ir::Expression::StructConstructor(
+            Box::new(r#type),
+            ret,
+            comptime,
+        ))
     } else {
         unreachable!();
     }

--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -27,7 +27,7 @@ pub enum Expression {
     ),
     Concatenation(Vec<(Expression, Option<Expression>)>, Box<Comptime>),
     ArrayLiteral(Vec<ArrayLiteralItem>, Box<Comptime>),
-    StructConstructor(Type, Vec<(StrId, Expression)>, Box<Comptime>),
+    StructConstructor(Box<Type>, Vec<(StrId, Expression)>, Box<Comptime>),
 }
 
 impl Expression {
@@ -257,7 +257,7 @@ impl Expression {
                     comptime.clock_domain = comptime.clock_domain.merge(&expr.clock_domain);
                 }
 
-                comptime.r#type = r#type.clone();
+                comptime.r#type = r#type.as_ref().clone();
                 comptime.is_const = is_const;
                 comptime.is_global = is_global;
                 comptime.evaluated = true;

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -15,6 +15,13 @@ pub struct Signature {
     pub full_path: Vec<StrId>,
     pub parameters: Vec<(StrId, ValueVariant)>,
     pub generic_parameters: Vec<(StrId, GenericSymbolPath)>,
+    /// Signatures of the interface instances connected to this instance's
+    /// modport ports (port name -> interface signature). A module body is
+    /// monomorphized by the parameters of the interfaces behind its modport
+    /// ports, so they must participate in the instance cache key; otherwise
+    /// a module connected to `some_if #(W: 128)` reuses the body built for
+    /// `some_if` at its default parameters (or vice versa).
+    pub modport_signatures: Vec<(StrId, Signature)>,
 }
 
 impl Signature {
@@ -24,6 +31,7 @@ impl Signature {
             full_path: vec![],
             parameters: vec![],
             generic_parameters: vec![],
+            modport_signatures: vec![],
         }
     }
 
@@ -53,9 +61,14 @@ impl Signature {
         self.generic_parameters.push((id, value));
     }
 
+    pub fn add_modport_signature(&mut self, id: StrId, sig: Signature) {
+        self.modport_signatures.push((id, sig));
+    }
+
     pub fn normalize(&mut self) {
         self.parameters.sort();
         self.generic_parameters.sort();
+        self.modport_signatures.sort();
     }
 
     pub fn from_path(context: &mut Context, mut path: GenericSymbolPath) -> Option<Self> {

--- a/crates/analyzer/src/ir/statement.rs
+++ b/crates/analyzer/src/ir/statement.rs
@@ -30,7 +30,7 @@ pub enum Statement {
     If(IfStatement),
     IfReset(IfResetStatement),
     Case(CaseStatement),
-    For(ForStatement),
+    For(Box<ForStatement>),
     SystemFunctionCall(Box<SystemFunctionCall>),
     FunctionCall(Box<FunctionCall>),
     TbMethodCall(TbMethodCall),

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -4077,6 +4077,81 @@ fn interface_array_modport_index() {
 }
 
 #[test]
+fn interface_parameter_override() {
+    // `inst u: Bus #(W: 16)`: the parameter override must size the interface
+    // members, including inside child modules that receive the interface via a
+    // modport port (directly or passed through another module's modport port).
+    // Earlier, the instance cache keyed a component only on its own parameters,
+    // so a child module built against the default-width interface was reused
+    // for a differently-parameterized one, truncating members.
+    let code = r#"
+    interface Bus #(
+        param W: u32 = 8,
+    ) {
+        var data: logic<W>;
+        modport master {
+            data: output,
+        }
+        modport slave {
+            data: input,
+        }
+    }
+
+    module Producer (
+        bus: modport Bus::master,
+    ) {
+        always_comb {
+            bus.data = '1;
+        }
+    }
+
+    module Leaf (
+        bus: modport Bus::slave,
+        out_data: output logic<16>,
+    ) {
+        assign out_data = bus.data as 16;
+    }
+
+    module Passthru (
+        bus: modport Bus::slave,
+        out_data: output logic<16>,
+    ) {
+        inst u_leaf: Leaf (
+            bus: bus,
+            out_data: out_data,
+        );
+    }
+
+    module Top (
+        clk: input clock,
+        rst: input reset,
+        out_narrow: output logic<16>,
+        out_wide: output logic<16>,
+    ) {
+        inst u_bus8: Bus;
+        inst u_bus16: Bus #( W: 16 );
+
+        inst u_p8: Producer ( bus: u_bus8 );
+        inst u_p16: Producer ( bus: u_bus16 );
+
+        inst u_c8: Passthru ( bus: u_bus8, out_data: out_narrow );
+        inst u_c16: Passthru ( bus: u_bus16, out_data: out_wide );
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+        let narrow = sim.get("out_narrow").unwrap();
+        let wide = sim.get("out_wide").unwrap();
+        assert_eq!(narrow, Value::new(0x00FF, 16, false));
+        assert_eq!(wide, Value::new(0xFFFF, 16, false));
+    }
+}
+
+#[test]
 fn interface_function() {
     let code = r#"
     interface BusIf {


### PR DESCRIPTION
A module receiving an interface through a modport port was elaborated once and cached keyed only on its own parameters, so the first elaboration (e.g. against a default-parameter interface) was reused for instances connected to interfaces with overridden parameters:

    interface If #( param DW: u32 = 64 ) { var data: logic<DW>; ... }
    inst a_if: If;                 // DW=64
    inst b_if: If #( DW: 128 );
    inst a: Consumer ( xif: a_if );
    inst b: Consumer ( xif: b_if ); // reused DW=64 body: data truncated

Fold the connected interface instances' signatures into the consuming module's Signature (participating in the instance-cache key and normalize()), and register modport ports' effective interface signatures so pass-through connections (module A's modport port forwarded to a child's modport port) key correctly as well. Adds the interface_parameter_override simulator regression test (direct and pass-through modports, default + overridden widths).