### PR TITLE
Apply select to a value resolved through the symbol route

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -183,7 +183,7 @@ pub fn eval_expr(
     if let Ok(mut expr) = expr {
         check_anonymous(context, &expr, allow_anonymous, token);
 
-        let comptime = if let Some(dst_type) = dst_type {
+        let mut comptime = if let Some(dst_type) = dst_type {
             let mut comptime = expr.eval_comptime(context, dst_type.total_width()).clone();
 
             check_compatibility(context, &dst_type, &comptime, &token);
@@ -193,6 +193,15 @@ pub fn eval_expr(
         } else {
             expr.eval_comptime(context, None).clone()
         };
+
+        // `eval_comptime` doesn't evaluate an array literal, so evaluate it here
+        // to carry the element values.
+        if matches!(expr, ir::Expression::ArrayLiteral(..))
+            && !comptime.r#type.array.is_empty()
+            && let Some(values) = eval_array_literal_values(context, &comptime.r#type, &mut expr)?
+        {
+            comptime.value = ValueVariant::NumericArray(values);
+        }
 
         Ok((comptime, expr))
     } else {
@@ -2234,9 +2243,15 @@ fn eval_factor_path_inner(
             let index = array_select.to_index();
             comptime.r#type.array.drain(0..index.dimension());
 
-            // A const symbol read through a dynamic index/select is not itself
-            // a compile-time constant (e.g. `A[idx]` for a const array `A`).
             comptime.is_const &= index.is_const() && width_select.is_const();
+
+            // The whole-array value doesn't describe a selected part of it; drop
+            // it so consumers resolve the selection from the variable table.
+            if (index.dimension() > 0 || !width_select.is_empty())
+                && matches!(comptime.value, ValueVariant::NumericArray(_))
+            {
+                comptime.value = ValueVariant::Unknown;
+            }
 
             comptime.token = token;
             if comptime.r#type.is_type() {
@@ -2336,14 +2351,14 @@ fn eval_factor_path_inner(
             .current_namespace()
             .map(|x| symbol.found.namespace.included(&x))
             .unwrap_or(false);
-        if is_inernal {
+        let factor = if is_inernal {
             eval_factor_symbol(
                 context,
                 generic_path,
                 (*symbol).clone(),
                 allow_unknown_value,
                 token,
-            )
+            )?
         } else {
             let maps = generic_path.to_generic_maps();
             eval_factor_symbol_external(
@@ -2353,10 +2368,90 @@ fn eval_factor_path_inner(
                 maps,
                 allow_unknown_value,
                 token,
-            )
-        }
+            )?
+        };
+
+        apply_symbol_select(context, factor, select, token)
     } else {
         Err(ir_error!(token))
+    }
+}
+
+/// Apply a `select` that the symbol route (`eval_factor_symbol[_external]`)
+/// dropped: none → the value as-is; constant → the selected value; dynamic →
+/// `Factor::SelectedValue`.
+fn apply_symbol_select(
+    context: &mut Context,
+    factor: ir::Factor,
+    select: VarSelect,
+    token: TokenRange,
+) -> IrResult<ir::Factor> {
+    if select.is_empty() {
+        return Ok(factor);
+    }
+    let ir::Factor::Value(mut comptime) = factor else {
+        return Ok(factor);
+    };
+    let values = match &comptime.value {
+        ValueVariant::NumericArray(values) => values.clone(),
+        ValueVariant::Numeric(value) => vec![value.clone()],
+        _ => return Ok(ir::Factor::Value(comptime)),
+    };
+
+    let array = comptime.r#type.array.clone();
+    let (array_select, width_select) = select.split(array.dims());
+    // Array select type check (out-of-range / wrong-order).
+    let _ = array_select.eval_comptime(context, &comptime.r#type, true);
+    if array_select.is_range() {
+        // TODO: array range select.
+        return Err(ir_error!(token));
+    }
+    let index = array_select.to_index();
+
+    comptime.r#type.array.drain(0..index.dimension());
+    if !width_select.is_empty() {
+        comptime.r#type.flatten_struct_union_enum();
+        if let Some(width) = width_select.eval_comptime(context, &comptime.r#type, false) {
+            comptime.r#type.set_concrete_width(width);
+        }
+    }
+    let is_const_select = index.is_const() && width_select.is_const();
+    comptime.is_const &= is_const_select;
+    comptime.is_global = comptime.is_const;
+    comptime.token = token;
+
+    // A partial array index selects a sub-array, which can't fold to a single
+    // value: carry the elements so a const assignment materializes them.
+    if !comptime.r#type.array.is_empty() {
+        if !is_const_select || !width_select.is_empty() {
+            // TODO: dynamic sub-array select.
+            return Err(ir_error!(token));
+        }
+        let indices = index.eval_value(context).ok_or_else(|| ir_error!(token))?;
+        let (beg, end) = array.calc_range(&indices).ok_or_else(|| ir_error!(token))?;
+        let values = values.get(beg..=end).ok_or_else(|| ir_error!(token))?;
+        comptime.value = ValueVariant::NumericArray(values.to_vec());
+        return Ok(ir::Factor::Value(comptime));
+    }
+    // The per-element values travel in `SelectedValue.values` instead.
+    comptime.value = ValueVariant::Unknown;
+
+    let factor = ir::Factor::SelectedValue(Box::new(ir::SelectedValue {
+        values,
+        array,
+        index,
+        select: width_select,
+        comptime,
+    }));
+
+    // `eval_value` is not a constness test — it evaluates a non-const index as
+    // 0 — so gate the fold on the select being constant.
+    if is_const_select && let Some(element) = factor.eval_value(context) {
+        let mut comptime = factor.comptime().clone();
+        comptime.value = ValueVariant::Numeric(element);
+        Ok(ir::Factor::Value(comptime))
+    } else {
+        Ok(factor)
     }
 }
 

--- a/crates/analyzer/src/ir.rs
+++ b/crates/analyzer/src/ir.rs
@@ -27,7 +27,7 @@ pub use declaration::{
     ExternalParamValue, FfClock, FfDeclaration, FfReset, FinalDeclaration, InitialDeclaration,
     InstDeclaration, InstInput, InstOutput, qualified_prefix_len,
 };
-pub use expression::{ArrayLiteralItem, Expression, Factor, HierVarRef};
+pub use expression::{ArrayLiteralItem, Expression, Factor, HierVarRef, SelectedValue};
 pub use ff_table::FfTable;
 pub use function::{Arguments, FuncArg, FuncPath, FuncProto, Function, FunctionBody, FunctionCall};
 pub use interface::Interface;

--- a/crates/analyzer/src/ir/expression.rs
+++ b/crates/analyzer/src/ir/expression.rs
@@ -5,7 +5,7 @@ use crate::ir::assign_table::{AssignContext, AssignTable};
 use crate::ir::ff_table::AssignTarget;
 use crate::ir::utils::convert_cast;
 use crate::ir::{
-    Comptime, ExpressionContext, FfTable, FunctionCall, Op, Signature, SystemFunctionCall,
+    Comptime, ExpressionContext, FfTable, FunctionCall, Op, Shape, Signature, SystemFunctionCall,
     SystemFunctionKind, Type, TypeKind, ValueVariant, VarId, VarIndex, VarPath, VarSelect,
 };
 use crate::symbol::{ClockDomain, Symbol, SymbolKind};
@@ -712,6 +712,8 @@ pub enum Factor {
     /// (e.g. `dut.u_core.pc` in a testbench initial block). Resolved to a
     /// concrete buffer offset by the simulator after elaboration.
     HierVariable(Box<HierVarRef>),
+    /// A const value with a dynamic selection applied.
+    SelectedValue(Box<SelectedValue>),
     Value(Comptime),
     SystemFunctionCall(SystemFunctionCall),
     FunctionCall(FunctionCall),
@@ -725,6 +727,15 @@ pub struct HierVarRef {
     pub inst_path: Vec<StrId>,
     /// Variable path within the target module.
     pub var_path: VarPath,
+    pub index: VarIndex,
+    pub select: VarSelect,
+    pub comptime: Comptime,
+}
+
+#[derive(Clone, Debug)]
+pub struct SelectedValue {
+    pub values: Vec<Value>,
+    pub array: Shape,
     pub index: VarIndex,
     pub select: VarSelect,
     pub comptime: Comptime,
@@ -759,6 +770,7 @@ impl Factor {
         match self {
             // SystemVerilog member is interpreted as Factor::Value, but it may be assignable.
             Factor::Value(x) => x.r#type.is_systemverilog(),
+            Factor::SelectedValue(x) => x.comptime.r#type.is_systemverilog(),
             Factor::FunctionCall(_) | Factor::SystemFunctionCall(_) => false,
             _ => true,
         }
@@ -819,6 +831,32 @@ impl Factor {
                 is_const: x.is_const,
                 is_global: x.is_global,
             },
+            // The dynamic index/select is a data-dependent read (mirrors Variable).
+            Factor::SelectedValue(x) => {
+                let SelectedValue {
+                    index,
+                    select,
+                    comptime,
+                    ..
+                } = x.as_mut();
+                if !comptime.evaluated {
+                    let select_exprs = select
+                        .0
+                        .iter_mut()
+                        .chain(select.1.as_mut().map(|(_, expr)| expr));
+                    for expr in index.0.iter_mut().chain(select_exprs) {
+                        let c = expr.eval_comptime(context, None);
+                        check_clock_domain(context, comptime, c, &comptime.token.beg);
+                        comptime.clock_domain = comptime.clock_domain.merge(&c.clock_domain);
+                    }
+                }
+                ExpressionContext {
+                    width: comptime.r#type.total_width().unwrap_or(0),
+                    signed: comptime.r#type.signed,
+                    is_const: comptime.is_const,
+                    is_global: comptime.is_global,
+                }
+            }
             Factor::FunctionCall(x) => {
                 x.eval_type(context);
                 ExpressionContext {
@@ -851,6 +889,10 @@ impl Factor {
             Factor::Value(x) => {
                 x.expr_context = expr_context;
                 x.evaluated = true;
+            }
+            Factor::SelectedValue(x) => {
+                x.comptime.expr_context = expr_context;
+                x.comptime.evaluated = true;
             }
             Factor::SystemFunctionCall(x) => {
                 // Preserve the signed flag set by $signed / $unsigned:
@@ -945,6 +987,13 @@ impl Factor {
             }
             Factor::HierVariable(_) => None,
             Factor::Value(x) => x.get_value().ok().cloned(),
+            Factor::SelectedValue(x) => {
+                let index = x.index.eval_value(context)?;
+                let flat = x.array.calc_index(&index)?;
+                let value = x.values.get(flat)?.clone();
+                let (beg, end) = x.select.eval_value(context, &x.comptime.r#type, false)?;
+                Some(value.select(beg, end))
+            }
             Factor::SystemFunctionCall(x) => x.eval_value(context),
             Factor::FunctionCall(x) => x.eval_value(context),
             Factor::Anonymous(_) => None,
@@ -1057,6 +1106,7 @@ impl Factor {
         match self {
             Factor::Variable(_, _, _, x) => x,
             Factor::HierVariable(x) => &x.comptime,
+            Factor::SelectedValue(x) => &x.comptime,
             Factor::Value(x) => x,
             Factor::SystemFunctionCall(x) => &x.comptime,
             Factor::FunctionCall(x) => &x.comptime,
@@ -1069,6 +1119,7 @@ impl Factor {
         match self {
             Factor::Variable(_, _, _, x) => x,
             Factor::HierVariable(x) => &mut x.comptime,
+            Factor::SelectedValue(x) => &mut x.comptime,
             Factor::Value(x) => x,
             Factor::SystemFunctionCall(x) => &mut x.comptime,
             Factor::FunctionCall(x) => &mut x.comptime,
@@ -1081,6 +1132,7 @@ impl Factor {
         match self {
             Factor::Variable(_, _, _, x) => x.token,
             Factor::HierVariable(x) => x.comptime.token,
+            Factor::SelectedValue(x) => x.comptime.token,
             Factor::Value(x) => x.token,
             Factor::SystemFunctionCall(x) => x.comptime.token,
             Factor::FunctionCall(x) => x.comptime.token,
@@ -1102,6 +1154,9 @@ impl fmt::Display for Factor {
                     s.push_str(&format!("{seg}."));
                 }
                 format!("{s}{}{}{}", x.var_path, x.index, x.select)
+            }
+            Factor::SelectedValue(x) => {
+                format!("<const>{}{}", x.index, x.select)
             }
             Factor::Value(x) => {
                 if let Ok(x) = x.get_value() {

--- a/crates/analyzer/src/ir/tests.rs
+++ b/crates/analyzer/src/ir/tests.rs
@@ -1316,9 +1316,9 @@ fn array_literal() {
   var var1[4](b): logic = 1'hx;
   var var1[5](b): logic = 1'hx;
   var var2(c): logic<2, 3, 4> = 24'hxxxxxx;
-  const var3[0](X): bit<32> = 32'sh0000000a;
-  const var3[1](X): bit<32> = 32'sh0000000b;
-  const var3[2](X): bit<32> = 32'sh0000000c;
+  const var3[0](X): bit<32> = 32'h0000000a;
+  const var3[1](X): bit<32> = 32'h0000000b;
+  const var3[2](X): bit<32> = 32'h0000000c;
   const var4(Y): bit<3, 4> = 12'habc;
 
   comb {
@@ -3113,4 +3113,35 @@ fn defines_select_ifdef_branch() {
         !ir.contains("00000002"),
         "did not expect ifndef(DEBUG) branch (=2) in IR:\n{ir}"
     );
+}
+
+#[test]
+fn package_const_select() {
+    // A const declared in another package, selected at the reference site: an
+    // element for a full index, a sub-array for a partial one.
+    let code = r#"
+    package a_pkg {
+        const A: bit<16>    = 16'habcd;
+        const B: u32[2]     = '{0, 1};
+        const C: u32 [2, 2] = '{'{1, 2}, '{3, 4}};
+    }
+    module b_module {
+        const A: bit<8>  = a_pkg::A[0+:8];
+        const B: u32     = a_pkg::B[1];
+        const C: u32 [2] = a_pkg::C[0];
+        const D: u32     = a_pkg::C[1][1];
+    }
+    "#;
+
+    let exp = r#"module b_module {
+  const var0(A): bit<8> = 8'hcd;
+  const var1(B): bit<32> = 32'h00000001;
+  const var2[0](C): bit<32> = 32'h00000001;
+  const var2[1](C): bit<32> = 32'h00000002;
+  const var3(D): bit<32> = 32'h00000004;
+
+}
+"#;
+
+    check_ir(code, exp);
 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10560,6 +10560,18 @@ fn invalid_operand() {
 
     let errors = analyze(code);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package PkgA {
+        const ARRAY: bit<8> [4] = '{8'h11, 8'h22, 8'h33, 8'h44};
+    }
+    module ModuleA {
+        let _a: bit<8> = PkgA::ARRAY[0];
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]

--- a/crates/simulator/src/backend/aot_c/emit.rs
+++ b/crates/simulator/src/backend/aot_c/emit.rs
@@ -423,6 +423,16 @@ impl LocalAnalysis {
                     self.walk_reads(&ds.index_expr, i);
                 }
             }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                self.walk_reads(index_expr, i);
+                if let Some(ds) = dynamic_select {
+                    self.walk_reads(&ds.index_expr, i);
+                }
+            }
         }
     }
 
@@ -534,6 +544,9 @@ impl LocalAnalysis {
                 if let VarOffset::Comb(o) = base_offset {
                     self.bad.insert(*o);
                 }
+                self.poison_expr(index_expr);
+            }
+            ProtoExpression::DynamicValue { index_expr, .. } => {
                 self.poison_expr(index_expr);
             }
         }
@@ -763,6 +776,7 @@ fn emit_wide_const(
 fn emit_wide_expr(expr: &ProtoExpression, pre: &mut String) -> Option<WideRef> {
     match expr {
         ProtoExpression::HierVariable(_) => None,
+        ProtoExpression::DynamicValue { .. } => None,
         ProtoExpression::Value {
             value,
             width,
@@ -1825,6 +1839,16 @@ fn classify_uncovered_expr(e: &ProtoExpression) -> String {
                 classify_uncovered_expr(index_expr),
             )
         }
+        ProtoExpression::DynamicValue {
+            width,
+            values,
+            dynamic_select,
+            ..
+        } => format!(
+            "DynValue(w={width},ne={},ds={})",
+            values.len(),
+            dynamic_select.is_some(),
+        ),
     }
 }
 
@@ -3756,6 +3780,7 @@ pub fn emit_expr_root(expr: &ProtoExpression) -> Option<String> {
 fn emit_expr_inner(expr: &ProtoExpression, needs_clean: bool) -> Option<String> {
     match expr {
         ProtoExpression::HierVariable(_) => None,
+        ProtoExpression::DynamicValue { .. } => None,
         ProtoExpression::Value {
             value,
             width,

--- a/crates/simulator/src/backend/cranelift/expression.rs
+++ b/crates/simulator/src/backend/cranelift/expression.rs
@@ -240,6 +240,7 @@ impl ProtoExpression {
                 };
                 dyn_ok && index_expr.can_build_binary()
             }
+            ProtoExpression::DynamicValue { .. } => false,
         }
     }
     pub fn build_binary(
@@ -270,6 +271,7 @@ impl ProtoExpression {
     ) -> Option<(CraneliftValue, Option<CraneliftValue>)> {
         match self {
             ProtoExpression::HierVariable(_) => None,
+            ProtoExpression::DynamicValue { .. } => None,
             ProtoExpression::Variable {
                 var_offset,
                 dynamic_select,

--- a/crates/simulator/src/ir/expression.rs
+++ b/crates/simulator/src/ir/expression.rs
@@ -77,6 +77,14 @@ pub enum Expression {
         width: usize,
         signed: bool,
     },
+    DynamicValue {
+        values: Vec<Value>,
+        index_expr: Box<Expression>,
+        select: Option<(usize, usize)>,
+        dynamic_select: Option<DynamicBitSelect>,
+        width: usize,
+        signed: bool,
+    },
 }
 
 // SAFETY: Same as Statement — see statement.rs.
@@ -229,6 +237,39 @@ impl Expression {
                     value
                 }
             }
+            Expression::DynamicValue {
+                values,
+                index_expr,
+                select,
+                dynamic_select,
+                width,
+                signed,
+            } => {
+                if values.is_empty() {
+                    return Value::new(0, *width, *signed);
+                }
+                let index = index_expr
+                    .eval(mask_cache)
+                    .to_usize()
+                    .unwrap_or(0)
+                    .min(values.len().saturating_sub(1));
+                let value = values[index].clone();
+                if let Some(dyn_sel) = dynamic_select {
+                    let sel_index = dyn_sel
+                        .index_expr
+                        .eval(mask_cache)
+                        .to_usize()
+                        .unwrap_or(0)
+                        .min(dyn_sel.num_elements.saturating_sub(1));
+                    let end = sel_index * dyn_sel.elem_width;
+                    let beg = end + dyn_sel.window - 1;
+                    value.select(beg, end)
+                } else if let Some((beg, end)) = select {
+                    value.select(*beg, *end)
+                } else {
+                    value
+                }
+            }
         }
     }
 
@@ -289,6 +330,16 @@ impl Expression {
                 for i in 0..*num_elements {
                     let ptr = unsafe { (*base_ptr).offset(*stride * i as isize) };
                     inputs.push(ptr);
+                }
+            }
+            Expression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.gather_variable(inputs, outputs);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.gather_variable(inputs, outputs);
                 }
             }
         }
@@ -358,6 +409,16 @@ impl ProtoExpression {
                     inputs.push(last_offset);
                 }
             }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.gather_variable_offsets(inputs);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.gather_variable_offsets(inputs);
+                }
+            }
         }
     }
 
@@ -425,6 +486,16 @@ impl ProtoExpression {
                     out.push((last_offset, None));
                 }
             }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.gather_reads_with_ranges(out);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.gather_reads_with_ranges(out);
+                }
+            }
         }
     }
 
@@ -489,6 +560,16 @@ impl ProtoExpression {
                     inputs.push(off);
                 }
             }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.gather_variable_offsets_expanded(inputs);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.gather_variable_offsets_expanded(inputs);
+                }
+            }
         }
     }
 
