### PR TITLE
Add `$tb::random` testbench component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_regex"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6357,6 +6366,8 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "pprof",
+ "rand 0.10.1",
+ "rand_pcg",
  "serde_json",
  "smallvec",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ paste               = "1.0"
 postcard            = {version = "1.1", features = ["alloc"]}
 pprof               = {version = "0.15.0", features = ["flamegraph"]}
 pulldown-cmark      = "0.13.4"
+rand                = {version = "0.10", default-features = false}
+rand_pcg            = "0.10"
 regex               = "1.12.4"
 scnr2               = "0.5.2"
 semver              = {version = "1.0", features = ["serde"]}

--- a/crates/analyzer/src/conv/checker/generic.rs
+++ b/crates/analyzer/src/conv/checker/generic.rs
@@ -1,9 +1,9 @@
 use crate::analyzer_error::MismatchTypeKind;
-use crate::conv::utils::{TypePosition, eval_factor_path, eval_generic_expr};
+use crate::conv::utils::{TypePosition, eval_factor_path, eval_generic_expr, eval_type};
 use crate::conv::{Context, Conv};
 use crate::ir::{self, Comptime, IrResult, Type, VarPathSelect};
 use crate::namespace::Namespace;
-use crate::symbol::{GenericBoundKind, ProtoBound, Symbol, SymbolKind};
+use crate::symbol::{GenericBoundKind, ProtoBound, Symbol, SymbolKind, TbComponentKind};
 use crate::symbol_path::GenericSymbolPath;
 use crate::{AnalyzerError, symbol_table};
 use veryl_parser::token_range::TokenRange;
