### PR TITLE
Pass --top-module to Verilator test compiles

### DIFF
--- a/crates/veryl/src/runner/verilator.rs
+++ b/crates/veryl/src/runner/verilator.rs
@@ -187,11 +187,15 @@ impl Runner for Verilator {
             }
         }
 
+        let top_name = test.to_string();
+
         let rt = Runtime::new().unwrap();
 
         rt.block_on(async {
             let compile = new_cmd("verilator")
                 .args(&opt)
+                .arg("--top-module")
+                .arg(&top_name)
                 .arg("-f")
                 .arg(metadata.filelist_path())
                 .arg("-o")


### PR DESCRIPTION
Problem

  The Verilator runner hands the whole project filelist to Verilator with -Wno-MULTITOP and no explicit top module, so every
  module that isn't instantiated by the test elaborates as an additional top.

  Once modules carry interface (modport) ports, those dangling tops alias spurious drivers onto the test's real interface
  instances — every member reports MULTIDRIVEN, and slave-to-master members are forced to 0, which hangs the test.

  This was harmless while all module boundaries were plain logic ports, so the problem only surfaces with interface/modport
  ports.

Fix

  Pass --top-module <test> so elaboration is restricted to the test's own module tree. Unreferenced modules are still parsed
  but pruned during elaboration.

```
  let top_name = test.to_string();
  // ...
  let compile = new_cmd("verilator")
      .args(&opt)
      .arg("--top-module")
      .arg(&top_name)
      .arg("-f")
      .arg(metadata.filelist_path())
      // ...
```
  Notes

  - As a side benefit, this speeds up the per-test --binary compile, since Verilator no longer elaborates unreferenced modules.