### PR TITLE
Fix emittion of global generic functions called from non generic global function

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -369,6 +369,19 @@ impl ReferenceTable {
                     }
 
                     if (params.len() + n_args) == 0 {
+                        if symbol.found.is_global_function() {
+                            // A non-generic global function may call generic global functions.
+                            // `insert_subordinate_generic_instances` is used to connect the current namespace
+                            // and such functions.
+                            let namespace = scope::namespace(scope, define_context);
+                            Self::insert_subordinate_generic_instances(
+                                &namespace,
+                                &symbol.found,
+                                None,
+                                &generic_maps,
+                                None,
+                            );
+                        }
                         continue;
                     }
 
@@ -481,7 +494,7 @@ impl ReferenceTable {
         Self::insert_subordinate_generic_instances(
             namespace,
             target,
-            &symbol,
+            Some(&symbol),
             generic_maps,
             affiliation_symbol,
         );
@@ -519,7 +532,7 @@ impl ReferenceTable {
     fn insert_subordinate_generic_instances(
         namespace: &Namespace,
         target: &Symbol,
-        inst_symbol: &Symbol,
+        inst_symbol: Option<&Symbol>,
         generic_maps: &[GenericMap],
         affiliation_symbol: Option<&Symbol>,
     ) {
@@ -566,7 +579,7 @@ impl ReferenceTable {
                         target_namespace,
                         &path_symbol.found,
                         &mut generic_maps.to_vec(),
-                        Some(inst_symbol),
+                        inst_symbol,
                     );
                 }
             }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -3271,6 +3271,73 @@ endmodule
 
     println!("ret\n{}exp\n{}", ret, expect);
     assert_eq!(ret, expect);
+
+    let code = r#"
+function count_ones::<N: p32> (
+    x: input logic<N>,
+) -> logic<8> {
+    var n: logic<8>;
+    n = 0;
+    for i in 0..N {
+        if x[i] == 1 {
+            n = n + 1;
+        }
+    }
+    return n;
+}
+function helper (
+    x: input logic<16>,
+) -> logic<8> {
+    return count_ones::<16>(x);
+}
+module User (
+    i_x: input  logic<16>,
+    o_n: output logic<8> ,
+) {
+    always_comb {
+        o_n = helper(i_x);
+    }
+}
+    "#;
+
+    let expect = r#"
+
+
+module prj_User (
+    input  var logic [16-1:0] i_x,
+    output var logic [8-1:0]  o_n
+);
+    always_comb begin
+        o_n = helper(i_x);
+    end
+
+    function automatic logic [8-1:0] __count_ones__16(
+        input var logic [16-1:0] x
+    ) ;
+        logic [8-1:0] n;
+        n = 0;
+        for (int i = 0; i < 16; i++) begin
+            if (x[i] == 1) begin
+                n = n + 1;
+            end
+        end
+        return n;
+    endfunction
+    function automatic logic [8-1:0] helper(
+        input var logic [16-1:0] x
+    ) ;
+        return __count_ones__16(x);
+    endfunction
+endmodule
+//# sourceMappingURL=test.sv.map
+"#;
+
+    let metadata = Metadata::create_default("prj").unwrap();
+
+    let ret = emit(&metadata, code);
+
+    println!("ret\n{}exp\n{}", ret, expect);
+    assert_eq!(ret, expect);
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#2995

## Cause

File-scope (global) functions are emitted at their call sites, so the instances of any generic functions they reference must be registered into the caller's namespace too.

For a **non-generic** global function this registration was skipped: reference resolution returned early before reaching it, so the generic functions called inside it were never registered. As a result their monomorphized definitions (`__name__N`) were emitted nowhere.

## Fix

Register the subordinate generic instances of a non-generic global function before that early return, connecting the caller's namespace to the generic functions it calls (transitive cases handled via the recursion in `insert_generic_instance`).