@@ -548,6 +629,16 @@ impl ProtoExpression {
                     *stride,
                     *num_elements,
                 ));
+            }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.gather_dynamic_read_ranges(ranges);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.gather_dynamic_read_ranges(ranges);
+                }
             }
         }
     }
@@ -633,6 +724,14 @@ pub enum ProtoExpression {
         width: usize,
         expr_context: ExpressionContext,
     },
+    DynamicValue {
+        values: Vec<Value>,
+        index_expr: Box<ProtoExpression>,
+        select: Option<(usize, usize)>,
+        dynamic_select: Option<ProtoDynamicBitSelect>,
+        width: usize,
+        expr_context: ExpressionContext,
+    },
     /// Hierarchical testbench reference into a child module instance.
     /// Resolved to a plain `Variable` by `resolve_hier_refs` once the
     /// module's whole `ModuleVariableMeta` tree is assembled; no later
@@ -708,6 +807,16 @@ impl ProtoExpression {
                     dyn_sel.index_expr.adjust_offsets(ff_delta, comb_delta);
                 }
             }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.adjust_offsets(ff_delta, comb_delta);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.adjust_offsets(ff_delta, comb_delta);
+                }
+            }
             ProtoExpression::Unary { x, .. } => {
                 x.adjust_offsets(ff_delta, comb_delta);
             }
