### PR TITLE
Fix false positive of `invalid_select` error

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -2096,7 +2096,8 @@ fn eval_factor_path_inner(
 ) -> IrResult<ir::Factor> {
     let (path, select, _) = var_path.into();
 
-    let generic_path = context.resolve_path(symbol_path);
+    let mut generic_path = context.resolve_path(symbol_path);
+    generic_path.unalias(None);
     check_generic_refereence(context, &generic_path);
 
     let found = if let Some(path) = generic_path.to_var_path()

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -11398,6 +11398,30 @@ fn invalid_select() {
             .iter()
             .any(|e| matches!(e, AnalyzerError::NonConstantSelectWidth { .. }))
     );
+
+    let code = r#"
+    package a_pkg::<A_VALUE: u32> {
+        const A: u32 = A_VALUE;
+    }
+    package b_pkg {
+        alias package a = a_pkg::<2>;
+    }
+    interface c_if {
+        var c: logic;
+        modport mp {
+            c: output,
+        }
+    }
+    module e_module {
+        const N: u32 = b_pkg::a::A;
+        inst c: c_if[N];
+        connect c[0].mp <> 0;
+        connect c[1].mp <> 0;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#3006

The generic arg given to `a_pkg` is not propagated when evaluating the value of parameter `N`.
A generic path to a factor should be unaliased to fix this situation.