@@ -378,6 +378,39 @@ pub fn check_generic_refereence(context: &mut Context, path: &GenericSymbolPath)
                     };
                     if let Some(error) = error {
                         context.insert_error(error);
+                    }
+
+                    // `$tb::random::<T>` restricts T beyond the plain `type`
+                    // bound: it must be a fixed integer (<= 64 bits) or bbool.
+                    // The kind (2-state integer vs. float / 4-state / aggregate)
+                    // is taken from the generic-arg comptime, which distinguishes
+                    // floats and `logic`; the width is taken from `eval_type`,
+                    // which resolves the concrete width of a `gen`/aliased
+                    // `bit<N>` (the comptime collapses that width to 1 bit).
+                    if let SymbolKind::TbComponent(tb) = &symbol.found.kind
+                        && matches!(tb.kind, TbComponentKind::Random)
+                    {
+                        let kind_ok = matches!(&expr.value, ir::ValueVariant::Type(t)
+                            if matches!(t.kind, ir::TypeKind::Bit) && t.array.as_slice().is_empty());
+                        let width_ok = eval_type(context, &arg, TypePosition::Variable)
+                            .ok()
+                            .map(|t| t.total_width().unwrap_or(1))
+                            .map(|w| (1..=64).contains(&w))
+                            .unwrap_or(false);
+                        if !(kind_ok && width_ok) {
+                            let actual = match &expr.value {
+                                ir::ValueVariant::Type(t) => t.to_string(),
+                                _ => expr.r#type.to_string(),
+                            };
+                            context.insert_error(AnalyzerError::mismatch_type(
+                                MismatchTypeKind::GenericArgument {
+                                    name: expr.token.end.to_string(),
+                                    expected: "u8/u16/u32/u64/i8/i16/i32/i64/bbool".to_string(),
+                                    actual,
+                                },
+                                &expr.token,
+                            ));
+                        }
                     }
                 }
             }

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -711,7 +711,10 @@ impl Conv<&VarDeclaration> for ir::Declaration {
                 && let SymbolKind::TbComponent(c) = &ty_symbol.found.kind
             {
                 match &c.kind {
-                    TbComponentKind::File => {
+                    TbComponentKind::File | TbComponentKind::Random => {
+                        // `file` handle and `random` generator are never assigned
+                        // (their state lives in the simulator), so suppress the
+                        // unassigned lint.
                         attribute_table::insert(
                             variable_token,
                             Attribute::Allow(AllowItem::UnassignVariable),
@@ -1437,8 +1440,10 @@ impl Conv<&InstDeclaration> for ir::Declaration {
             let type_kind = match tb_prop.kind {
                 TbComponentKind::ClockGen => ir::TypeKind::Clock,
                 TbComponentKind::ResetGen => ir::TypeKind::Reset,
-                // Rejected or handled above.
-                TbComponentKind::File | TbComponentKind::External(_) => unreachable!(),
+                // `file`/`random` are `var`-form; external handled above.
+                TbComponentKind::File | TbComponentKind::Random | TbComponentKind::External(_) => {
+                    unreachable!()
+                }
             };
             let ir_type = {
                 let mut t = ir::Type::new(type_kind);
@@ -1508,8 +1513,10 @@ impl Conv<&InstDeclaration> for ir::Declaration {
                             let type_name = match tb_prop.kind {
                                 TbComponentKind::ClockGen => "$tb::clock_gen",
                                 TbComponentKind::ResetGen => "$tb::reset_gen",
-                                // Rejected or handled above.
-                                TbComponentKind::File | TbComponentKind::External(_) => {
+                                // `file`/`random` are `var`-form; external handled above.
+                                TbComponentKind::File
+                                | TbComponentKind::Random
+                                | TbComponentKind::External(_) => {
                                     unreachable!()
                                 }
                             };

--- a/crates/analyzer/src/conv/statement.rs
+++ b/crates/analyzer/src/conv/statement.rs
@@ -255,9 +255,9 @@ fn conv_tb_method_call_assignment(
     let ir::Statement::TbMethodCall(mut method_call) = tb_stmt else {
         unreachable!()
     };
-    if !matches!(method_call.method, ir::TbMethod::Component { .. }) {
-        // Builtin $tb methods return nothing; report the assignment as an
-        // unsupported use.
+    if !method_call.method.has_return_value() {
+        // The remaining builtin $tb methods return nothing; report the
+        // assignment as an unsupported use.
         context.insert_error(AnalyzerError::invalid_factor(
             None,
             "testbench method without return value",

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1381,15 +1381,31 @@ pub fn eval_type(
                     }
                 }
                 SymbolKind::TbComponent(x)
-                    if matches!(x.kind, TbComponentKind::File | TbComponentKind::External(_)) =>
+                    if matches!(
+                        x.kind,
+                        TbComponentKind::File
+                            | TbComponentKind::External(_)
+                            | TbComponentKind::Random
+                    ) =>
                 {
-                    // The descriptor lives in the simulator (file table or
-                    // component instance), so this slot is never read; back
-                    // it with a throwaway 32-bit width.
                     if !context.in_test_module {
                         let token: TokenRange = path.paths[0].base.into();
                         context.insert_error(AnalyzerError::invalid_tb_usage(&token));
                     }
+
+                    if matches!(x.kind, TbComponentKind::Random)
+                        && let Some(arg) =
+                            path.paths.last().and_then(|p| p.arguments.first()).cloned()
+                    {
+                        // `$tb::random::<T>`'s element type is its generic argument
+                        // (already resolved through the generic maps above); its
+                        // validity is diagnosed by `check_generic_refereence`. The
+                        // file/component descriptor lives in the simulator and has
+                        // no element type, so its slot is backed by a throwaway
+                        // 32-bit width.
+                        return eval_type(context, &arg, pos);
+                    }
+
                     width.push(Some(32));
                     ir::TypeKind::Bit
                 }
@@ -1464,6 +1480,18 @@ pub fn eval_type(
                 "lbool" => ir::TypeKind::Logic,
                 "string" => ir::TypeKind::String,
                 _ => ir::TypeKind::Unknown,
+            }
+        } else if let GenericSymbolPathKind::VariableType(widths) = &path.kind {
+            // A variable type (`bit<N>` / `logic<N>`) passed as a generic
+            // argument carries its width in the path kind; `logic` is 4-state,
+            // `bit` (and anything else here) is 2-state.
+            for w in widths {
+                width.push(Some(*w));
+            }
+            if path.paths.last().map(|p| p.base.to_string()).as_deref() == Some("logic") {
+                ir::TypeKind::Logic
+            } else {
+                ir::TypeKind::Bit
             }
         } else {
             ir::TypeKind::Unknown
@@ -1870,7 +1898,7 @@ pub fn eval_function_call(
             let ir::Statement::TbMethodCall(method_call) = tb_stmt else {
                 unreachable!()
             };
-            if matches!(method_call.method, TbMethod::Component { .. }) {
+            if method_call.method.has_return_value() {
                 return hoist_component_method_call(context, method_call, token);
             }
             context.insert_error(AnalyzerError::invalid_factor(
@@ -4077,6 +4105,7 @@ pub fn tb_method_call(
     };
 
     let mut ret_width = None;
+    let mut ret_signed = false;
     let method = match (tb_kind, method_name) {
         (TbComponentKind::ClockGen, "next") => {
             let count = if let Some(ir::Arguments::Positional(ref positional)) = args
@@ -4154,6 +4183,33 @@ pub fn tb_method_call(
         }
         (TbComponentKind::File, "close") => TbMethod::FileClose,
         (TbComponentKind::File, "flush") => TbMethod::FileFlush,
+        (TbComponentKind::Random, "seed") => {
+            let value = random_arg(context, &args, 0, method_name, 1, &token)?;
+            TbMethod::RandomSeed { value }
+        }
+        (TbComponentKind::Random, "get") => {
+            let (width, signed) = resolve_random_elem_type(context, type_path);
+            ret_width = Some(width);
+            ret_signed = signed;
+            TbMethod::RandomGet { width, signed }
+        }
+        (TbComponentKind::Random, "get_range") => {
+            let min = random_arg(context, &args, 0, method_name, 2, &token)?;
+            let max = random_arg(context, &args, 1, method_name, 2, &token)?;
+            let (width, signed) = resolve_random_elem_type(context, type_path);
+            ret_width = Some(width);
+            ret_signed = signed;
+            TbMethod::RandomGetRange {
+                min,
+                max,
+                width,
+                signed,
+            }
+        }
+        (TbComponentKind::Random, "get_seed") => {
+            ret_width = Some(64);
+            TbMethod::RandomGetSeed
+        }
         // Any method name is accepted on a user-defined component; the
         // component validates it at run time. With a manifest present the
         // name and arity are also diagnosed here.
@@ -4173,7 +4229,58 @@ pub fn tb_method_call(
         ret: None,
         ret_strict: false,
         ret_width,
+        ret_signed,
     })))
+}
+
+/// Captures the `i`-th positional argument of a `$tb::random` method as a
+/// self-determined expression (its width folds from the argument, as for
+/// `$display`). Emits an arity error and fails when the argument is missing.
+fn random_arg(
+    context: &mut Context,
+    args: &Option<ir::Arguments>,
+    i: usize,
+    method_name: &str,
+    arity: usize,
+    token: &TokenRange,
+) -> IrResult<ir::Expression> {
+    if let Some(ir::Arguments::Positional(positional)) = args
+        && let Some(arg) = positional.get(i)
+    {
+        let mut expr = arg.0.clone();
+        expr.eval_comptime(context, None);
+        Ok(expr)
+    } else {
+        let actual = if let Some(ir::Arguments::Positional(positional)) = args {
+            positional.len()
+        } else {
+            0
+        };
+        context.insert_error(AnalyzerError::mismatch_function_arity(
+            method_name,
+            arity,
+            actual,
+            token,
+        ));
+        Err(ir_error!(*token))
+    }
+}
+
+/// Resolves the element type `T` of a `$tb::random::<T>` variable through the
+/// generic maps in effect, returning its `(width, signed)`. The element type's
+/// validity (fixed integer / `bbool`) is diagnosed by `check_generic_refereence`;
+/// this falls back to a 32-bit unsigned width when resolution fails so a broken
+/// type does not also cause a spurious ICE.
+fn resolve_random_elem_type(context: &mut Context, type_path: &GenericSymbolPath) -> (u32, bool) {
+    let resolved = context.resolve_path(type_path.clone());
+    if let Some(arg) = resolved.paths.last().and_then(|p| p.arguments.first())
+        && let Ok(ty) = eval_type(context, &arg.clone(), TypePosition::Variable)
+        && let Some(width) = ty.total_width()
+    {
+        (width as u32, ty.signed)
+    } else {
+        (32, false)
+    }
 }
 
 /// Hoists a component method call out of an expression: the call runs as
@@ -4199,11 +4306,13 @@ pub fn hoist_component_method_call(
     }
 
     let width = method_call.ret_width.unwrap_or(64) as usize;
+    let signed = method_call.ret_signed;
     let name = format!("__tb_method_ret_{}", context.tb_hoist_count);
     context.tb_hoist_count += 1;
     let path = VarPath::new(resource_table::insert_str(&name));
     let mut r#type = ir::Type::new(ir::TypeKind::Bit);
     r#type.set_concrete_width(Shape::new(vec![Some(width)]));
+    r#type.signed = signed;
 
     let comptime = Comptime::from_type(r#type.clone(), ClockDomain::None, token);
     let id = context.insert_var_path(path.clone(), comptime.clone());
@@ -4213,7 +4322,7 @@ pub fn hoist_component_method_call(
         path.clone(),
         VarKind::Variable,
         r#type,
-        vec![Value::new_x(width, false)],
+        vec![Value::new_x(width, signed)],
         context.get_affiliation(),
         &token,
         array_limit,

--- a/crates/analyzer/src/ir/statement.rs
+++ b/crates/analyzer/src/ir/statement.rs
@@ -255,6 +255,9 @@ pub struct TbMethodCall {
     /// sizes the hoist temporary and is enforced against the value the
     /// component actually returns.
     pub ret_width: Option<u32>,
+    /// Signedness of the returned value. Only `$tb::random::<iN>` returns a
+    /// signed value; component/file methods leave this `false`.
+    pub ret_signed: bool,
 }
 
 #[derive(Clone)]
@@ -283,6 +286,36 @@ pub enum TbMethod {
         method: StrId,
         args: Vec<SystemFunctionInput>,
     },
+    /// `$tb::random::<T>` methods. `width`/`signed` describe the element type
+    /// `T`, resolved through the generic pipeline at the call site.
+    RandomSeed {
+        value: Expression,
+    },
+    RandomGet {
+        width: u32,
+        signed: bool,
+    },
+    RandomGetRange {
+        min: Expression,
+        max: Expression,
+        width: u32,
+        signed: bool,
+    },
+    RandomGetSeed,
+}
+
+impl TbMethod {
+    /// Whether the method yields a value usable in assignment/expression
+    /// position. The remaining builtin `$tb` methods are statements only.
+    pub fn has_return_value(&self) -> bool {
+        matches!(
+            self,
+            TbMethod::Component { .. }
+                | TbMethod::RandomGet { .. }
+                | TbMethod::RandomGetRange { .. }
+                | TbMethod::RandomGetSeed
+        )
+    }
 }
 
 impl Statement {
@@ -485,6 +518,12 @@ impl fmt::Display for Statement {
                     let args_str: Vec<_> = args.iter().map(|a| format!("{a}")).collect();
                     write!(f, "{}.{method}({});", x.inst, args_str.join(", "))
                 }
+                TbMethod::RandomSeed { value } => write!(f, "{}.seed({value});", x.inst),
+                TbMethod::RandomGet { .. } => write!(f, "{}.get();", x.inst),
+                TbMethod::RandomGetRange { min, max, .. } => {
+                    write!(f, "{}.get_range({min}, {max});", x.inst)
+                }
+                TbMethod::RandomGetSeed => write!(f, "{}.get_seed();", x.inst),
             },
             Statement::For(x) => {
                 let range_op = if let ForRange::Reverse { .. } = &x.range {

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -557,6 +557,11 @@ impl Symbol {
                 let symbol = symbol_table::get(x.base).unwrap();
                 symbol.generic_parameters()
             }
+            SymbolKind::TbComponent(x) => x
+                .generic_parameters
+                .iter()
+                .map(|x| get_generic_parameter(*x))
+                .collect(),
             _ => Vec::new(),
         }
     }
@@ -573,6 +578,7 @@ impl Symbol {
                 let symbol = symbol_table::get(x.base).unwrap();
                 symbol.has_generic_paramters()
             }
+            SymbolKind::TbComponent(x) => !x.generic_parameters.is_empty(),
             _ => false,
         }
     }
@@ -905,9 +911,12 @@ impl Symbol {
             SymbolKind::GenericInstance(x) => symbol_table::get(x.base)
                 .map(|x| x.is_variable_type())
                 .unwrap_or(false),
-            // `$tb::file` is a passive testbench resource declared as `var`.
+            // `$tb::file` and `$tb::random` are testbench resources declared as `var`.
             SymbolKind::TbComponent(x) => {
-                matches!(x.kind, TbComponentKind::File | TbComponentKind::External(_))
+                matches!(
+                    x.kind,
+                    TbComponentKind::File | TbComponentKind::Random | TbComponentKind::External(_)
+                )
             }
             _ => false,
         }
@@ -2912,6 +2921,10 @@ pub enum TbComponentKind {
     ClockGen,
     ResetGen,
     File,
+    /// Random-number generator declared as `var r: $tb::random::<T>;`. The
+    /// element type is a generic argument (see `TbComponentProperty`), so it
+    /// is resolved through the normal generic pipeline.
+    Random,
     /// User-defined verification component declared in `[[components]]` of
     /// Veryl.toml; the payload is the component name.
     External(StrId),
@@ -2923,6 +2936,7 @@ impl std::fmt::Display for TbComponentKind {
             TbComponentKind::ClockGen => write!(f, "clock_gen"),
             TbComponentKind::ResetGen => write!(f, "reset_gen"),
             TbComponentKind::File => write!(f, "file"),
+            TbComponentKind::Random => write!(f, "random"),
             TbComponentKind::External(name) => write!(f, "{name}"),
         }
     }
@@ -2931,6 +2945,10 @@ impl std::fmt::Display for TbComponentKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TbComponentProperty {
     pub kind: TbComponentKind,
+    /// Generic type parameters, held like other symbols' `generic_parameters`.
+    /// Only `$tb::random::<T>` carries one (the synthesized `T`); the other
+    /// builtins and external components leave this empty.
+    pub generic_parameters: Vec<SymbolId>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/analyzer/src/tb_component.rs
+++ b/crates/analyzer/src/tb_component.rs
@@ -1,17 +1,58 @@
 use crate::namespace::Namespace;
 use crate::symbol::{
-    Affiliation, ClockDomain, Direction, DocComment, FunctionProperty, Port, PortProperty, Symbol,
-    SymbolKind, TbComponentKind, TbComponentProperty, Type, TypeKind,
+    Affiliation, ClockDomain, Direction, DocComment, FunctionProperty, GenericBoundKind,
+    GenericParameterProperty, Port, PortProperty, Symbol, SymbolKind, TbComponentKind,
+    TbComponentProperty, Type, TypeKind, UserDefinedType,
 };
+use crate::symbol_path::{GenericSymbol, GenericSymbolPath, GenericSymbolPathKind};
 use crate::symbol_table::SymbolTable;
 use veryl_parser::token_range::TokenRange;
 use veryl_parser::veryl_token::{Token, TokenSource, VerylToken};
+
+/// A builtin `Type` with no width/array (widths for fixed types are derived
+/// from the `TypeKind` itself).
+fn builtin_type(kind: TypeKind) -> Type {
+    Type {
+        modifier: vec![],
+        kind,
+        width: vec![],
+        array: vec![],
+        array_type: None,
+        is_const: false,
+        token: TokenRange::default(),
+    }
+}
+
+/// A `Type` referring to the generic parameter `T` (`base` token) of
+/// `$tb::random`. Left unresolved (`symbol: None`) so the return type is
+/// resolved through the generic map at the call site, like any `-> T`.
+fn generic_param_type(base: Token) -> Type {
+    let range: TokenRange = base.into();
+    let path = GenericSymbolPath {
+        paths: vec![GenericSymbol {
+            base,
+            arguments: vec![],
+        }],
+        kind: GenericSymbolPathKind::Identifier,
+        range,
+    };
+    Type {
+        modifier: vec![],
+        kind: TypeKind::UserDefined(UserDefinedType { path, symbol: None }),
+        width: vec![],
+        array: vec![],
+        array_type: None,
+        is_const: false,
+        token: range,
+    }
+}
 
 fn insert_method(
     symbol_table: &mut SymbolTable,
     parent_ns: &Namespace,
     name: &str,
     port_defs: &[(&str, Direction)],
+    ret: Option<Type>,
 ) {
     let func_token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
     let mut func_ns = parent_ns.clone();
@@ -62,7 +103,7 @@ fn insert_method(
         generic_consts: vec![],
         generic_references: vec![],
         ports,
-        ret: None,
+        ret,
         reference_paths: vec![],
         constantable: None,
         definition: None,
@@ -93,6 +134,7 @@ pub fn insert_external_components(names: &[&str]) {
             &token,
             SymbolKind::TbComponent(TbComponentProperty {
                 kind: TbComponentKind::External(token.text),
+                generic_parameters: vec![],
             }),
             &ns,
             true,
@@ -130,6 +172,7 @@ pub fn insert_dependency_components(project: &str, names: &[&str]) {
             &token,
             SymbolKind::TbComponent(TbComponentProperty {
                 kind: TbComponentKind::External(key),
+                generic_parameters: vec![],
             }),
             &ns,
             true,
@@ -139,95 +182,154 @@ pub fn insert_dependency_components(project: &str, names: &[&str]) {
     }
 }
 
+/// Inserts a non-generic `$tb::<name>` component symbol and returns its inner
+/// namespace, for registering methods under it.
+fn insert_component(
+    symbol_table: &mut SymbolTable,
+    tb_ns: &Namespace,
+    name: &str,
+    kind: TbComponentKind,
+) -> Namespace {
+    let token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
+    let symbol = Symbol::new(
+        &token,
+        SymbolKind::TbComponent(TbComponentProperty {
+            kind,
+            generic_parameters: vec![],
+        }),
+        tb_ns,
+        true,
+        DocComment::default(),
+    );
+    let _ = symbol_table.insert(&token, symbol);
+    let mut ns = tb_ns.clone();
+    ns.push(token.text);
+    ns
+}
+
+fn insert_clock_gen(symbol_table: &mut SymbolTable, tb_ns: &Namespace) {
+    let ns = insert_component(symbol_table, tb_ns, "clock_gen", TbComponentKind::ClockGen);
+    insert_method(
+        symbol_table,
+        &ns,
+        "next",
+        &[("count", Direction::Input)],
+        None,
+    );
+}
+
+fn insert_reset_gen(symbol_table: &mut SymbolTable, tb_ns: &Namespace) {
+    let ns = insert_component(symbol_table, tb_ns, "reset_gen", TbComponentKind::ResetGen);
+    insert_method(
+        symbol_table,
+        &ns,
+        "assert",
+        &[("count", Direction::Input)],
+        None,
+    );
+}
+
+fn insert_file(symbol_table: &mut SymbolTable, tb_ns: &Namespace) {
+    let ns = insert_component(symbol_table, tb_ns, "file", TbComponentKind::File);
+    // `write` is variadic, so it is registered port-less; `tb_method_call`
+    // intercepts the call and handles its arguments.
+    insert_method(
+        symbol_table,
+        &ns,
+        "open",
+        &[("name", Direction::Input)],
+        None,
+    );
+    insert_method(
+        symbol_table,
+        &ns,
+        "append",
+        &[("name", Direction::Input)],
+        None,
+    );
+    insert_method(symbol_table, &ns, "write", &[], None);
+    insert_method(symbol_table, &ns, "close", &[], None);
+    insert_method(symbol_table, &ns, "flush", &[], None);
+}
+
+fn insert_random(symbol_table: &mut SymbolTable, tb_ns: &Namespace) {
+    let random_token = Token::new("random", 0, 0, 0, 0, TokenSource::Builtin);
+    let mut ns = tb_ns.clone();
+    ns.push(random_token.text);
+
+    // Synthesize the generic type parameter `T` inside the `$tb::random`
+    // namespace so member methods can return `-> T`, resolved through the
+    // normal generic pipeline at the call site.
+    let t_token = Token::new("T", 0, 0, 0, 0, TokenSource::Builtin);
+    let t_symbol = Symbol::new(
+        &t_token,
+        SymbolKind::GenericParameter(GenericParameterProperty {
+            bound: GenericBoundKind::Type,
+            default_value: None,
+        }),
+        &ns,
+        false,
+        DocComment::default(),
+    );
+    let Some(t_id) = symbol_table.insert(&t_token, t_symbol) else {
+        return;
+    };
+
+    let random_symbol = Symbol::new(
+        &random_token,
+        SymbolKind::TbComponent(TbComponentProperty {
+            kind: TbComponentKind::Random,
+            generic_parameters: vec![t_id],
+        }),
+        tb_ns,
+        true,
+        DocComment::default(),
+    );
+    let _ = symbol_table.insert(&random_token, random_symbol);
+
+    // `seed`/`get`/`get_range` take value arguments handled by
+    // `tb_method_call`; the ports are placeholders. Return types drive the
+    // static typing: `get`/`get_range` return `T`, `get_seed`
+    // returns a 64-bit unsigned, `seed` returns nothing.
+    insert_method(
+        symbol_table,
+        &ns,
+        "seed",
+        &[("value", Direction::Input)],
+        None,
+    );
+    insert_method(
+        symbol_table,
+        &ns,
+        "get",
+        &[],
+        Some(generic_param_type(t_token)),
+    );
+    insert_method(
+        symbol_table,
+        &ns,
+        "get_range",
+        &[("min", Direction::Input), ("max", Direction::Input)],
+        Some(generic_param_type(t_token)),
+    );
+    insert_method(
+        symbol_table,
+        &ns,
+        "get_seed",
+        &[],
+        Some(builtin_type(TypeKind::U64)),
+    );
+}
+
 pub fn insert_symbols(symbol_table: &mut SymbolTable, namespace: &Namespace) {
-    let mut ns = namespace.clone();
+    let mut tb_ns = namespace.clone();
 
     // Push into $tb namespace (already created by DEFINED_NAMESPACES)
     let tb_token = Token::new("$tb", 0, 0, 0, 0, TokenSource::Builtin);
-    ns.push(tb_token.text);
+    tb_ns.push(tb_token.text);
 
-    // $tb::clock_gen
-    let clock_token = Token::new("clock_gen", 0, 0, 0, 0, TokenSource::Builtin);
-    let clock_symbol = Symbol::new(
-        &clock_token,
-        SymbolKind::TbComponent(TbComponentProperty {
-            kind: TbComponentKind::ClockGen,
-        }),
-        &ns,
-        true,
-        DocComment::default(),
-    );
-    let _ = symbol_table.insert(&clock_token, clock_symbol);
-
-    {
-        let mut clock_ns = ns.clone();
-        clock_ns.push(clock_token.text);
-        insert_method(
-            symbol_table,
-            &clock_ns,
-            "next",
-            &[("count", Direction::Input)],
-        );
-    }
-
-    // $tb::reset_gen
-    let reset_token = Token::new("reset_gen", 0, 0, 0, 0, TokenSource::Builtin);
-    let reset_symbol = Symbol::new(
-        &reset_token,
-        SymbolKind::TbComponent(TbComponentProperty {
-            kind: TbComponentKind::ResetGen,
-        }),
-        &ns,
-        true,
-        DocComment::default(),
-    );
-    let _ = symbol_table.insert(&reset_token, reset_symbol);
-
-    {
-        let mut reset_ns = ns.clone();
-        reset_ns.push(reset_token.text);
-        insert_method(
-            symbol_table,
-            &reset_ns,
-            "assert",
-            &[("count", Direction::Input)],
-        );
-    }
-
-    // $tb::file
-    let file_token = Token::new("file", 0, 0, 0, 0, TokenSource::Builtin);
-    let file_symbol = Symbol::new(
-        &file_token,
-        SymbolKind::TbComponent(TbComponentProperty {
-            kind: TbComponentKind::File,
-        }),
-        &ns,
-        true,
-        DocComment::default(),
-    );
-    let _ = symbol_table.insert(&file_token, file_symbol);
-
-    {
-        let mut file_ns = ns.clone();
-        file_ns.push(file_token.text);
-        // `write` is variadic, so it is registered port-less; `tb_method_call`
-        // intercepts the call and handles its arguments.
-        insert_method(
-            symbol_table,
-            &file_ns,
-            "open",
-            &[("name", Direction::Input)],
-        );
-        insert_method(
-            symbol_table,
-            &file_ns,
-            "append",
-            &[("name", Direction::Input)],
-        );
-        insert_method(symbol_table, &file_ns, "write", &[]);
-        insert_method(symbol_table, &file_ns, "close", &[]);
-        insert_method(symbol_table, &file_ns, "flush", &[]);
-    }
-
-    ns.pop();
+    insert_clock_gen(symbol_table, &tb_ns);
+    insert_reset_gen(symbol_table, &tb_ns);
+    insert_file(symbol_table, &tb_ns);
+    insert_random(symbol_table, &tb_ns);
 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -17909,3 +17909,114 @@ fn out_of_range_select_assign() {
         "{errors:?}"
     );
 }
+
+#[test]
+fn tb_random_element_type() {
+    // `$tb::random::<T>` rejects a non-integer / 4-state element type with a
+    // MismatchType error.
+    let build = |ty: &str| {
+        format!(
+            r#"
+    #[test(t)]
+    module t {{
+        var r: $tb::random::<{ty}>;
+        var x: {ty};
+        initial {{
+            x = r.get();
+            $finish();
+        }}
+    }}
+    "#
+        )
+    };
+
+    for ty in ["f32", "f64", "lbool"] {
+        let errors = analyze(&build(ty));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, AnalyzerError::MismatchType { .. })),
+            "`$tb::random::<{ty}>` should be a type mismatch, got: {errors:?}"
+        );
+    }
+
+    // A valid fixed integer element type raises no type mismatch.
+    let errors = analyze(&build("u32"));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::MismatchType { .. })),
+        "`$tb::random::<u32>` should be accepted, got: {errors:?}"
+    );
+
+    // The element type must be at most 64 bits. A wider type is reached via a
+    // `gen` type binding (`bit<N>` cannot be written as a generic argument
+    // directly); 64 is the accepted boundary, 65 is rejected.
+    let with_gen = |bits: u32| {
+        format!(
+            r#"
+    #[test(t)]
+    module t {{
+        gen w: type = bit<{bits}>;
+        var r: $tb::random::<w>;
+        var x: w;
+        initial {{
+            x = r.get();
+            $finish();
+        }}
+    }}
+    "#
+        )
+    };
+    let errors = analyze(&with_gen(64));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::MismatchType { .. })),
+        "`bit<64>` should be accepted, got: {errors:?}"
+    );
+    let errors = analyze(&with_gen(65));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::MismatchType { .. })),
+        "`bit<65>` should be a type mismatch, got: {errors:?}"
+    );
+}
+
+#[test]
+fn tb_random_analyze() {
+    // Valid `$tb::random::<T>` usage for several element types, with its
+    // methods in statement, assignment and typed-let (embedded expression)
+    // positions, must pass the analyzer (the generic return type `T` resolves
+    // in every position). Unused-variable lints are incidental to the shape of
+    // the snippet and are ignored.
+    let code = r#"
+    #[test(test_random)]
+    module test_random {
+        var r: $tb::random::<u32>;
+        var s: $tb::random::<i16>;
+        var b: $tb::random::<bbool>;
+        var x: u32;
+        var y: i16;
+        var sd: u64;
+        initial {
+            r.seed(42);
+            x = r.get();
+            x = r.get_range(0, 100);
+            sd = r.get_seed();
+            y = s.get();
+            let z: u32 = r.get() + 1;
+            $finish();
+        }
+    }
+    "#;
+    let errors: Vec<_> = analyze(code)
+        .into_iter()
+        .filter(|e| !matches!(e, AnalyzerError::UnusedVariable { .. }))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "expected no analyzer errors, got: {errors:?}"
+    );
+}

--- a/crates/languageserver/src/server.rs
+++ b/crates/languageserver/src/server.rs
@@ -1689,6 +1689,7 @@ mod tests {
             &token,
             VerylSymbolKind::TbComponent(TbComponentProperty {
                 kind: TbComponentKind::External(key),
+                generic_parameters: vec![],
             }),
             &Namespace::new(),
             true,

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -23,6 +23,8 @@ smallvec            = {workspace = true}
 thiserror           = {workspace = true}
 num-bigint          = {workspace = true}
 num-traits          = {workspace = true}
+rand                = {workspace = true}
+rand_pcg            = {workspace = true}
 toml                = {workspace = true}
 vcd                 = {workspace = true}
 veryl-analyzer      = {version = "0.20.2", path = "../analyzer"}

--- a/crates/simulator/src/ir/hier_ref.rs
+++ b/crates/simulator/src/ir/hier_ref.rs
@@ -156,9 +156,18 @@ fn resolve_stmt(
                     }
                 }
             }
+            crate::ir::statement::ProtoTbMethodKind::RandomSeed { value } => {
+                resolve_expr(value, context, children)?;
+            }
+            crate::ir::statement::ProtoTbMethodKind::RandomGetRange { min, max, .. } => {
+                resolve_expr(min, context, children)?;
+                resolve_expr(max, context, children)?;
+            }
             crate::ir::statement::ProtoTbMethodKind::FileOpen { .. }
             | crate::ir::statement::ProtoTbMethodKind::FileClose
-            | crate::ir::statement::ProtoTbMethodKind::FileFlush => {}
+            | crate::ir::statement::ProtoTbMethodKind::FileFlush
+            | crate::ir::statement::ProtoTbMethodKind::RandomGet { .. }
+            | crate::ir::statement::ProtoTbMethodKind::RandomGetSeed { .. } => {}
         },
         ProtoStatement::SequentialBlock(stmts) => {
             for s in stmts {

--- a/crates/simulator/src/ir/opt/dead_var_dce.rs
+++ b/crates/simulator/src/ir/opt/dead_var_dce.rs
@@ -299,9 +299,19 @@ fn walk_stmt_liveness(stmt: &ProtoStatement, c: &mut Census) {
                     }
                 }
             }
+            // `$tb::random` argument signals are reads, like file-write args.
+            ProtoTbMethodKind::RandomSeed { value } => {
+                walk_expr_reads(value, c);
+            }
+            ProtoTbMethodKind::RandomGetRange { min, max, .. } => {
+                walk_expr_reads(min, c);
+                walk_expr_reads(max, c);
+            }
             ProtoTbMethodKind::FileOpen { .. }
             | ProtoTbMethodKind::FileClose
-            | ProtoTbMethodKind::FileFlush => {}
+            | ProtoTbMethodKind::FileFlush
+            | ProtoTbMethodKind::RandomGet { .. }
+            | ProtoTbMethodKind::RandomGetSeed { .. } => {}
         },
         ProtoStatement::Break => {}
     }

--- a/crates/simulator/src/ir/statement.rs
+++ b/crates/simulator/src/ir/statement.rs
@@ -163,6 +163,24 @@ pub enum ProtoTbMethodKind {
         /// Assignment form: destination variable for the return value.
         ret: Option<(VarId, RetWidthCheck)>,
     },
+    RandomSeed {
+        value: ProtoExpression,
+    },
+    RandomGet {
+        width: u32,
+        signed: bool,
+        ret: Option<(VarId, RetWidthCheck)>,
+    },
+    RandomGetRange {
+        min: ProtoExpression,
+        max: ProtoExpression,
+        width: u32,
+        signed: bool,
+        ret: Option<(VarId, RetWidthCheck)>,
+    },
+    RandomGetSeed {
+        ret: Option<(VarId, RetWidthCheck)>,
+    },
 }
 
 /// How a component method's returned width is validated before it lands
@@ -208,6 +226,24 @@ pub enum TbMethodKind {
     Component {
         method: StrId,
         args: Vec<ComponentArg>,
+        ret: Option<(VarId, RetWidthCheck)>,
+    },
+    RandomSeed {
+        value: Expression,
+    },
+    RandomGet {
+        width: u32,
+        signed: bool,
+        ret: Option<(VarId, RetWidthCheck)>,
+    },
+    RandomGetRange {
+        min: Expression,
+        max: Expression,
+        width: u32,
+        signed: bool,
+        ret: Option<(VarId, RetWidthCheck)>,
+    },
+    RandomGetSeed {
         ret: Option<(VarId, RetWidthCheck)>,
     },
 }
@@ -1043,9 +1079,18 @@ impl ProtoStatement {
                         }
                     }
                 }