@@ -766,6 +875,16 @@ impl ProtoExpression {
                     dyn_sel.index_expr.remap_offsets(map);
                 }
             }
+            ProtoExpression::DynamicValue {
+                index_expr,
+                dynamic_select,
+                ..
+            } => {
+                index_expr.remap_offsets(map);
+                if let Some(dyn_sel) = dynamic_select {
+                    dyn_sel.index_expr.remap_offsets(map);
+                }
+            }
             ProtoExpression::Unary { x, .. } => x.remap_offsets(map),
             ProtoExpression::Binary { x, y, .. } => {
                 x.remap_offsets(map);
@@ -800,6 +919,7 @@ impl ProtoExpression {
             ProtoExpression::Concatenation { width, .. } => *width,
             ProtoExpression::Ternary { width, .. } => *width,
             ProtoExpression::DynamicVariable { width, .. } => *width,
+            ProtoExpression::DynamicValue { width, .. } => *width,
         }
     }
 
@@ -879,6 +999,7 @@ impl ProtoExpression {
                 ..
             } => true_expr.effective_bits().max(false_expr.effective_bits()),
             ProtoExpression::DynamicVariable { width, .. } => *width,
+            ProtoExpression::DynamicValue { width, .. } => *width,
         }
     }
 
@@ -892,6 +1013,7 @@ impl ProtoExpression {
             ProtoExpression::Concatenation { expr_context, .. } => expr_context,
             ProtoExpression::Ternary { expr_context, .. } => expr_context,
             ProtoExpression::DynamicVariable { expr_context, .. } => expr_context,
+            ProtoExpression::DynamicValue { expr_context, .. } => expr_context,
         }
     }
 
