### PR TITLE
fix(analyzer): emit mismatch_type for non-FactorType proto generic default

### DIFF
--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -26,7 +26,7 @@ use crate::ir::{
 };
 use crate::namespace::DefineContext;
 use crate::symbol::{
-    ClockDomain, Direction, GenericBoundKind, Symbol, SymbolKind, TbComponentKind,
+    ClockDomain, Direction, GenericBoundKind, ProtoBound, Symbol, SymbolKind, TbComponentKind,
 };
 use crate::symbol_path::{GenericSymbolPath, SymbolPathNamespace};
 use crate::symbol_table;
@@ -364,7 +364,26 @@ impl Conv<&WithGenericParameterItem> for () {
                 match y.with_generic_argument_item.as_ref() {
                     WithGenericArgumentItem::Number(_)
                     | WithGenericArgumentItem::BooleanLiteral(_) => {
-                        if !matches!(x.bound, GenericBoundKind::Proto(_)) {
+                        if let GenericBoundKind::Proto(_) = &x.bound {
+                            // A number/boolean default is only valid when the proto
+                            // bound resolves to a variable type (e.g. `M: u32 = 1`).
+                            // For a proto module/interface/package (or enum/struct/
+                            // union type bound) it is a type mismatch, matching the
+                            // call-site check in `check_generic_proto_arg`.
+                            if !matches!(
+                                x.bound.resolve_proto_bound(&symbol.found.namespace),
+                                Ok(ProtoBound::FactorType(_))
+                            ) {
+                                context.insert_error(AnalyzerError::mismatch_type(
+                                    MismatchTypeKind::GenericArgument {
+                                        name: value.identifier.text().to_string(),
+                                        expected: x.bound.to_string(),
+                                        actual: "number".into(),
+                                    },
+                                    &token,
+                                ));
+                            }
+                        } else {
                             context.insert_error(AnalyzerError::mismatch_assignment(
                                 "number",
                                 &x.bound.to_string(),

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -4652,6 +4652,21 @@ fn mismatch_type() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    proto module ProtoModuleA;
+    module ModuleA::<M: ProtoModuleA = 1> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(matches!(errors[0], AnalyzerError::MismatchType { .. }));
+
+    let code = r#"
+    module ModuleA::<M: u32 = 1> {}
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Proto generic parameters now reject a number/boolean default value unless the bound resolves to a variable (factor) type. A default like `M: ProtoModuleA = 1` is reported as a `mismatch_type` error, while a variable-type bound such as `M: u32 = 1` still analyzes clean.

## Why this matters

Reported in #2382. The `Conv<&WithGenericParameterItem>` impl in `crates/analyzer/src/conv/declaration.rs` guarded the numeric/boolean default arm with `if !matches!(x.bound, GenericBoundKind::Proto(_))`, which blanket-accepted a numeric default for every proto bound. For a `proto module` (or `proto interface` / `proto package`, and enum/struct/union type bounds) a number is not a valid default, so no error was emitted for the reproduction:

```veryl
proto module ProtoModuleA;
module ModuleA::<M: ProtoModuleA = 1> {}
```

The fix resolves the bound with `resolve_proto_bound` and only accepts the number when it is a `ProtoBound::FactorType`, otherwise emitting `mismatch_type` with `MismatchTypeKind::GenericArgument`. This mirrors the existing call-site check in `check_generic_proto_arg` (`crates/analyzer/src/conv/checker/generic.rs`), which already rejects a non-component argument for those bounds.

## Testing

- Added subtests to the existing `mismatch_type` test in `crates/analyzer/src/tests.rs`: the issue's `proto module` reproduction now yields a `MismatchType` error, and the `M: u32 = 1` regression happy path still analyzes clean.
- `cargo test -p veryl-analyzer mismatch_type` passes.
- `cargo fmt --check` and `cargo build` are clean.

Fixes #2382