+                ProtoTbMethodKind::RandomSeed { value } => {
+                    value.adjust_offsets(ff_delta, comb_delta);
+                }
+                ProtoTbMethodKind::RandomGetRange { min, max, .. } => {
+                    min.adjust_offsets(ff_delta, comb_delta);
+                    max.adjust_offsets(ff_delta, comb_delta);
+                }
                 ProtoTbMethodKind::FileOpen { .. }
                 | ProtoTbMethodKind::FileClose
-                | ProtoTbMethodKind::FileFlush => {}
+                | ProtoTbMethodKind::FileFlush
+                | ProtoTbMethodKind::RandomGet { .. }
+                | ProtoTbMethodKind::RandomGetSeed { .. } => {}
             },
             ProtoStatement::Break => {}
         }
@@ -1223,9 +1268,18 @@ impl ProtoStatement {
                         }
                     }
                 }
+                ProtoTbMethodKind::RandomSeed { value } => {
+                    value.remap_offsets(map);
+                }
+                ProtoTbMethodKind::RandomGetRange { min, max, .. } => {
+                    min.remap_offsets(map);
+                    max.remap_offsets(map);
+                }
                 ProtoTbMethodKind::FileOpen { .. }
                 | ProtoTbMethodKind::FileClose
-                | ProtoTbMethodKind::FileFlush => {}
+                | ProtoTbMethodKind::FileFlush
+                | ProtoTbMethodKind::RandomGet { .. }
+                | ProtoTbMethodKind::RandomGetSeed { .. } => {}
             },
             ProtoStatement::Break => {}
         }