@@ -955,6 +1077,9 @@ impl ProtoExpression {
                 *element_native_bytes > 16
                     && !(select.is_some() && dynamic_select.is_none() && !is_wide_ptr(*width))
             }
+            // Always interpreter-handled (both backends bail on DynamicValue),
+            // so it never materializes as a wide pointer.
+            ProtoExpression::DynamicValue { .. } => false,
             // Reductions (IS_REDUCTION) collapse to a 1-bit register.
             // NOTE: use `expr_context.width` (the EVALUATION width that
             // `build_binary` keys its wide-vs-narrow dispatch on — Cranelift
@@ -1072,6 +1197,8 @@ impl ProtoExpression {
                 };
                 result_width <= target_width
             }
+            // Conservative: interpreter-evaluated and re-masked at store time.
+            ProtoExpression::DynamicValue { .. } => false,
             ProtoExpression::Unary { op, x, width, .. } => match op {
                 Op::BitAnd
                 | Op::BitNand
@@ -1405,6 +1532,42 @@ impl ProtoExpression {
                         stride: *stride,
                         index_expr: Box::new(index_expr),
                         num_elements: *num_elements,
+                        select: *select,
+                        dynamic_select,
+                        width: *width,
+                        signed: expr_context.signed,
+                    }
+                }
+                ProtoExpression::DynamicValue {
+                    values,
+                    index_expr,
+                    select,
+                    dynamic_select,
+                    width,
+                    expr_context,
+                } => {
+                    let index_expr = index_expr.apply_values_ptr(
+                        ff_values_ptr,
+                        ff_len,
+                        comb_values_ptr,
+                        comb_len,
+                        use_4state,
+                    );
+                    let dynamic_select = dynamic_select.as_ref().map(|dyn_sel| DynamicBitSelect {
+                        index_expr: Box::new(dyn_sel.index_expr.apply_values_ptr(
+                            ff_values_ptr,
+                            ff_len,
+                            comb_values_ptr,
+                            comb_len,
+                            use_4state,
+                        )),
+                        elem_width: dyn_sel.elem_width,
+                        window: dyn_sel.window,
+                        num_elements: dyn_sel.num_elements,
+                    });
+                    Expression::DynamicValue {
+                        values: values.clone(),
+                        index_expr: Box::new(index_expr),
                         select: *select,
                         dynamic_select,
                         width: *width,
@@ -1834,6 +1997,38 @@ impl Conv<&air::Expression> for ProtoExpression {
                         expr_context,
                     })
                 }
