### PR TITLE
Fix port default value being const-folded into connected instances

### DIFF
--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -600,13 +600,26 @@ impl Conv<&PortDeclarationItem> for () {
                 None
             };
 
-            if let Some((value, comptime)) = default_value {
-                let mut comptime = comptime.clone();
-                comptime.value = ValueVariant::Numeric(value.clone());
-                comptime.r#type = r#type.clone();
+            if let Some((value, _)) = default_value {
+                // The default seeds the port's *storage* (used when an instance
+                // leaves the port unconnected), but the port itself must stay a
+                // runtime variable: the module IR is shared by every instance,
+                // and a connected instance overrides the default. Registering
+                // the default as the port's comptime value would const-fold
+                // expressions over the port to the default for all instances.
+                let comptime = Comptime::from_type(r#type.clone(), clock_domain, variable_token);
 
                 // TODO for array
                 let id = context.insert_var_path(path.clone(), comptime);
+
+                for x in r#type.expand_struct_union(&path, &[], None) {
+                    let r#type = x.part_select.last().unwrap().r#type.clone();
+                    let mut comptime = Comptime::from_type(r#type, clock_domain, variable_token);
+                    let path = x.path.clone();
+                    comptime.part_select = Some(x);
+                    context.insert_var_path_with_id(path, id, comptime);
+                }
+
                 let array_limit = context.config.evaluate_array_limit;
                 let variable = Variable::new(
                     id,

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -2264,6 +2264,50 @@ fn inst() {
 }
 
 #[test]
+fn inst_port_default_value_connected_not_folded() {
+    // A default-valued input port must evaluate to the *connected* value in a
+    // connected instance; the default is only the fallback for an unconnected
+    // one. The module IR is shared by every instance, so registering the
+    // default as the port's comptime value used to const-fold expressions
+    // over the port (e.g. a shift amount) to the default for all instances.
+    let code = r#"
+    module Sub (
+        i_cfg : input  logic<5>  = 5'd0,
+        o_mask: output logic<16>,
+    ) {
+        assign o_mask = (16'd1 << i_cfg) - 16'd1;
+    }
+
+    module Top (
+        o_conn: output logic<16>,
+        o_open: output logic<16>,
+    ) {
+        inst s_conn: Sub (
+            i_cfg : 5'd2  ,
+            o_mask: o_conn,
+        );
+        inst s_open: Sub (
+            o_mask: o_open,
+        );
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        // connected: (1 << 2) - 1
+        assert_eq!(sim.get("o_conn").unwrap(), Value::new(3, 16, false));
+        // unconnected: the default applies, (1 << 0) - 1
+        assert_eq!(sim.get("o_open").unwrap(), Value::new(0, 16, false));
+    }
+}
+
+#[test]
 fn inst_array_input_port() {
     let code = r#"
     module Top (


### PR DESCRIPTION
A default-valued input port was registered with the default as its comptime value (is_const = true), so expressions over the port (e.g. a shift amount) const-folded to the default in the shared module IR even when an instance connected a different value:

    module Sub (
        i_cfg : input  logic<5>  = 5'd0,
        o_mask: output logic<16>,
    ) {
        assign o_mask = (16'd1 << i_cfg) - 16'd1; // folded to 0
    }
    inst s: Sub ( i_cfg: 5'd2, o_mask: mask );   // mask = 0, not 3

Register the port like any runtime variable (Comptime::from_type, plus the struct-member expansion eval_variable does) and keep the default only as the port variable's storage init, which is what an unconnected instance reads. Emitted SystemVerilog was already correct (the emitter injects the default at unconnected instantiation sites); only the native simulator misbehaved.