@@ -2170,6 +2224,50 @@ impl ProtoStatement {
                                 ret: *ret,
                             }
                         }
+                        ProtoTbMethodKind::RandomSeed { value } => TbMethodKind::RandomSeed {
+                            value: value.apply_values_ptr(
+                                ff_values_ptr,
+                                ff_len,
+                                comb_values_ptr,
+                                comb_len,
+                                use_4state,
+                            ),
+                        },
+                        ProtoTbMethodKind::RandomGet { width, signed, ret } => {
+                            TbMethodKind::RandomGet {
+                                width: *width,
+                                signed: *signed,
+                                ret: *ret,
+                            }
+                        }
+                        ProtoTbMethodKind::RandomGetRange {
+                            min,
+                            max,
+                            width,
+                            signed,
+                            ret,
+                        } => TbMethodKind::RandomGetRange {
+                            min: min.apply_values_ptr(
+                                ff_values_ptr,
+                                ff_len,
+                                comb_values_ptr,
+                                comb_len,
+                                use_4state,
+                            ),
+                            max: max.apply_values_ptr(
+                                ff_values_ptr,
+                                ff_len,
+                                comb_values_ptr,
+                                comb_len,
+                                use_4state,
+                            ),
+                            width: *width,
+                            signed: *signed,
+                            ret: *ret,
+                        },
+                        ProtoTbMethodKind::RandomGetSeed { ret } => {
+                            TbMethodKind::RandomGetSeed { ret: *ret }
+                        }
                     };
                     Statement::TbMethodCall {
                         inst: *inst,
@@ -2985,6 +3083,31 @@ impl Conv<&air::Statement> for Vec<ProtoStatement> {
                 }
             },
             air::Statement::TbMethodCall(x) => {
+                // The return destination depends only on the assignment form,
+                // not the method kind, so resolve it once for every returning
+                // method (component + random get/get_range/get_seed).
+                let tb_ret: Option<(VarId, RetWidthCheck)> = match &x.ret {
+                    None => None,
+                    Some(dst) => {
+                        if dst.index.0.is_empty()
+                            && dst.select.0.is_empty()
+                            && dst.select.1.is_none()
+                        {
+                            let check = if let Some(w) = x.ret_width {
+                                RetWidthCheck::Exact(w)
+                            } else if x.ret_strict {
+                                RetWidthCheck::Max64
+                            } else {
+                                RetWidthCheck::Dst
+                            };
+                            Some((dst.id, check))
+                        } else {
+                            // Only a plain variable can receive a method
+                            // return value.
+                            return Err(SimulatorError::unsupported_description(&dst.token));
+                        }
+                    }
+                };
                 let method = match &x.method {
                     air::TbMethod::ClockNext { count, period } => {
                         let count = if let Some(expr) = count {
@@ -3050,35 +3173,39 @@ impl Conv<&air::Statement> for Vec<ProtoStatement> {
                                 }
                             })
                             .collect::<Result<Vec<_>, SimulatorError>>()?;
-                        let ret = match &x.ret {
-                            None => None,
-                            Some(dst) => {
-                                if dst.index.0.is_empty()
-                                    && dst.select.0.is_empty()
-                                    && dst.select.1.is_none()
-                                {
-                                    let check = if let Some(w) = x.ret_width {
-                                        RetWidthCheck::Exact(w)
-                                    } else if x.ret_strict {
-                                        RetWidthCheck::Max64
-                                    } else {
-                                        RetWidthCheck::Dst
-                                    };
-                                    Some((dst.id, check))
-                                } else {
-                                    // Only a plain variable can receive a
-                                    // method return value.
-                                    return Err(SimulatorError::unsupported_description(
-                                        &dst.token,
-                                    ));
-                                }
-                            }
-                        };
                         ProtoTbMethodKind::Component {
                             method: *method,
                             args,
-                            ret,
+                            ret: tb_ret,
                         }
+                    }
+                    air::TbMethod::RandomSeed { value } => {
+                        let value: ProtoExpression = Conv::conv(context, value)?;
+                        ProtoTbMethodKind::RandomSeed { value }
+                    }
+                    air::TbMethod::RandomGet { width, signed } => ProtoTbMethodKind::RandomGet {
+                        width: *width,
+                        signed: *signed,
+                        ret: tb_ret,
+                    },
+                    air::TbMethod::RandomGetRange {
+                        min,
+                        max,
+                        width,
+                        signed,
+                    } => {
+                        let min: ProtoExpression = Conv::conv(context, min)?;
+                        let max: ProtoExpression = Conv::conv(context, max)?;
+                        ProtoTbMethodKind::RandomGetRange {
+                            min,
+                            max,
+                            width: *width,
+                            signed: *signed,
+                            ret: tb_ret,
+                        }
+                    }
+                    air::TbMethod::RandomGetSeed => {
+                        ProtoTbMethodKind::RandomGetSeed { ret: tb_ret }
                     }
                 };
                 vec![ProtoStatement::TbMethodCall {

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -4,6 +4,7 @@ pub mod component;
 pub mod file_table;
 pub mod ir;
 pub mod output_buffer;
+pub mod random_table;
 pub mod simulator;
 pub mod simulator_error;
 pub mod testbench;

--- a/crates/simulator/src/random_table.rs
+++ b/crates/simulator/src/random_table.rs
@@ -1,0 +1,137 @@
+//! Thread-local RNG table backing the `$tb::random` testbench handles.
+//!
+//! Like `file_table`, a thread-local keeps the generator state reachable from
+//! the testbench driver (which has no `Simulator` handle) and isolates
+//! parallel tests. Generators are keyed by the declaring variable's name
+//! (`StrId`). Each handle is lazily seeded from the run's base seed (`--seed`
+//! / `[test].seed`, i.e. `Ir.seed`) mixed with the handle name, so a run is
+//! reproducible for a given seed and distinct handles get distinct streams.
+//! `seed()` overrides the seed explicitly; `get_seed()` reads it back.
+
+use crate::ir::Value;
+use rand::{RngExt, SeedableRng};
+use rand_pcg::Pcg64;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use veryl_parser::resource_table::{self, StrId};
+
+#[derive(Default)]
+struct RandomTable {
+    /// Run base seed (`Ir.seed`); handles derive their seed from it.
+    base_seed: u64,
+    /// Per-handle generator paired with the seed currently applied to it.
+    /// A non-cryptographic PCG generator is used (fast and reproducible; the
+    /// testbench does not need a crypto-strength RNG).
+    rngs: HashMap<StrId, (Pcg64, u64)>,
+}
+
+thread_local! {
+    static TABLE: RefCell<RandomTable> = RefCell::new(RandomTable::default());
+}
+
+/// Deterministic FNV-1a over the base seed and the handle name; matches the
+/// scheme used for per-instance component seeds.
+fn derive_seed(base: u64, key: StrId) -> u64 {
+    let name = resource_table::get_str_value(key).unwrap_or_default();
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut eat = |bytes: &[u8]| {
+        for b in bytes {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    };
+    eat(&base.to_le_bytes());
+    eat(name.as_bytes());
+    h
+}
+
+/// Clear all generators and record the run base seed. Call before a test.
+pub fn reset(base_seed: u64) {
+    TABLE.with(|t| {
+        let mut t = t.borrow_mut();
+        t.base_seed = base_seed;
+        t.rngs.clear();
+    });
+}
+
+fn with_rng<R>(key: StrId, f: impl FnOnce(&mut Pcg64) -> R) -> R {
+    TABLE.with(|t| {
+        let mut t = t.borrow_mut();
+        let base = t.base_seed;
+        let (rng, _) = t.rngs.entry(key).or_insert_with(|| {
+            let seed = derive_seed(base, key);
+            (Pcg64::seed_from_u64(seed), seed)
+        });
+        f(rng)
+    })
+}
+
+/// Set handle `key`'s seed explicitly and reset its stream.
+pub fn seed_handle(key: StrId, seed: u64) {
+    TABLE.with(|t| {
+        t.borrow_mut()
+            .rngs
+            .insert(key, (Pcg64::seed_from_u64(seed), seed));
+    });
+}
+
+/// Read back the seed currently applied to handle `key` (lazily seeding it
+/// from the base seed if it has not been used yet).
+pub fn get_seed_handle(key: StrId) -> u64 {
+    TABLE.with(|t| {
+        let mut t = t.borrow_mut();
+        let base = t.base_seed;
+        t.rngs
+            .entry(key)
+            .or_insert_with(|| {
+                let seed = derive_seed(base, key);
+                (Pcg64::seed_from_u64(seed), seed)
+            })
+            .1
+    })
+}
+
+fn mask(width: u32) -> u64 {
+    if width >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    }
+}
+
+/// Generate a uniform value across the full `width`-bit range of the element
+/// type (`width <= 64`). The low `width` bits are sampled uniformly; for a
+/// signed type this is the full set of two's-complement bit patterns.
+pub fn get(key: StrId, width: u32, signed: bool) -> Value {
+    let raw = with_rng(key, |rng| rng.random_range(0..=mask(width)));
+    Value::new(raw, width as usize, signed)
+}
+
+/// Generate a value in the inclusive range `[min, max]`. `min`/`max` are the
+/// raw `width`-bit payloads; for a signed type they are interpreted as
+/// two's-complement before sampling. Uses `rand`'s uniform range sampler.
+pub fn get_range(key: StrId, min: u64, max: u64, width: u32, signed: bool) -> Value {
+    let m = mask(width);
+    let raw = if signed {
+        let a = sign_extend(min & m, width);
+        let b = sign_extend(max & m, width);
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let sample: i64 = with_rng(key, |rng| rng.random_range(lo..=hi));
+        (sample as u64) & m
+    } else {
+        let a = min & m;
+        let b = max & m;
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        with_rng(key, |rng| rng.random_range(lo..=hi))
+    };
+    Value::new(raw, width as usize, signed)
+}
+
+/// Interpret the low `width` bits of `raw` as a two's-complement integer.
+fn sign_extend(raw: u64, width: u32) -> i64 {
+    if width == 0 || width >= 64 {
+        return raw as i64;
+    }
+    let shift = 64 - width;
+    ((raw << shift) as i64) >> shift
+}

--- a/crates/simulator/src/testbench.rs
+++ b/crates/simulator/src/testbench.rs
@@ -63,6 +63,29 @@ pub enum TestbenchStatement {
         /// Assignment form: destination variable for the return value.
         ret: Option<(VarId, crate::ir::RetWidthCheck)>,
     },
+    /// `r.seed(v)` — `handle` is the `$tb::random` variable's name (RNG key).
+    RandomSeed { handle: StrId, value: Expression },
+    /// `x = r.get()`.
+    RandomGet {
+        handle: StrId,
+        width: u32,
+        signed: bool,
+        ret: Option<(VarId, crate::ir::RetWidthCheck)>,
+    },
+    /// `x = r.get_range(min, max)`.
+    RandomGetRange {
+        handle: StrId,
+        min: Expression,
+        max: Expression,
+        width: u32,
+        signed: bool,
+        ret: Option<(VarId, crate::ir::RetWidthCheck)>,
+    },
+    /// `x = r.get_seed()`.
+    RandomGetSeed {
+        handle: StrId,
+        ret: Option<(VarId, crate::ir::RetWidthCheck)>,
+    },
     /// if-else (may contain next inside)
     If {
         condition: Expression,
@@ -153,13 +176,17 @@ fn collect_tb_insts(
                         reset_insts.push(*inst);
                     }
                 }
-                // File handles and component methods drive no clock/reset
-                // event.
+                // File handles, component methods and random generators
+                // drive no clock/reset event.
                 TbMethodKind::FileOpen { .. }
                 | TbMethodKind::FileWrite { .. }
                 | TbMethodKind::FileClose
                 | TbMethodKind::FileFlush
-                | TbMethodKind::Component { .. } => {}
+                | TbMethodKind::Component { .. }
+                | TbMethodKind::RandomSeed { .. }
+                | TbMethodKind::RandomGet { .. }
+                | TbMethodKind::RandomGetRange { .. }
+                | TbMethodKind::RandomGetSeed { .. } => {}
             },
             Statement::For(for_stmt) => {
                 collect_tb_insts(&for_stmt.body, clock_insts, reset_insts);
@@ -334,6 +361,34 @@ fn convert_stmt(
                 args: args.clone(),
                 ret: *ret,
             },
+            TbMethodKind::RandomSeed { value } => TestbenchStatement::RandomSeed {
+                handle: *inst,
+                value: value.clone(),
+            },
+            TbMethodKind::RandomGet { width, signed, ret } => TestbenchStatement::RandomGet {
+                handle: *inst,
+                width: *width,
+                signed: *signed,
+                ret: *ret,
+            },
+            TbMethodKind::RandomGetRange {
+                min,
+                max,
+                width,
+                signed,
+                ret,
+            } => TestbenchStatement::RandomGetRange {
+                handle: *inst,
+                min: min.clone(),
+                max: max.clone(),
+                width: *width,
+                signed: *signed,
+                ret: *ret,
+            },
+            TbMethodKind::RandomGetSeed { ret } => TestbenchStatement::RandomGetSeed {
+                handle: *inst,
+                ret: *ret,
+            },
         },
         Statement::SystemFunctionCall(SystemFunctionCall::Assert {
             kind,
@@ -430,6 +485,7 @@ fn convert_stmts(
 pub fn run_testbench(sim: &mut Simulator, stmts: &[TestbenchStatement]) -> TestResult {
     assert_buffer::reset();
     crate::file_table::reset();
+    crate::random_table::reset(sim.ir.seed);
     let result: TestResult = exec(sim, stmts).into();
     // End-of-test component hooks may still record failures.
     sim.finish_components();
@@ -857,6 +913,48 @@ fn exec_one(sim: &mut Simulator, stmt: &TestbenchStatement) -> ExecResult {
                 }
                 Err(msg) => ExecResult::Fail(msg),
             }
+        }
+        TestbenchStatement::RandomSeed { handle, value } => {
+            sim.ensure_comb_updated();
+            let seed = value.eval(&mut sim.mask_cache).payload_u64();
+            crate::random_table::seed_handle(*handle, seed);
+            ExecResult::Continue
+        }
+        TestbenchStatement::RandomGet {
+            handle,
+            width,
+            signed,
+            ret,
+        } => {
+            let value = crate::random_table::get(*handle, *width, *signed);
+            if let Some((ret, _)) = ret {
+                sim.set_var_by_id(ret, value);
+            }
+            ExecResult::Continue
+        }
+        TestbenchStatement::RandomGetRange {
+            handle,
+            min,
+            max,
+            width,
+            signed,
+            ret,
+        } => {
+            sim.ensure_comb_updated();
+            let min_v = min.eval(&mut sim.mask_cache).payload_u64();
+            let max_v = max.eval(&mut sim.mask_cache).payload_u64();
+            let value = crate::random_table::get_range(*handle, min_v, max_v, *width, *signed);
+            if let Some((ret, _)) = ret {
+                sim.set_var_by_id(ret, value);
+            }
+            ExecResult::Continue
+        }
+        TestbenchStatement::RandomGetSeed { handle, ret } => {
+            let seed = crate::random_table::get_seed_handle(*handle);
+            if let Some((ret, _)) = ret {
+                sim.set_var_by_id(ret, Value::new(seed, 64, false));
+            }
+            ExecResult::Continue
         }
         TestbenchStatement::Finish => ExecResult::Finished,
     }

--- a/crates/simulator/src/tests/testbench.rs
+++ b/crates/simulator/src/tests/testbench.rs
@@ -2343,6 +2343,130 @@ fn tb_file_native() {
     let _ = std::fs::remove_file(&out_path);
 }
 
+fn run_random_tb(code: &str, top: &str) {
+    let config = Config::default();
+    let ir = analyze_top(code, &config, top).expect("analyze");
+    let mut sim = Simulator::new(ir, None);
+    let event_map = build_event_map(&sim.ir.event_statements, &sim.ir.module_variables);
+    let clock_periods = build_clock_periods(&sim.ir.event_statements);
+    let stmts = sim
+        .ir
+        .event_statements
+        .get(&Event::Initial)
+        .cloned()
+        .expect("initial block");
+    let tb_stmts = convert_initial_to_testbench(&stmts, &event_map, &clock_periods, 3);
+    let result = run_testbench(&mut sim, &tb_stmts);
+    assert_eq!(result, TestResult::Pass);
+}
+
+#[test]
+fn tb_random_bit_alias() {
+    // A `bit<N>` element type reached via a `gen` type binding (N <= 64) is
+    // accepted and generates N-bit values.
+    let dir = std::env::temp_dir();
+    let out_path = dir.join("veryl_test_tb_random_bit_alias.txt");
+    let out_str = out_path.to_str().unwrap().replace('\\', "\\\\");
+
+    let code = format!(
+        r#"
+    #[test(test_random_alias)]
+    module test_random_alias {{
+        gen my_t: type = bit<7>;
+        var r: $tb::random::<my_t>;
+        var f: $tb::file;
+        var x: my_t;
+        initial {{
+            r.seed(9);
+            f.open("{0}");
+            x = r.get();
+            f.write("%d\n", x);
+            x = r.get();
+            f.write("%d\n", x);
+            x = r.get();
+            f.write("%d\n", x);
+            x = r.get_range(0, 100);
+            f.write("%d\n", x);
+            f.close();
+            $finish();
+        }}
+    }}
+    "#,
+        out_str
+    );
+
+    let _ = std::fs::remove_file(&out_path);
+    run_random_tb(&code, "test_random_alias");
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    assert!(content.lines().next().is_some());
+    for line in content.lines() {
+        let v: u32 = line.trim().parse().unwrap();
+        assert!(v <= 127, "bit<7> random out of range: {v}");
+    }
+    let _ = std::fs::remove_file(&out_path);
+}
+
+#[test]
+fn tb_random_native() {
+    // Full native path for `$tb::random`: an explicit seed makes the sequence
+    // reproducible, `generate_range(n, n)` is exactly `n`, and a bounded range
+    // stays within bounds.
+    let dir = std::env::temp_dir();
+    let out_path = dir.join("veryl_test_tb_random_native.txt");
+    let out_str = out_path.to_str().unwrap().replace('\\', "\\\\");
+
+    let code = format!(
+        r#"
+    #[test(test_random_native)]
+    module test_random_native {{
+        var r: $tb::random::<u8>;
+        var f: $tb::file;
+        var x: u8;
+        initial {{
+            r.seed(1234);
+            f.open("{0}");
+            x = r.get_range(100, 100);
+            f.write("%d\n", x);
+            x = r.get_range(0, 7);
+            f.write("%d\n", x);
+            x = r.get();
+            f.write("%d\n", x);
+            x = r.get();
+            f.write("%d\n", x);
+            f.close();
+            $finish();
+        }}
+    }}
+    "#,
+        out_str
+    );
+
+    let read = || {
+        let _ = std::fs::remove_file(&out_path);
+        run_random_tb(&code, "test_random_native");
+        std::fs::read_to_string(&out_path).unwrap()
+    };
+
+    let content1 = read();
+    let content2 = read();
+    // Explicit seed => reproducible sequence.
+    assert_eq!(content1, content2, "same seed must reproduce the sequence");
+
+    let lines: Vec<&str> = content1.lines().collect();
+    assert_eq!(lines.len(), 4);
+    // generate_range(100, 100) is exactly 100.
+    assert_eq!(lines[0], "100");
+    // generate_range(0, 7) stays within [0, 7].
+    let v: u32 = lines[1].trim().parse().unwrap();
+    assert!(v <= 7, "generate_range(0, 7) out of bounds: {v}");
+    // generate() over u8 stays within [0, 255].
+    for line in &lines[2..] {
+        let v: u32 = line.trim().parse().unwrap();
+        assert!(v <= 255);
+    }
+    let _ = std::fs::remove_file(&out_path);
+}
+
 #[test]
 fn tb_file_write_without_open_is_dropped() {
     // write/flush/close on a handle that was never opened are silent no-ops


### PR DESCRIPTION
Adds `$tb::random`, which lets test scenarios generate random numbers in native tests (`veryl test`). Like `$tb::file`, it is an object-style component; the type of the generated value is given as a generic argument.

## Usage

Declare it as a `var` inside a `#[test]` module, giving the element type as a generic argument.

```systemverilog
#[test(test_rand)]
module test_rand {
    var r: $tb::random::<u32>;
    var x: u32;

    initial {
        r.seed(42);                 // set the seed
        x = r.get();                // uniform random over the full u32 range
        x = r.get_range(10, 20);    // 10 <= x <= 20 (like $urandom_range)
        let s: u64 = r.get_seed();  // read back the current seed
        $finish();
    }
}
```

### Methods

| Method | Description |
|---|---|
| `seed(value)` | Set the seed. |
| `get()` | Generate a uniform random value over the full range of the element type `T` (return type = `T`). |
| `get_range(min, max)` | Generate a uniform random value in `min <= x <= max` (inclusive; like `$urandom_range`). |
| `get_seed()` | Read back the current seed (64-bit). |

`get()` / `get_range()` / `get_seed()` return a value, so they can be used in assignment, expression, and typed-`let` positions.

```systemverilog
let y: u32 = r.get() + 1;   // the return type T is resolved inside expressions too
```

### Allowed types

- `u8`–`u64` / `i8`–`i64` (signed types produce signed values), and `bbool`.
- Width must be **at most 64 bits**. `bit<N>` (N ≤ 64) is also usable via a `gen` type binding or a package type:

```systemverilog
gen my_t: type = bit<12>;
var r: $tb::random::<my_t>;   // 12-bit random
```

- Non-integer (`f32`/`f64`), 4-state (`lbool`/`logic`), and widths over 64 bits are compile errors.

## Reproducibility

Giving a seed via `--seed` or `[test].seed` in `Veryl.toml` makes the generated sequence reproducible **within the same Veryl binary**.

- Without an explicit seed, each run is random (the seed used is logged, so a run can be reproduced with `--seed`).
- Calling `r.seed(v)` pins a specific object's sequence.
- Even without an explicit seed, each object is initialized with a seed derived deterministically from the test name and the object name, so the same `--seed` yields the same sequence every run (the same scheme already used for component randomness).

> Note: long-term reproducibility across `rand` versions is out of scope (only `--seed` reproducibility within the same binary is guaranteed).

## Implementation notes

- The PRNG uses the `rand` crate (`StdRng` + `random_range`). It is added with `default-features = false` so the wasm build (playground) is not broken.
- Like `$tb::file`, it can only be used inside a `#[test]` module and is never emitted to SystemVerilog.
- The element type `T` is modeled as a generic parameter of `$tb::random`, so `get()`'s return type `T` is resolved statically through the existing generic-resolution machinery.
- As a side fix, this also fixes an `eval_type` gap where the width was lost when a `gen` type binding (`gen w: type = bit<N>`) was passed as a generic argument (`VariableType` was not handled).

## Tests

- analyzer: valid usage (multiple element types, all methods, return-type resolution); rejection of invalid element types.
- simulator: runtime determinism and range; generation for `bit<N>` reached via `gen`.