+                air::Factor::SelectedValue(x) => {
+                    let width =
+                        x.comptime.r#type.total_width().ok_or_else(|| {
+                            SimulatorError::unresolved_expression(&x.comptime.token)
+                        })?;
+                    let expr_context: ExpressionContext = (&x.comptime.expr_context).into();
+                    let values = x.values.clone();
+
+                    let index_expr = build_linear_index_expr(context, &x.array, &x.index)?;
+
+                    let dynamic_select = if x.select.is_empty() {
+                        None
+                    } else {
+                        let elem_bits = values.first().map(|v| v.width()).unwrap_or(width);
+                        let width_shape = [Some(elem_bits)];
+                        Some(build_dynamic_bit_select(
+                            context,
+                            air::ShapeRef::new(&width_shape),
+                            &x.select,
+                            1,
+                        )?)
+                    };
+
+                    Ok(ProtoExpression::DynamicValue {
+                        values,
+                        index_expr: Box::new(index_expr),
+                        select: None,
+                        dynamic_select,
+                        width,
+                        expr_context,
+                    })
+                }
                 air::Factor::FunctionCall(call) => {
                     let mut stmts: Vec<ProtoStatement> = Conv::conv(context, call)?;
 
@@ -1944,7 +2139,8 @@ impl Conv<&air::Expression> for ProtoExpression {
                             | ProtoExpression::Binary { expr_context, .. }
                             | ProtoExpression::Concatenation { expr_context, .. }
                             | ProtoExpression::Ternary { expr_context, .. }
-                            | ProtoExpression::DynamicVariable { expr_context, .. } => expr_context,
+                            | ProtoExpression::DynamicVariable { expr_context, .. }
+                            | ProtoExpression::DynamicValue { expr_context, .. } => expr_context,
                         };
                         ctx.signed = signed;
                         Ok(inner)

--- a/crates/simulator/src/ir/hier_ref.rs
+++ b/crates/simulator/src/ir/hier_ref.rs
@@ -287,6 +287,16 @@ pub(crate) fn resolve_expr(
                 resolve_expr(&mut dyn_sel.index_expr, context, children)?;
             }
         }
