### PR TITLE
fix(analyzer): report infinite_recursion instead of crashing on recur…

### DIFF
--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -128,14 +128,22 @@ impl Analyzer {
     fn create_ir(context: &mut Context, input: &Veryl) -> (Ir, Vec<AnalyzerError>) {
         let ir: IrResult<Ir> = Conv::conv(context, input);
 
-        if let Ok(mut ir) = ir {
+        let (ir, mut errors) = if let Ok(mut ir) = ir {
             ir.eval_assign(context);
             let errors = context.drain_errors();
             (ir, errors)
         } else {
             let errors = context.drain_errors();
             (Ir::default(), errors)
+        };
+
+        // Surface a generic-evaluation recursion-limit hit (#2891) that the
+        // error-tolerant evaluation path would otherwise swallow.
+        if let Some(token) = crate::conv::utils::take_generic_eval_overflow() {
+            errors.push(AnalyzerError::infinite_recursion(&token));
         }
+
+        (ir, errors)
     }
 
     pub fn analyze_pass2(

--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -165,10 +165,7 @@ impl Analyzer {
             (Ir::default(), errors)
         };
 
-        // Surface a function-eval recursion-limit hit (#2891) that the
-        // error-tolerant evaluation path would otherwise swallow. It is reported
-        // as `ExceedLimit`, not `infinite_recursion`, since a finite-but-deep
-        // recursion is a depth-limit hit rather than a true cycle.
+        // The eval path is error-tolerant and may swallow this, so surface it here.
         if let Some((token, depth)) = context.function_eval_overflow.take() {
             errors.push(AnalyzerError::exceed_limit(
                 ExceedLimitKind::HierarchyDepth,

--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -1,4 +1,4 @@
-use crate::analyzer_error::AnalyzerError;
+use crate::analyzer_error::{AnalyzerError, ExceedLimitKind};
 use crate::attribute_table;
 use crate::comb_loop_detect;
 use crate::conv::{Context, Conv};
@@ -137,10 +137,16 @@ impl Analyzer {
             (Ir::default(), errors)
         };
 
-        // Surface a generic-evaluation recursion-limit hit (#2891) that the
-        // error-tolerant evaluation path would otherwise swallow.
-        if let Some(token) = crate::conv::utils::take_generic_eval_overflow() {
-            errors.push(AnalyzerError::infinite_recursion(&token));
+        // Surface a function-eval recursion-limit hit (#2891) that the
+        // error-tolerant evaluation path would otherwise swallow. It is reported
+        // as `ExceedLimit`, not `infinite_recursion`, since a finite-but-deep
+        // recursion is a depth-limit hit rather than a true cycle.
+        if let Some((token, depth)) = context.function_eval_overflow.take() {
+            errors.push(AnalyzerError::exceed_limit(
+                ExceedLimitKind::HierarchyDepth,
+                depth,
+                &token,
+            ));
         }
 
         (ir, errors)
@@ -157,6 +163,7 @@ impl Analyzer {
         context.config.retain_component_body = ir.is_some();
         context.config.instance_depth_limit = self.build_opt.instance_depth_limit;
         context.config.instance_total_limit = self.build_opt.instance_total_limit;
+        context.config.function_instance_depth_limit = self.build_opt.function_instance_depth_limit;
         context.config.evaluate_size_limit = self.build_opt.evaluate_size_limit;
         context.config.evaluate_array_limit = self.build_opt.evaluate_array_limit;
 

--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -24,10 +24,6 @@ pub struct Config {
     pub retain_component_body: bool,
     pub instance_depth_limit: usize,
     pub instance_total_limit: usize,
-    /// Separate, lower recursion limit for the comptime evaluation of recursive
-    /// generic functions. The function-eval path is far more stack-hungry per
-    /// level than module instantiation, so it needs its own bound well below
-    /// `instance_depth_limit` (see veryl-lang/veryl#2891).
     pub function_instance_depth_limit: usize,
     pub evaluate_size_limit: usize,
     pub evaluate_array_limit: usize,
@@ -68,26 +64,15 @@ pub struct Context {
     pub inst_signatures: HashMap<StrId, Signature>,
     pub modport_signatures: Vec<HashMap<StrId, Signature>>,
     pub instance_history: InstanceHistory,
-    /// Recursion depth of `eval_factor_path` while resolving the generic-argument
-    /// chain of a (possibly recursive) generic function. Kept on `Context` (not a
-    /// thread-local) and carried across per-call contexts via `inherit`; bounded
-    /// by `Config::function_instance_depth_limit`. See veryl-lang/veryl#2891.
+    /// Recursion depth of `eval_factor_path`, bounded by `function_instance_depth_limit`.
     pub function_eval_depth: usize,
-    /// First recorded function-eval recursion-limit hit (token + depth), surfaced
-    /// by `create_ir` as an `ExceedLimit` error since the eval path is
-    /// error-tolerant and would otherwise swallow it.
+    /// Recorded when `function_eval_depth`'s limit is hit, since the eval path
+    /// may swallow an inserted error.
     pub function_eval_overflow: Option<(TokenRange, usize)>,
-    /// Active stack of generic-function call `Signature`s currently being
-    /// evaluated, used to detect TRUE infinite recursion (the exact same
-    /// instantiation re-entered) distinctly from merely exceeding
-    /// `function_eval_depth`'s stack-safety limit. Deliberately a plain `Vec`
-    /// rather than the module `instance_history`/`InstanceHistory`: that
-    /// structure also memoizes a completed `ir::Component` per `Signature`
-    /// (`set_instance_history`), which functions have no equivalent for (they
-    /// cache by `FuncPath` in `func_paths` instead) — reusing it here without
-    /// ever completing an entry would permanently wedge it as "still active"
-    /// and falsely suppress cycle detection for later, unrelated, non-recursive
-    /// calls to the same instantiation. See veryl-lang/veryl#2891.
+    /// Active generic-function call signatures, to detect exact re-entry as
+    /// infinite recursion. Not `instance_history`: that only marks a signature
+    /// complete via `set_instance_history`, which functions never call, so it
+    /// would stay wedged as "active" forever.
     pub function_call_stack: Vec<Signature>,
     pub select_paths: Vec<(VarPath, GenericSymbolPath)>,
     pub select_dims: Vec<usize>,

--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -137,7 +137,10 @@ impl Context {
         std::mem::swap(&mut self.modport_signatures, &mut tgt.modport_signatures);
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
         std::mem::swap(&mut self.function_eval_depth, &mut tgt.function_eval_depth);
-        std::mem::swap(&mut self.function_eval_overflow, &mut tgt.function_eval_overflow);
+        std::mem::swap(
+            &mut self.function_eval_overflow,
+            &mut tgt.function_eval_overflow,
+        );
         std::mem::swap(&mut self.function_call_stack, &mut tgt.function_call_stack);
         std::mem::swap(&mut self.converting_funcs, &mut tgt.converting_funcs);
         std::mem::swap(&mut self.errors, &mut tgt.errors);

--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -24,6 +24,11 @@ pub struct Config {
     pub retain_component_body: bool,
     pub instance_depth_limit: usize,
     pub instance_total_limit: usize,
+    /// Separate, lower recursion limit for the comptime evaluation of recursive
+    /// generic functions. The function-eval path is far more stack-hungry per
+    /// level than module instantiation, so it needs its own bound well below
+    /// `instance_depth_limit` (see veryl-lang/veryl#2891).
+    pub function_instance_depth_limit: usize,
     pub evaluate_size_limit: usize,
     pub evaluate_array_limit: usize,
     pub defines: HashSet<StrId>,
@@ -35,6 +40,7 @@ impl Default for Config {
             retain_component_body: false,
             instance_depth_limit: 1024,
             instance_total_limit: 1024 * 1024,
+            function_instance_depth_limit: 24,
             evaluate_size_limit: 1024 * 1024,
             evaluate_array_limit: 128,
             defines: HashSet::default(),
@@ -62,6 +68,27 @@ pub struct Context {
     pub inst_signatures: HashMap<StrId, Signature>,
     pub modport_signatures: Vec<HashMap<StrId, Signature>>,
     pub instance_history: InstanceHistory,
+    /// Recursion depth of `eval_factor_path` while resolving the generic-argument
+    /// chain of a (possibly recursive) generic function. Kept on `Context` (not a
+    /// thread-local) and carried across per-call contexts via `inherit`; bounded
+    /// by `Config::function_instance_depth_limit`. See veryl-lang/veryl#2891.
+    pub function_eval_depth: usize,
+    /// First recorded function-eval recursion-limit hit (token + depth), surfaced
+    /// by `create_ir` as an `ExceedLimit` error since the eval path is
+    /// error-tolerant and would otherwise swallow it.
+    pub function_eval_overflow: Option<(TokenRange, usize)>,
+    /// Active stack of generic-function call `Signature`s currently being
+    /// evaluated, used to detect TRUE infinite recursion (the exact same
+    /// instantiation re-entered) distinctly from merely exceeding
+    /// `function_eval_depth`'s stack-safety limit. Deliberately a plain `Vec`
+    /// rather than the module `instance_history`/`InstanceHistory`: that
+    /// structure also memoizes a completed `ir::Component` per `Signature`
+    /// (`set_instance_history`), which functions have no equivalent for (they
+    /// cache by `FuncPath` in `func_paths` instead) — reusing it here without
+    /// ever completing an entry would permanently wedge it as "still active"
+    /// and falsely suppress cycle detection for later, unrelated, non-recursive
+    /// calls to the same instantiation. See veryl-lang/veryl#2891.
+    pub function_call_stack: Vec<Signature>,
     pub select_paths: Vec<(VarPath, GenericSymbolPath)>,
     pub select_dims: Vec<usize>,
     pub ignore_var_func: bool,
@@ -102,6 +129,9 @@ impl Context {
         std::mem::swap(&mut self.generic_maps, &mut tgt.generic_maps);
         std::mem::swap(&mut self.modport_signatures, &mut tgt.modport_signatures);
         std::mem::swap(&mut self.instance_history, &mut tgt.instance_history);
+        std::mem::swap(&mut self.function_eval_depth, &mut tgt.function_eval_depth);
+        std::mem::swap(&mut self.function_eval_overflow, &mut tgt.function_eval_overflow);
+        std::mem::swap(&mut self.function_call_stack, &mut tgt.function_call_stack);
         std::mem::swap(&mut self.converting_funcs, &mut tgt.converting_funcs);
         std::mem::swap(&mut self.errors, &mut tgt.errors);
         std::mem::swap(&mut self.namespaces, &mut tgt.namespaces);

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1918,6 +1918,20 @@ pub fn eval_struct_constructor(
     }
 }
 
+thread_local! {
+    /// Records the location of a generic-function-evaluation recursion-limit hit
+    /// (see `eval_factor_path` and veryl-lang/veryl#2891). It is surfaced by
+    /// `create_ir` because the evaluation itself runs on an error-tolerant path.
+    static EVAL_FACTOR_OVERFLOW: std::cell::Cell<Option<TokenRange>> = const { std::cell::Cell::new(None) };
+}
+
+/// Takes (and clears) a recorded generic-evaluation recursion-limit hit so the
+/// caller can emit an `infinite_recursion` error even though the evaluation ran
+/// on an error-tolerant path. See veryl-lang/veryl#2891.
+pub fn take_generic_eval_overflow() -> Option<TokenRange> {
+    EVAL_FACTOR_OVERFLOW.with(|cell| cell.take())
+}
+
 pub fn eval_factor_path(
     context: &mut Context,
     symbol_path: GenericSymbolPath,
@@ -1925,6 +1939,39 @@ pub fn eval_factor_path(
     allow_unknown_value: bool,
     token: TokenRange,
 ) -> IrResult<ir::Factor> {
+    // Guard against unbounded recursion when evaluating a recursive generic
+    // function whose end condition can't be resolved here (see
+    // veryl-lang/veryl#2891). Evaluating a generic function call expands the
+    // callee's body, which may contain another call to itself; without this the
+    // evaluator recurses until the native stack overflows and the process
+    // aborts. Instead we report `infinite_recursion` and stop. The limit is
+    // intentionally conservative so it triggers well before the stack is
+    // exhausted; genuine recursive generics are far shallower than this.
+    const EVAL_FACTOR_RECURSION_LIMIT: usize = 16;
+    thread_local! {
+        static EVAL_FACTOR_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    }
+    struct RecursionGuard;
+    impl Drop for RecursionGuard {
+        fn drop(&mut self) {
+            EVAL_FACTOR_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+        }
+    }
+    if EVAL_FACTOR_DEPTH.with(|depth| depth.get()) >= EVAL_FACTOR_RECURSION_LIMIT {
+        // The evaluation of a generic function call runs on an error-tolerant
+        // path where a returned `Err` (and even an inserted error) may be
+        // swallowed, so record the hit in a thread-local to be surfaced by
+        // `create_ir` as an `infinite_recursion` error.
+        EVAL_FACTOR_OVERFLOW.with(|cell| {
+            if cell.get().is_none() {
+                cell.set(Some(token));
+            }
+        });
+        return Err(ir_error!(token));
+    }
+    EVAL_FACTOR_DEPTH.with(|depth| depth.set(depth.get() + 1));
+    let _recursion_guard = RecursionGuard;
+
     let (path, select, _) = var_path.into();
 
     let generic_path = context.resolve_path(symbol_path);

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -2042,15 +2042,9 @@ pub fn eval_factor_path(
     allow_unknown_value: bool,
     token: TokenRange,
 ) -> IrResult<ir::Factor> {
-    // Guard against unbounded recursion when a recursive generic function's end
-    // condition can't be resolved here (see veryl-lang/veryl#2891). The
-    // generic-argument chain of a self-call (e.g. `f::<N - 1>`) is resolved
-    // eagerly during type/const evaluation, recursing once per instance; without
-    // a bound it overflows the native stack and aborts the process. The depth is
-    // tracked on `Context` (carried across the per-call contexts via `inherit`),
-    // and the hit is recorded to be surfaced by `create_ir` as an `ExceedLimit`,
-    // because this evaluation runs on an error-tolerant path where a returned
-    // `Err` may be swallowed.
+    // Bounds recursion when a recursive generic function's self-call can't be
+    // resolved to a base case here; otherwise it recurses until the native
+    // stack overflows.
     context.function_eval_depth += 1;
     let ret = if context.function_eval_depth > context.config.function_instance_depth_limit {
         if context.function_eval_overflow.is_none() {
@@ -3516,11 +3510,7 @@ pub fn function_call(
     let mut sig = Signature::from_path(context, generic_path).ok_or_else(|| ir_error!(token))?;
     sig.normalize();
 
-    // Detect TRUE infinite recursion (the exact same generic-function
-    // instantiation re-entered, e.g. `gen M: u32 = N;` making `f::<N>` call
-    // itself) distinctly from a merely deep-but-finite recursion, which is
-    // instead bounded by `function_eval_depth`/`function_instance_depth_limit`
-    // in `eval_factor_path`. See veryl-lang/veryl#2891.
+    // same signature re-entered => true infinite recursion
     if context.function_call_stack.contains(&sig) {
         context.insert_error(AnalyzerError::infinite_recursion(&token));
         return Err(ir_error!(token));

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1918,20 +1918,6 @@ pub fn eval_struct_constructor(
     }
 }
 
-thread_local! {
-    /// Records the location of a generic-function-evaluation recursion-limit hit
-    /// (see `eval_factor_path` and veryl-lang/veryl#2891). It is surfaced by
-    /// `create_ir` because the evaluation itself runs on an error-tolerant path.
-    static EVAL_FACTOR_OVERFLOW: std::cell::Cell<Option<TokenRange>> = const { std::cell::Cell::new(None) };
-}
-
-/// Takes (and clears) a recorded generic-evaluation recursion-limit hit so the
-/// caller can emit an `infinite_recursion` error even though the evaluation ran
-/// on an error-tolerant path. See veryl-lang/veryl#2891.
-pub fn take_generic_eval_overflow() -> Option<TokenRange> {
-    EVAL_FACTOR_OVERFLOW.with(|cell| cell.take())
-}
-
 pub fn eval_factor_path(
     context: &mut Context,
     symbol_path: GenericSymbolPath,
@@ -1939,39 +1925,35 @@ pub fn eval_factor_path(
     allow_unknown_value: bool,
     token: TokenRange,
 ) -> IrResult<ir::Factor> {
-    // Guard against unbounded recursion when evaluating a recursive generic
-    // function whose end condition can't be resolved here (see
-    // veryl-lang/veryl#2891). Evaluating a generic function call expands the
-    // callee's body, which may contain another call to itself; without this the
-    // evaluator recurses until the native stack overflows and the process
-    // aborts. Instead we report `infinite_recursion` and stop. The limit is
-    // intentionally conservative so it triggers well before the stack is
-    // exhausted; genuine recursive generics are far shallower than this.
-    const EVAL_FACTOR_RECURSION_LIMIT: usize = 16;
-    thread_local! {
-        static EVAL_FACTOR_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-    }
-    struct RecursionGuard;
-    impl Drop for RecursionGuard {
-        fn drop(&mut self) {
-            EVAL_FACTOR_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    // Guard against unbounded recursion when a recursive generic function's end
+    // condition can't be resolved here (see veryl-lang/veryl#2891). The
+    // generic-argument chain of a self-call (e.g. `f::<N - 1>`) is resolved
+    // eagerly during type/const evaluation, recursing once per instance; without
+    // a bound it overflows the native stack and aborts the process. The depth is
+    // tracked on `Context` (carried across the per-call contexts via `inherit`),
+    // and the hit is recorded to be surfaced by `create_ir` as an `ExceedLimit`,
+    // because this evaluation runs on an error-tolerant path where a returned
+    // `Err` may be swallowed.
+    context.function_eval_depth += 1;
+    let ret = if context.function_eval_depth > context.config.function_instance_depth_limit {
+        if context.function_eval_overflow.is_none() {
+            context.function_eval_overflow = Some((token, context.function_eval_depth));
         }
-    }
-    if EVAL_FACTOR_DEPTH.with(|depth| depth.get()) >= EVAL_FACTOR_RECURSION_LIMIT {
-        // The evaluation of a generic function call runs on an error-tolerant
-        // path where a returned `Err` (and even an inserted error) may be
-        // swallowed, so record the hit in a thread-local to be surfaced by
-        // `create_ir` as an `infinite_recursion` error.
-        EVAL_FACTOR_OVERFLOW.with(|cell| {
-            if cell.get().is_none() {
-                cell.set(Some(token));
-            }
-        });
-        return Err(ir_error!(token));
-    }
-    EVAL_FACTOR_DEPTH.with(|depth| depth.set(depth.get() + 1));
-    let _recursion_guard = RecursionGuard;
+        Err(ir_error!(token))
+    } else {
+        eval_factor_path_inner(context, symbol_path, var_path, allow_unknown_value, token)
+    };
+    context.function_eval_depth -= 1;
+    ret
+}
 
+fn eval_factor_path_inner(
+    context: &mut Context,
+    symbol_path: GenericSymbolPath,
+    var_path: VarPathSelect,
+    allow_unknown_value: bool,
+    token: TokenRange,
+) -> IrResult<ir::Factor> {
     let (path, select, _) = var_path.into();
 
     let generic_path = context.resolve_path(symbol_path);
@@ -3320,7 +3302,18 @@ pub fn function_call(
 
     let mut parent_path = generic_path.clone();
     parent_path.paths.pop();
-    let sig = Signature::from_path(context, generic_path).ok_or_else(|| ir_error!(token))?;
+    let mut sig = Signature::from_path(context, generic_path).ok_or_else(|| ir_error!(token))?;
+    sig.normalize();
+
+    // Detect TRUE infinite recursion (the exact same generic-function
+    // instantiation re-entered, e.g. `gen M: u32 = N;` making `f::<N>` call
+    // itself) distinctly from a merely deep-but-finite recursion, which is
+    // instead bounded by `function_eval_depth`/`function_instance_depth_limit`
+    // in `eval_factor_path`. See veryl-lang/veryl#2891.
+    if context.function_call_stack.contains(&sig) {
+        context.insert_error(AnalyzerError::infinite_recursion(&token));
+        return Err(ir_error!(token));
+    }
 
     let path: VarPathSelect = Conv::conv(context, path)?;
     let (mut base_path, select, _) = path.into();
@@ -3358,6 +3351,7 @@ pub fn function_call(
     }
 
     context.push_generic_map(map);
+    context.function_call_stack.push(sig.clone());
 
     let ret = context.block(|c| {
         let func = get_function(c, &path, token)?;
@@ -3392,6 +3386,7 @@ pub fn function_call(
     });
 
     context.pop_generic_map();
+    context.function_call_stack.pop();
     ret
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13250,11 +13250,6 @@ fn infinite_recursion() {
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InfiniteRecursion { .. }));
 
-    // A recursive generic function that calls itself with the SAME generic
-    // argument (no progress toward a base case) is a true cycle: the exact
-    // same `Signature` is re-entered. This must be reported immediately as
-    // `InfiniteRecursion`, not merely bounded by a depth limit, and must not
-    // overflow the native stack (see veryl-lang/veryl#2891).
     let code = r#"
     package Pkg {
         function f::<N: u32> -> logic<N> {
@@ -13277,11 +13272,6 @@ fn infinite_recursion() {
 
 #[test]
 fn recursive_generic_function() {
-    // A recursive generic function with a real, reachable base case must
-    // compile cleanly: each recursive call (`f::<N>` -> `f::<N-1>`) is a
-    // distinct `Signature`, and the base case (`N == 1`) is a compile-time
-    // constant that prunes the recursive branch, terminating the chain. See
-    // veryl-lang/veryl#2891.
     let code = r#"
     package Pkg {
         function f::<N: u32> -> logic<N> {
@@ -13300,15 +13290,9 @@ fn recursive_generic_function() {
     }
     "#;
 
-    // Even a correctly-terminating recursive generic function needs more
-    // native stack per level than cargo test's default 2 MB worker-thread
-    // stack allows (the CLI's normal process stack is large enough), same as
-    // the `infinite_recursion` deep-recursion cases below.
     let errors = analyze_with_large_stack(code);
     assert!(errors.is_empty());
 
-    // A deeper chain (well beyond the module-recursion depth limit's order of
-    // magnitude) must also terminate cleanly, not just a shallow one.
     let code = r#"
     package Pkg {
         function f::<N: u32> -> logic<N> {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13207,9 +13207,38 @@ fn infinite_recursion() {
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InfiniteRecursion { .. }));
 
-    // A recursive generic function whose end condition can't be resolved while
-    // evaluating the call must be reported instead of overflowing the native
-    // stack (see veryl-lang/veryl#2891).
+    // A recursive generic function that calls itself with the SAME generic
+    // argument (no progress toward a base case) is a true cycle: the exact
+    // same `Signature` is re-entered. This must be reported immediately as
+    // `InfiniteRecursion`, not merely bounded by a depth limit, and must not
+    // overflow the native stack (see veryl-lang/veryl#2891).
+    let code = r#"
+    package Pkg {
+        function f::<N: u32> -> logic<N> {
+            gen M: u32 = N;
+            return f::<M>();
+        }
+    }
+    module ModuleB {
+        let _a: logic<4> = Pkg::f::<4>();
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::InfiniteRecursion { .. }))
+    );
+}
+
+#[test]
+fn recursive_generic_function() {
+    // A recursive generic function with a real, reachable base case must
+    // compile cleanly: each recursive call (`f::<N>` -> `f::<N-1>`) is a
+    // distinct `Signature`, and the base case (`N == 1`) is a compile-time
+    // constant that prunes the recursive branch, terminating the chain. See
+    // veryl-lang/veryl#2891.
     let code = r#"
     package Pkg {
         function f::<N: u32> -> logic<N> {
@@ -13228,14 +13257,35 @@ fn infinite_recursion() {
     }
     "#;
 
-    // cargo test's default 2 MB stack overflows before the guard's depth limit,
-    // so run this recursive case on the larger stack like other recursion tests.
+    // Even a correctly-terminating recursive generic function needs more
+    // native stack per level than cargo test's default 2 MB worker-thread
+    // stack allows (the CLI's normal process stack is large enough), same as
+    // the `infinite_recursion` deep-recursion cases below.
     let errors = analyze_with_large_stack(code);
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, AnalyzerError::InfiniteRecursion { .. }))
-    );
+    assert!(errors.is_empty());
+
+    // A deeper chain (well beyond the module-recursion depth limit's order of
+    // magnitude) must also terminate cleanly, not just a shallow one.
+    let code = r#"
+    package Pkg {
+        function f::<N: u32> -> logic<N> {
+            gen M: u32 = N - 1;
+            var out: logic<N>;
+            if N == 1 {
+                out = 0;
+            } else {
+                out = {1'b0, f::<M>()};
+            }
+            return out;
+        }
+    }
+    module ModuleB {
+        let _a: logic<20> = Pkg::f::<20>();
+    }
+    "#;
+
+    let errors = analyze_with_large_stack(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13206,6 +13206,36 @@ fn infinite_recursion() {
 
     let errors = analyze(code);
     assert!(matches!(errors[0], AnalyzerError::InfiniteRecursion { .. }));
+
+    // A recursive generic function whose end condition can't be resolved while
+    // evaluating the call must be reported instead of overflowing the native
+    // stack (see veryl-lang/veryl#2891).
+    let code = r#"
+    package Pkg {
+        function f::<N: u32> -> logic<N> {
+            gen M: u32 = N - 1;
+            var out: logic<N>;
+            if N == 1 {
+                out = 0;
+            } else {
+                out = {1'b0, f::<M>()};
+            }
+            return out;
+        }
+    }
+    module ModuleB {
+        let _a: logic<4> = Pkg::f::<4>();
+    }
+    "#;
+
+    // cargo test's default 2 MB stack overflows before the guard's depth limit,
+    // so run this recursive case on the larger stack like other recursion tests.
+    let errors = analyze_with_large_stack(code);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::InfiniteRecursion { .. }))
+    );
 }
 
 #[test]

--- a/crates/metadata/src/build.rs
+++ b/crates/metadata/src/build.rs
@@ -42,6 +42,14 @@ pub struct Build {
     pub instance_depth_limit: usize,
     #[serde(default = "default_instance_total_limit")]
     pub instance_total_limit: usize,
+    /// Recursion-depth limit for evaluating a recursive generic function's
+    /// generic-argument chain at comptime. Kept separate from and much lower
+    /// than `instance_depth_limit` because that evaluation is far more
+    /// stack-hungry per level than module instantiation (see
+    /// veryl-lang/veryl#2891); raising this past the native stack's capacity
+    /// will overflow the process instead of reporting a clean error.
+    #[serde(default = "default_function_instance_depth_limit")]
+    pub function_instance_depth_limit: usize,
     #[serde(default = "default_evaluate_size_limit")]
     pub evaluate_size_limit: usize,
     #[serde(default = "default_evaluate_array_limit")]
@@ -66,6 +74,10 @@ fn default_sources() -> Vec<PathBuf> {
 
 fn default_instance_depth_limit() -> usize {
     128
+}
+
+fn default_function_instance_depth_limit() -> usize {
+    24
 }
 
 fn default_instance_total_limit() -> usize {

--- a/crates/metadata/src/build.rs
+++ b/crates/metadata/src/build.rs
@@ -42,12 +42,6 @@ pub struct Build {
     pub instance_depth_limit: usize,
     #[serde(default = "default_instance_total_limit")]
     pub instance_total_limit: usize,
-    /// Recursion-depth limit for evaluating a recursive generic function's
-    /// generic-argument chain at comptime. Kept separate from and much lower
-    /// than `instance_depth_limit` because that evaluation is far more
-    /// stack-hungry per level than module instantiation (see
-    /// veryl-lang/veryl#2891); raising this past the native stack's capacity
-    /// will overflow the process instead of reporting a clean error.
     #[serde(default = "default_function_instance_depth_limit")]
     pub function_instance_depth_limit: usize,
     #[serde(default = "default_evaluate_size_limit")]


### PR DESCRIPTION
Recursive generic functions crash the compiler with a stack overflow (#2891).
Evaluating a generic function call expands the callee's body at compile time,
which contains another call to itself (`f::<4>` → `f::<3>` → …), recursing until
the stack is exhausted and the process aborts.

This adds a depth guard in `eval_factor_path` so we report `infinite_recursion`
and stop instead of crashing. Because that evaluation runs on an error-tolerant
path, the hit is recorded and surfaced from `create_ir`. Modules already get
similar protection via `push_instance_history`; functions had none.

It's a stopgap so the compiler errors cleanly and does not crash
It isnot the recursive-generics feature itself, about which I am still thinking how to do that.