+        ProtoExpression::DynamicValue {
+            index_expr,
+            dynamic_select,
+            ..
+        } => {
+            resolve_expr(index_expr, context, children)?;
+            if let Some(dyn_sel) = dynamic_select {
+                resolve_expr(&mut dyn_sel.index_expr, context, children)?;
+            }
+        }
         ProtoExpression::Unary { x, .. } => {
             resolve_expr(x, context, children)?;
         }

--- a/crates/simulator/src/ir/opt/dead_var_dce.rs
+++ b/crates/simulator/src/ir/opt/dead_var_dce.rs
@@ -161,6 +161,16 @@ fn walk_expr_reads(expr: &ProtoExpression, c: &mut Census) {
                 walk_expr_reads(&dyn_sel.index_expr, c);
             }
         }
+        ProtoExpression::DynamicValue {
+            index_expr,
+            dynamic_select,
+            ..
+        } => {
+            walk_expr_reads(index_expr, c);
+            if let Some(dyn_sel) = dynamic_select {
+                walk_expr_reads(&dyn_sel.index_expr, c);
+            }
+        }
     }
 }
 

--- a/crates/simulator/src/ir/opt/load_cache_lookahead.rs
+++ b/crates/simulator/src/ir/opt/load_cache_lookahead.rs
@@ -147,6 +147,16 @@ fn walk_expr(expr: &ProtoExpression, idx: usize, reads: &mut FutureReads) {
                 walk_expr(&dyn_sel.index_expr, idx, reads);
             }
         }
+        ProtoExpression::DynamicValue {
+            index_expr,
+            dynamic_select,
+            ..
+        } => {
+            walk_expr(index_expr, idx, reads);
+            if let Some(dyn_sel) = dynamic_select {
+                walk_expr(&dyn_sel.index_expr, idx, reads);
+            }
+        }
         ProtoExpression::Unary { x, .. } => walk_expr(x, idx, reads),
         ProtoExpression::Binary { x, y, .. } => {
             walk_expr(x, idx, reads);

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -20050,3 +20050,66 @@ fn for_loop_break_honored() {
         );
     }
 }
+
+#[test]
+fn package_const_select() {
+    // A package const selected at the reference site, statically and at runtime.
+    let code = r#"
+    package a_pkg {
+        const A: bit<16>   = 16'habcd;
+        const B: bit<8>[4] = '{8'h11, 8'h22, 8'h33, 8'h44};
+    }
+    module Top (
+        i:   input  logic<1>,
+        j:   input  logic<2>,
+        o_a: output logic<8>,
+        o_b: output logic<8>,
+        o_c: output logic<8>,
+        o_d: output logic<8>,
+    ) {
+        assign o_a = a_pkg::A[0+:8];
+        assign o_b = a_pkg::B[2];
+        assign o_c = a_pkg::A[8 * i +: 8];
+        assign o_d = a_pkg::B[j];
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        for (i, j, exp_c, exp_d) in [
+            (0, 0, 0xcd, 0x11),
+            (1, 1, 0xab, 0x22),
+            (0, 2, 0xcd, 0x33),
+            (1, 3, 0xab, 0x44),
+        ] {
+            let ir = analyze(code, &config);
+            let mut sim = Simulator::new(ir, None);
+
+            sim.set("i", Value::new(i, 1, false));
+            sim.set("j", Value::new(j, 2, false));
+            sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+            assert_eq!(
+                sim.get("o_a").unwrap(),
+                Value::new(0xcd, 8, false),
+                "const part-select config={config:?}"
+            );
+            assert_eq!(
+                sim.get("o_b").unwrap(),
+                Value::new(0x33, 8, false),
+                "const index config={config:?}"
+            );
+            assert_eq!(
+                sim.get("o_c").unwrap(),
+                Value::new(exp_c, 8, false),
+                "dynamic part-select i={i} config={config:?}"
+            );
+            assert_eq!(
+                sim.get("o_d").unwrap(),
+                Value::new(exp_d, 8, false),
+                "dynamic index j={j} config={config:?}"
+            );
+        }
+    }
+}

--- a/crates/synthesizer/src/conv/expression.rs
+++ b/crates/synthesizer/src/conv/expression.rs
@@ -352,6 +352,83 @@ fn synth_factor(
             let elements: Vec<Vec<NetId>> = element_nets.iter().map(|&n| vec![n]).collect();
             Ok(arith::dynamic_mux_tree(ctx, &elements, &idx_nets))
         }
+        Factor::SelectedValue(x) => {
+            let ct = &x.comptime;
+            let elem_width = x.values[0].width();
+            let elements: Vec<Vec<NetId>> = x
+                .values
+                .iter()
+                .map(|v| value_to_nets(v, elem_width))
+                .collect();
+
+            let element_nets: Vec<NetId> = if x.index.0.is_empty() {
+                elements[0].clone()
+            } else if x.index.is_const() {
+                x.index
+                    .eval_value(&mut ctx.eval_ctx)
+                    .and_then(|indices| x.array.calc_index(&indices))
+                    .and_then(|flat| elements.get(flat).cloned())
+                    .ok_or_else(|| {
+                        SynthesizerError::internal(
+                            "const array index does not match its value table".to_string(),
+                        )
+                    })?
+            } else {
+                if x.array.dims() != 1 {
+                    return Err(SynthesizerError::unsupported(
+                        UnsupportedKind::DynamicMultiDimIndex {
+                            what: "const array".to_string(),
+                        },
+                        &ct.token,
+                    ));
+                }
+                let index_bits = arith::index_bits_for(elements.len());
+                let index_nets = synthesize_expr(ctx, &x.index.0[0], current, index_bits)?;
+                arith::dynamic_mux_tree(ctx, &elements, &index_nets)
+            };
+
+            if x.select.is_empty() {
+                return Ok(element_nets);
+            }
+            if !x.select.is_const() {
+                // A part-select at a runtime position can't expand to a fixed slice.
+                if x.select.is_range() {
+                    return Err(SynthesizerError::unsupported(
+                        UnsupportedKind::DynamicRangeSelect {
+                            what: "const value".to_string(),
+                        },
+                        &ct.token,
+                    ));
+                }
+                if x.select.0.len() != 1 {
+                    return Err(SynthesizerError::unsupported(
+                        UnsupportedKind::MultiDimDynamicSelect {
+                            what: "const value".to_string(),
+                        },
+                        &ct.token,
+                    ));
+                }
+                let index_bits = arith::index_bits_for(element_nets.len());
+                let index_nets = synthesize_expr(ctx, &x.select.0[0], current, index_bits)?;
+                let bits: Vec<Vec<NetId>> = element_nets.iter().map(|&n| vec![n]).collect();
+                return Ok(arith::dynamic_mux_tree(ctx, &bits, &index_nets));
+            }
+            let (high, low) = x
+                .select
+                .eval_value(&mut ctx.eval_ctx, &ct.r#type, false)
+                .ok_or_else(|| {
+                    SynthesizerError::dynamic_select("const value".to_string(), &ct.token)
+                })?;
+            if high >= element_nets.len() {
+                return Err(SynthesizerError::internal(format!(
+                    "bit select out of range: {}..={} of {}-bit const",
+                    low,
+                    high,
+                    element_nets.len()
+                )));
+            }
+            Ok(element_nets[low..=high].to_vec())
+        }
         Factor::FunctionCall(call) => synth_function_call(ctx, call, current),
         Factor::SystemFunctionCall(call) => synth_system_function_call(ctx, call, current),
         Factor::Anonymous(ct) => {

--- a/crates/synthesizer/tests/integration.rs
+++ b/crates/synthesizer/tests/integration.rs
@@ -4357,3 +4357,66 @@ fn count_trailing_zeros_netlist_matches_golden_model_exhaustively() {
         }
     }
 }
+
+#[test]
+fn package_const_dynamic_select() {
+    // A package const read at a runtime index / bit position.
+    let code = r#"
+        package a_pkg {
+            const ROM:  logic<4> [4] = '{4'h1, 4'h2, 4'h4, 4'h8};
+            const ONES: logic<4> [4] = '{4'hf, 4'hf, 4'hf, 4'hf};
+            const MASK: logic<4>     = 4'b1010;
+        }
+        module Top (
+            sel: input  logic<2>,
+            y:   output logic<4>,
+            w:   output logic<4>,
+            z:   output logic,
+        ) {
+            always_comb {
+                y = a_pkg::ROM[sel];
+                w = a_pkg::ONES[sel];
+                z = a_pkg::MASK[sel];
+            }
+        }
+    "#;
+    let (ir, top) = analyze(code, "Top");
+    let gate = build_gate_ir(&ir, top).expect("synthesize");
+    let port = |name: &str| {
+        gate.module
+            .ports
+            .iter()
+            .find(|p| format!("{}", p.name) == name)
+            .unwrap()
+    };
+
+    // `ROM[sel]` is a one-hot decode of `sel`: every bit is real logic, and no
+    // two bits share a driver.
+    let y = port("y");
+    for &n in &y.nets {
+        assert!(
+            matches!(gate.module.nets[n as usize].driver, NetDriver::Cell(_)),
+            "ROM[sel] bit must be decoded logic, got {:?}",
+            gate.module.nets[n as usize].driver
+        );
+    }
+    let mut distinct = y.nets.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(distinct.len(), y.nets.len(), "one-hot bits must differ");
+
+    // Every element of `ONES` is 4'hf, so the selection folds to all ones.
+    for &n in &port("w").nets {
+        assert!(
+            matches!(gate.module.nets[n as usize].driver, NetDriver::Const(true)),
+            "ONES[sel] must fold to a constant"
+        );
+    }
+
+    // 4'b1010 selected by `sel` is exactly `sel[0]`.
+    assert_eq!(
+        port("z").nets[0],
+        port("sel").nets[0],
+        "MASK[sel] must reduce to sel[0]"
+    );
+}


### PR DESCRIPTION
Fixes #3082.

## Problem

The analyzer reported a false-positive `invalid_operand` error when a package `const` array is indexed at a reference site:

```veryl
package PkgA {
    const ARRAY: bit<8> [4] = '{8'h11, 8'h22, 8'h33, 8'h44};
}
module ModuleA {
    let _a: bit<8> = PkgA::ARRAY[0];  // ARRAY[0] was typed as bit<8>[4]
}
```

## Cause

`ARRAY` is not registered in the referring scope's variable table, so `find_path` misses and it is resolved through the symbol route (`eval_factor_symbol` / `eval_factor_symbol_external`).

That route takes no `select` argument and silently drops the array index, returning the whole `bit<8>[4]` type instead of the element type `bit<8>`. The array-typed operand then trips the `+` operand check.

## Fix

### analyzer

`apply_symbol_select` applies the dropped select to whatever `eval_factor_symbol[_external]` returned, branching purely on the select:

| select | result |
| --- | --- |
| none | the `Factor::Value` as-is |
| constant, full index | folds to the selected element (`Factor::Value`) |
| constant, partial index | the selected sub-array, carried as `ValueVariant::NumericArray` |
| dynamic | the new `ir::Factor::SelectedValue` |

Supporting changes:

- `eval_expr` carries an array literal's per-element values as `ValueVariant::NumericArray`, so a later reference can resolve individual elements.
- New `ir::Factor::SelectedValue { values, array, index, select, comptime }` — a const value selected at runtime. It holds the whole-const per-element values inline; `comptime.r#type` is the **post-select** (reduced) type, and `comptime.value` is `Unknown` because the read is dynamic. Constant selection never reaches it (the analyzer folds that above), so the simulator/synthesizer only see it for genuinely dynamic selection.
- The `find_path` branch now clears a whole-array `NumericArray` when the reference applies an index/select — that value describes the whole array, not the selected part, and leaving it there broke sliced parameter overrides (`#(YS: M[1])`).

### simulator

New `ProtoExpression::DynamicValue` / `Expression::DynamicValue`, the value-side counterpart of `DynamicVariable`: it reads an element by runtime index from an **inline constant table** instead of a state buffer, then applies the static or dynamic bit-select. Both backends (Cranelift, AOT-C) decline it, so it evaluates on the interpreter.

This keeps the analyzer's `comptime.r#type` at the correct post-select width instead of widening it to the element width to make a shift/mask lowering work.

### synthesizer

`synth_factor` gains a `SelectedValue` arm: the constant table becomes nets, `arith::dynamic_mux_tree` selects the element, then the bit-select is applied (constant → net slice, dynamic → 1-bit mux). Unsupported cases (multi-dimensional dynamic index, dynamic range select) match the existing `Factor::Variable` path.

## Tests

- `analyzer`: the reported case added to `tests::invalid_operand`; `ir::tests::package_const_select` covers a scalar part-select, an array element, a sub-array (`C[0]`), and a fully-indexed element (`C[1][1]`).
- `simulator`: `tests::simulation::package_const_select` checks static part-select / static index / dynamic part-select / dynamic index across all configs (interpreter, JIT, AOT-C, 4-state).
- `synthesizer`: `package_const_dynamic_select` checks that a dynamic const-array read synthesizes to a one-hot decode, that an all-identical table folds to a constant, and that `4'b1010[sel]` reduces to `sel[0]`.

Full workspace test suite passes.

## Notes

**Signedness of `u32` const array elements.** `ir::tests::array_literal` now expects `32'h0000000a` where it used to expect `32'sh0000000a`. Carrying the element values on the comptime moves a const array literal from the `ArrayLiteral` branch of `eval_const_assign` to the `NumericArray` branch, which applies `set_signed(r#type.signed)` via `fit_array_elements`. If the stored values represent "the value held by `const X: u32[3]`", propagating the declared type's signedness looks right, but the literal itself is an `i32` array — **is this propagation intended?**

