### PR TITLE
Add ECC encoder/decoder modules to `std` lib

### DIFF
--- a/crates/std/veryl/src/ecc/ecc_decoder.veryl
+++ b/crates/std/veryl/src/ecc/ecc_decoder.veryl
@@ -1,0 +1,130 @@
+pub module ecc_decoder #(
+    param WIDTH      : u32  = 8                                   ,
+    param TYPE       : type = logic<WIDTH>                        ,
+    const DATA_WIDTH : u32  = $bits(TYPE)                         ,
+    const CHECK_WIDTH: u32  = ecc_pkg::get_check_width(DATA_WIDTH),
+    const CODE_WIDTH : u32  = DATA_WIDTH + CHECK_WIDTH            ,
+) (
+    i_enable   : input  logic            ,
+    i_code     : input  logic<CODE_WIDTH>,
+    o_data     : output TYPE             ,
+    o_corrected: output logic            ,
+    o_detected : output logic            ,
+) {
+    var data     : logic<DATA_WIDTH> ;
+    var syndrome : logic<CHECK_WIDTH>;
+    var error_pos: logic<DATA_WIDTH> ;
+    var corrected: logic             ;
+    var detected : logic             ;
+
+    always_comb {
+        o_data      = data ^ error_pos;
+        o_corrected = corrected;
+        o_detected  = detected;
+    }
+
+    if CHECK_WIDTH == 5 :g {
+        var code  : logic                          <hamming_11_5_pkg::CODE_WIDTH>;
+        var result: hamming_11_5_pkg::decode_result                              ;
+
+        always_comb {
+            code = i_code as hamming_11_5_pkg::CODE_WIDTH;
+            if i_enable {
+                syndrome = hamming_11_5_pkg::calc_syndrome(code);
+                result   = hamming_11_5_pkg::decode(syndrome, DATA_WIDTH);
+            } else {
+                syndrome = '0;
+                result   = '0;
+            }
+
+            data      = code[CHECK_WIDTH+:DATA_WIDTH];
+            error_pos = result.error_pos[CHECK_WIDTH+:DATA_WIDTH];
+            corrected = result.corrected;
+            detected  = result.detected;
+        }
+    } else if CHECK_WIDTH == 6 {
+        var code  : logic                          <hamming_26_6_pkg::CODE_WIDTH>;
+        var result: hamming_26_6_pkg::decode_result                              ;
+
+        always_comb {
+            code = i_code as hamming_26_6_pkg::CODE_WIDTH;
+            if i_enable {
+                syndrome = hamming_26_6_pkg::calc_syndrome(code);
+                result   = hamming_26_6_pkg::decode(syndrome, DATA_WIDTH);
+            } else {
+                syndrome = '0;
+                result   = '0;
+            }
+
+            data      = code[CHECK_WIDTH+:DATA_WIDTH];
+            error_pos = result.error_pos[CHECK_WIDTH+:DATA_WIDTH];
+            corrected = result.corrected;
+            detected  = result.detected;
+        }
+    } else if CHECK_WIDTH == 7 {
+        var code  : logic                          <hamming_57_7_pkg::CODE_WIDTH>;
+        var result: hamming_57_7_pkg::decode_result                              ;
+
+        always_comb {
+            code = i_code as hamming_57_7_pkg::CODE_WIDTH;
+            if i_enable {
+                syndrome = hamming_57_7_pkg::calc_syndrome(code);
+                result   = hamming_57_7_pkg::decode(syndrome, DATA_WIDTH);
+            } else {
+                syndrome = '0;
+                result   = '0;
+            }
+
+            data      = code[CHECK_WIDTH+:DATA_WIDTH];
+            error_pos = result.error_pos[CHECK_WIDTH+:DATA_WIDTH];
+            corrected = result.corrected;
+            detected  = result.detected;
+        }
+    } else if CHECK_WIDTH == 8 {
+        var code  : logic                           <hamming_120_8_pkg::CODE_WIDTH>;
+        var result: hamming_120_8_pkg::decode_result                               ;
+
+        always_comb {
+            code = i_code as hamming_120_8_pkg::CODE_WIDTH;
+            if i_enable {
+                syndrome = hamming_120_8_pkg::calc_syndrome(code);
+                result   = hamming_120_8_pkg::decode(syndrome, DATA_WIDTH);
+            } else {
+                syndrome = '0;
+                result   = '0;
+            }
+
+            data      = code[CHECK_WIDTH+:DATA_WIDTH];
+            error_pos = result.error_pos[CHECK_WIDTH+:DATA_WIDTH];
+            corrected = result.corrected;
+            detected  = result.detected;
+        }
+    } else if CHECK_WIDTH == 9 {
+        var code  : logic                           <hamming_247_9_pkg::CODE_WIDTH>;
+        var result: hamming_247_9_pkg::decode_result                               ;
+
+        always_comb {
+            code = i_code as hamming_247_9_pkg::CODE_WIDTH;
+            if i_enable {
+                syndrome = hamming_247_9_pkg::calc_syndrome(code);
+                result   = hamming_247_9_pkg::decode(syndrome, DATA_WIDTH);
+            } else {
+                syndrome = '0;
+                result   = '0;
+            }
+
+            data      = code[CHECK_WIDTH+:DATA_WIDTH];
+            error_pos = result.error_pos[CHECK_WIDTH+:DATA_WIDTH];
+            corrected = result.corrected;
+            detected  = result.detected;
+        }
+    } else {
+        always_comb {
+            data      = '0;
+            syndrome  = '0;
+            error_pos = '0;
+            corrected = false;
+            detected  = false;
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/ecc_encoder.veryl
+++ b/crates/std/veryl/src/ecc/ecc_encoder.veryl
@@ -1,0 +1,78 @@
+pub module ecc_encoder #(
+    param WIDTH      : u32  = 8                                   ,
+    param TYPE       : type = logic<WIDTH>                        ,
+    const DATA_WIDTH : u32  = $bits(TYPE)                         ,
+    const CHECK_WIDTH: u32  = ecc_pkg::get_check_width(DATA_WIDTH),
+    const CODE_WIDTH : u32  = DATA_WIDTH + CHECK_WIDTH            ,
+) (
+    i_enable: input  logic            ,
+    i_data  : input  TYPE             ,
+    o_code  : output logic<CODE_WIDTH>,
+) {
+    var check: logic<CHECK_WIDTH>;
+
+    always_comb {
+        o_code = {i_data, check};
+    }
+
+    if CHECK_WIDTH == 5 :g {
+        var data: logic<hamming_11_5_pkg::DATA_WIDTH>;
+
+        always_comb {
+            data = i_data as hamming_11_5_pkg::DATA_WIDTH;
+            if i_enable {
+                check = hamming_11_5_pkg::encode(data) as CHECK_WIDTH;
+            } else {
+                check = '0;
+            }
+        }
+    } else if CHECK_WIDTH == 6 {
+        var data: logic<hamming_26_6_pkg::DATA_WIDTH>;
+
+        always_comb {
+            data = i_data as hamming_26_6_pkg::DATA_WIDTH;
+            if i_enable {
+                check = hamming_26_6_pkg::encode(data) as CHECK_WIDTH;
+            } else {
+                check = '0;
+            }
+        }
+    } else if CHECK_WIDTH == 7 {
+        var data: logic<hamming_57_7_pkg::DATA_WIDTH>;
+
+        always_comb {
+            data = i_data as hamming_57_7_pkg::DATA_WIDTH;
+            if i_enable {
+                check = hamming_57_7_pkg::encode(data) as CHECK_WIDTH;
+            } else {
+                check = '0;
+            }
+        }
+    } else if CHECK_WIDTH == 8 {
+        var data: logic<hamming_120_8_pkg::DATA_WIDTH>;
+
+        always_comb {
+            data = i_data as hamming_120_8_pkg::DATA_WIDTH;
+            if i_enable {
+                check = hamming_120_8_pkg::encode(data) as CHECK_WIDTH;
+            } else {
+                check = '0;
+            }
+        }
+    } else if CHECK_WIDTH == 9 {
+        var data: logic<hamming_247_9_pkg::DATA_WIDTH>;
+
+        always_comb {
+            data = i_data as hamming_247_9_pkg::DATA_WIDTH;
+            if i_enable {
+                check = hamming_247_9_pkg::encode(data) as CHECK_WIDTH;
+            } else {
+                check = '0;
+            }
+        }
+    } else {
+        always_comb {
+            check = '0;
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/ecc_pkg.veryl
+++ b/crates/std/veryl/src/ecc/ecc_pkg.veryl
@@ -1,0 +1,29 @@
+pub package ecc_pkg {
+    function get_check_width (
+        data_width: input u32,
+    ) -> u32 {
+        if data_width == 0 {
+            return 0;
+        }
+
+        if data_width <= hamming_11_5_pkg::DATA_WIDTH {
+            return hamming_11_5_pkg::CHECK_WIDTH;
+        } else if data_width <= hamming_26_6_pkg::DATA_WIDTH {
+            return hamming_26_6_pkg::CHECK_WIDTH;
+        } else if data_width <= hamming_57_7_pkg::DATA_WIDTH {
+            return hamming_57_7_pkg::CHECK_WIDTH;
+        } else if data_width <= hamming_120_8_pkg::DATA_WIDTH {
+            return hamming_120_8_pkg::CHECK_WIDTH;
+        } else if data_width <= hamming_247_9_pkg::DATA_WIDTH {
+            return hamming_247_9_pkg::CHECK_WIDTH;
+        } else {
+            return 0;
+        }
+    }
+
+    function get_code_width (
+        data_width: input u32,
+    ) -> u32 {
+        return data_width + get_check_width(data_width);
+    }
+}

--- a/crates/std/veryl/src/ecc/hamming.rb
+++ b/crates/std/veryl/src/ecc/hamming.rb
@@ -1,0 +1,218 @@
+def popcount(n)
+  n.digits(2).sum
+end
+
+def candidate_columns(check_width)
+  (1...(2**check_width))
+    .map { |i| [i, popcount(i)] }
+    .select { |(_, weight)| weight.odd? && weight >= 3 }
+    .sort_by { |(v, weight)| [weight, v] }
+end
+
+def build_h_columuns(data_width, check_width)
+  candidates = candidate_columns(check_width)
+
+  row_bits = Array.new(check_width, 0)
+  selected = []
+
+  data_width.times do
+    min_weight = candidates.map { |(_, weight)| weight }.min
+    pool = candidates.select { |(_, weight)| weight == min_weight }
+
+    best, _ = pool.min_by do |(v, _)|
+      after = row_bits.dup
+      check_width.times { |i| after[i] += v[i] }
+      [after.max, after.sum, v]
+    end
+
+    selected << best
+    check_width.times { |i| row_bits[i] += best[i] }
+    candidates.delete_if { |(v, _)| v == best }
+  end
+
+  selected
+end
+
+def build_h_matrix(data_width, check_width)
+  columns = build_h_columuns(data_width, check_width)
+  Array.new(check_width) do |row|
+    bits = 1 << row
+    columns.each_with_index { |column_bits, column| bits |= column_bits[row] << (column + check_width) }
+    bits
+  end
+end
+
+def h_matrix_comment(rows, data_width, check_width)
+  lines = []
+  lines << "    // data width = #{data_width} check width = #{check_width}"
+  rows
+    .map.with_index { |bits, i| [bits, i] }
+    .reverse_each do |bits, i|
+      data_part = format('%0*b', data_width, bits[check_width...])
+      check_part = format('%0*b', check_width, bits[0...check_width])
+      lines << "    // row[#{i}]: #{data_part} | #{check_part}"
+    end
+  lines.join("\n")
+end
+
+# Minimum number of check bits for a SEC-DED code with the given data width.
+# The usable columns are odd-weight vectors of length m excluding the m weight-1
+# ones, i.e. 2^(m-1) - m must be at least the data width.
+def min_check_width(data_width)
+  m = 2
+  m += 1 while (2**(m - 1) - m) < data_width
+  m
+end
+
+# Generate a HEX literal of the given bit width.
+def hex_literal(value, width)
+  digits = (width + 3) / 4
+  format("%d'h%0*x", width, digits, value)
+end
+
+# H column pattern for data bit j (row i as bit i): the single-error syndrome.
+def data_column_values(h_matrix, data_width, check_width)
+  n = data_width + check_width
+  (0...n).map do |column|
+    value = 0
+    h_matrix.each_with_index { |row_bits, row| value |= row_bits[column] << row }
+    value
+  end
+end
+
+def emit_consts(data_width, check_width)
+  lines = []
+  lines << "    const DATA_WIDTH : u32 = #{data_width};"
+  lines << "    const CHECK_WIDTH: u32 = #{check_width};"
+  lines << "    const CODE_WIDTH : u32 = DATA_WIDTH + CHECK_WIDTH;"
+  lines.join("\n")
+end
+
+def emit_encode_matrix(h_matrix, data_width, check_width)
+  lines = []
+  lines << "    // Coefficient matrix for check-bit generation."
+  h_matrix.each_with_index do |row, i|
+    value = hex_literal(row >> check_width, data_width)
+    lines << "    const ENCODE_MATRIX_ROW_#{i}: bit<DATA_WIDTH> = #{value}; // check[#{i}]"
+  end
+  lines.join("\n")
+end
+
+def emit_struct
+  lines = []
+  lines << "    struct decode_result {"
+  lines << "        error_pos: logic<CODE_WIDTH>, // error position (one-hot, [CHECK_WIDTH-1:0]=check, upper=data)"
+  lines << "        corrected: logic            , // a single-bit error was located and corrected"
+  lines << "        detected : logic            , // an uncorrectable error was detected"
+  lines << "    }"
+  lines.join("\n")
+end
+
+# Function that computes the check bits.
+def emit_encode(check_width)
+  lines = []
+  lines << "    /// Compute the check bits (AND with the coefficient matrix, then XOR reduction)."
+  lines << "    function encode ("
+  lines << "        data: input logic<DATA_WIDTH>,"
+  lines << "    ) -> logic<CHECK_WIDTH> {"
+  lines << "        var check: logic<CHECK_WIDTH>;"
+  check_width.times do |row|
+    lines << "        check[#{row}] = ^(ENCODE_MATRIX_ROW_#{row} & data);"
+  end
+  lines << "        return check;"
+  lines << "    }"
+  lines.join("\n")
+end
+
+# Function that computes the syndrome.
+def emit_syndrome
+  lines = []
+  lines << "    /// Compute the syndrome (received check bits ^ recomputed check bits)."
+  lines << "    function calc_syndrome ("
+  lines << "        code: input logic<CODE_WIDTH>"
+  lines << "    ) -> logic<CHECK_WIDTH> {"
+  lines << "        var data : logic<DATA_WIDTH> ;"
+  lines << "        var check: logic<CHECK_WIDTH>;"
+  lines << "        data  = code[CODE_WIDTH-1-:DATA_WIDTH];"
+  lines << "        check = code[0+:CHECK_WIDTH];"
+  lines << "        return encode(data) ^ check;"
+  lines << "    }"
+  lines.join("\n")
+end
+
+# Function that locates the error position and detects errors from the syndrome.
+def emit_decode(h_matrix, data_width, check_width)
+  columns = data_column_values(h_matrix, data_width, check_width)
+  code_width = data_width + check_width
+
+  # [condition, error position (one-hot), comment, corrected]
+  entries = []
+  entries << ["syndrome == #{hex_literal(0, check_width)}", 0, "no error", false]
+  columns.each_with_index do |column_bits, i|
+    condition, comment =
+      if i < check_width
+        ["syndrome == #{hex_literal(column_bits, check_width)}", "check[#{i}]"]
+      else
+        pos = i - check_width
+        w = pos + 1
+        ["syndrome == #{hex_literal(column_bits, check_width)} && width >= #{w}", "data[#{pos}]"]
+      end
+    entries << [condition, 1 << i, comment, true]
+  end
+
+  lines = []
+  lines << "    /// Determine the error position and flags (corrected/detected) from the syndrome."
+  lines << "    /// A data-bit correction is honored only while its index is below the active width."
+  lines << "    function decode ("
+  lines << "        syndrome: input logic<CHECK_WIDTH>,"
+  lines << "        width   : input u32               ,"
+  lines << "    ) -> decode_result {"
+  lines << "        // Boolean-selector switch (SV: case (1'b1)); the syndrome values are mutually"
+  lines << "        // exclusive, so the branches stay parallel while sharing the width gate."
+  lines << "        // A data branch that fails its width guard falls through to default -> detected."
+  lines << "        switch {"
+  entries.each do |condition, error_pos, comment, corrected|
+    lines << "            #{condition}: return decode_result'{error_pos: #{hex_literal(error_pos, code_width)}, corrected: #{corrected}, detected: false}; // #{comment}"
+  end
+  lines << "            default: return decode_result'{error_pos: #{hex_literal(0, code_width)}, corrected: false, detected: true}; // undefined syndrome / out-of-range (multiple-bit error)"
+  lines << "        }"
+  lines << "    }"
+  lines.join("\n")
+end
+
+def build_veryl(h_matrix, data_width, check_width)
+  header = "#[fmt(skip)]\npub package hamming_#{data_width}_#{check_width}_pkg {\n" +
+           h_matrix_comment(h_matrix, data_width, check_width)
+
+  sections = [
+    header,
+    emit_consts(data_width, check_width),
+    emit_encode_matrix(h_matrix, data_width, check_width),
+    emit_struct,
+    emit_encode(check_width),
+    emit_syndrome,
+    emit_decode(h_matrix, data_width, check_width),
+  ]
+
+  sections.join("\n\n") + "\n}\n"
+end
+
+# Generate a Veryl package for the given data / check widths and write it to a file.
+def generate_veryl(data_width, check_width)
+  h_matrix = build_h_matrix(data_width, check_width)
+  veryl = build_veryl(h_matrix, data_width, check_width)
+  path = "hamming_#{data_width}_#{check_width}_pkg.veryl"
+  File.write(path, veryl)
+  puts "generated: #{path}"
+end
+
+# Maximum data width supported by a SEC-DED code with the given check width:
+# all odd-weight vectors of length m (2^(m-1)) minus the m weight-1 columns.
+def max_data_width(check_width)
+  2**(check_width - 1) - check_width
+end
+
+# Scan by check (code) width; generate each package at its maximum data width.
+(5..9).each do |check_width|
+  generate_veryl(max_data_width(check_width), check_width)
+end

--- a/crates/std/veryl/src/ecc/hamming_11_5_pkg.veryl
+++ b/crates/std/veryl/src/ecc/hamming_11_5_pkg.veryl
@@ -1,0 +1,81 @@
+#[fmt(skip)]
+pub package hamming_11_5_pkg {
+    // data width = 11 check width = 5
+    // row[4]: 11111100100 | 10000
+    // row[3]: 11010011110 | 01000
+    // row[2]: 10101011101 | 00100
+    // row[1]: 10110110011 | 00010
+    // row[0]: 11001101011 | 00001
+
+    const DATA_WIDTH : u32 = 11;
+    const CHECK_WIDTH: u32 = 5;
+    const CODE_WIDTH : u32 = DATA_WIDTH + CHECK_WIDTH;
+
+    // Coefficient matrix for check-bit generation.
+    const ENCODE_MATRIX_ROW_0: bit<DATA_WIDTH> = 11'h66b; // check[0]
+    const ENCODE_MATRIX_ROW_1: bit<DATA_WIDTH> = 11'h5b3; // check[1]
+    const ENCODE_MATRIX_ROW_2: bit<DATA_WIDTH> = 11'h55d; // check[2]
+    const ENCODE_MATRIX_ROW_3: bit<DATA_WIDTH> = 11'h69e; // check[3]
+    const ENCODE_MATRIX_ROW_4: bit<DATA_WIDTH> = 11'h7e4; // check[4]
+
+    struct decode_result {
+        error_pos: logic<CODE_WIDTH>, // error position (one-hot, [CHECK_WIDTH-1:0]=check, upper=data)
+        corrected: logic            , // a single-bit error was located and corrected
+        detected : logic            , // an uncorrectable error was detected
+    }
+
+    /// Compute the check bits (AND with the coefficient matrix, then XOR reduction).
+    function encode (
+        data: input logic<DATA_WIDTH>,
+    ) -> logic<CHECK_WIDTH> {
+        var check: logic<CHECK_WIDTH>;
+        check[0] = ^(ENCODE_MATRIX_ROW_0 & data);
+        check[1] = ^(ENCODE_MATRIX_ROW_1 & data);
+        check[2] = ^(ENCODE_MATRIX_ROW_2 & data);
+        check[3] = ^(ENCODE_MATRIX_ROW_3 & data);
+        check[4] = ^(ENCODE_MATRIX_ROW_4 & data);
+        return check;
+    }
+
+    /// Compute the syndrome (received check bits ^ recomputed check bits).
+    function calc_syndrome (
+        code: input logic<CODE_WIDTH>
+    ) -> logic<CHECK_WIDTH> {
+        var data : logic<DATA_WIDTH> ;
+        var check: logic<CHECK_WIDTH>;
+        data  = code[CODE_WIDTH-1-:DATA_WIDTH];
+        check = code[0+:CHECK_WIDTH];
+        return encode(data) ^ check;
+    }
+
+    /// Determine the error position and flags (corrected/detected) from the syndrome.
+    /// A data-bit correction is honored only while its index is below the active width.
+    function decode (
+        syndrome: input logic<CHECK_WIDTH>,
+        width   : input u32               ,
+    ) -> decode_result {
+        // Boolean-selector switch (SV: case (1'b1)); the syndrome values are mutually
+        // exclusive, so the branches stay parallel while sharing the width gate.
+        // A data branch that fails its width guard falls through to default -> detected.
+        switch {
+            syndrome == 5'h00: return decode_result'{error_pos: 16'h0000, corrected: false, detected: false}; // no error
+            syndrome == 5'h01: return decode_result'{error_pos: 16'h0001, corrected: true, detected: false}; // check[0]
+            syndrome == 5'h02: return decode_result'{error_pos: 16'h0002, corrected: true, detected: false}; // check[1]
+            syndrome == 5'h04: return decode_result'{error_pos: 16'h0004, corrected: true, detected: false}; // check[2]
+            syndrome == 5'h08: return decode_result'{error_pos: 16'h0008, corrected: true, detected: false}; // check[3]
+            syndrome == 5'h10: return decode_result'{error_pos: 16'h0010, corrected: true, detected: false}; // check[4]
+            syndrome == 5'h07 && width >= 1: return decode_result'{error_pos: 16'h0020, corrected: true, detected: false}; // data[0]
+            syndrome == 5'h0b && width >= 2: return decode_result'{error_pos: 16'h0040, corrected: true, detected: false}; // data[1]
+            syndrome == 5'h1c && width >= 3: return decode_result'{error_pos: 16'h0080, corrected: true, detected: false}; // data[2]
+            syndrome == 5'h0d && width >= 4: return decode_result'{error_pos: 16'h0100, corrected: true, detected: false}; // data[3]
+            syndrome == 5'h0e && width >= 5: return decode_result'{error_pos: 16'h0200, corrected: true, detected: false}; // data[4]
+            syndrome == 5'h13 && width >= 6: return decode_result'{error_pos: 16'h0400, corrected: true, detected: false}; // data[5]
+            syndrome == 5'h15 && width >= 7: return decode_result'{error_pos: 16'h0800, corrected: true, detected: false}; // data[6]
+            syndrome == 5'h1a && width >= 8: return decode_result'{error_pos: 16'h1000, corrected: true, detected: false}; // data[7]
+            syndrome == 5'h16 && width >= 9: return decode_result'{error_pos: 16'h2000, corrected: true, detected: false}; // data[8]
+            syndrome == 5'h19 && width >= 10: return decode_result'{error_pos: 16'h4000, corrected: true, detected: false}; // data[9]
+            syndrome == 5'h1f && width >= 11: return decode_result'{error_pos: 16'h8000, corrected: true, detected: false}; // data[10]
+            default: return decode_result'{error_pos: 16'h0000, corrected: false, detected: true}; // undefined syndrome / out-of-range (multiple-bit error)
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/hamming_120_8_pkg.veryl
+++ b/crates/std/veryl/src/ecc/hamming_120_8_pkg.veryl
@@ -1,0 +1,202 @@
+#[fmt(skip)]
+pub package hamming_120_8_pkg {
+    // data width = 120 check width = 8
+    // row[7]: 111111101111111111111111111111111110100100101010010000001000100011111111101101101101100100110010000000000000000000000000 | 10000000
+    // row[6]: 111111011111111111101001010000010001011011111101111111111000100011000000010010010011111011111101111100000000000000000000 | 01000000
+    // row[5]: 111110111111010000010110101111010101011011111111110010000111111000101000010011001000010010100010010010101010101010101010 | 00100000
+    // row[4]: 111101111000101110010111110010101011011111101010001111100111110100010101001000010010001001010010010001010101010110101010 | 00010000
+    // row[3]: 111011110110101001111001001110111101110100010111001111010111101100010010010100011001000100001001001001010110101001010110 | 00001000
+    // row[2]: 110111111001010101100111011001110110101110010110101110111110011100100100100010100010100100000100101001101001011001011001 | 00000100
+    // row[1]: 101111110100110110101100101111001011101101011001111001111101011110000010101001000100001010000101000110011001100101100101 | 00000010
+    // row[0]: 011111110011001011011010110101101110110011100101110101111011011101001001000100100100010001001000100110100110010110010101 | 00000001
+
+    const DATA_WIDTH : u32 = 120;
+    const CHECK_WIDTH: u32 = 8;
+    const CODE_WIDTH : u32 = DATA_WIDTH + CHECK_WIDTH;
+
+    // Coefficient matrix for check-bit generation.
+    const ENCODE_MATRIX_ROW_0: bit<DATA_WIDTH> = 120'h7f32dad6ece5d7b7491244489a6595; // check[0]
+    const ENCODE_MATRIX_ROW_1: bit<DATA_WIDTH> = 120'hbf4dacbcbb59e7d782a44285199965; // check[1]
+    const ENCODE_MATRIX_ROW_2: bit<DATA_WIDTH> = 120'hdf9567676b96bbe7248a2904a69659; // check[2]
+    const ENCODE_MATRIX_ROW_3: bit<DATA_WIDTH> = 120'hef6a793bdd173d7b12519109256a56; // check[3]
+    const ENCODE_MATRIX_ROW_4: bit<DATA_WIDTH> = 120'hf78b97cab7ea3e7d152122524555aa; // check[4]
+    const ENCODE_MATRIX_ROW_5: bit<DATA_WIDTH> = 120'hfbf416bd56ffc87e284c84a24aaaaa; // check[5]
+    const ENCODE_MATRIX_ROW_6: bit<DATA_WIDTH> = 120'hfdffe94116fdff88c0493efdf00000; // check[6]
+    const ENCODE_MATRIX_ROW_7: bit<DATA_WIDTH> = 120'hfeffffffe92a4088ffb6d932000000; // check[7]
+
+    struct decode_result {
+        error_pos: logic<CODE_WIDTH>, // error position (one-hot, [CHECK_WIDTH-1:0]=check, upper=data)
+        corrected: logic            , // a single-bit error was located and corrected
+        detected : logic            , // an uncorrectable error was detected
+    }
+
+    /// Compute the check bits (AND with the coefficient matrix, then XOR reduction).
+    function encode (
+        data: input logic<DATA_WIDTH>,
+    ) -> logic<CHECK_WIDTH> {
+        var check: logic<CHECK_WIDTH>;
+        check[0] = ^(ENCODE_MATRIX_ROW_0 & data);
+        check[1] = ^(ENCODE_MATRIX_ROW_1 & data);
+        check[2] = ^(ENCODE_MATRIX_ROW_2 & data);
+        check[3] = ^(ENCODE_MATRIX_ROW_3 & data);
+        check[4] = ^(ENCODE_MATRIX_ROW_4 & data);
+        check[5] = ^(ENCODE_MATRIX_ROW_5 & data);
+        check[6] = ^(ENCODE_MATRIX_ROW_6 & data);
+        check[7] = ^(ENCODE_MATRIX_ROW_7 & data);
+        return check;
+    }
+
+    /// Compute the syndrome (received check bits ^ recomputed check bits).
+    function calc_syndrome (
+        code: input logic<CODE_WIDTH>
+    ) -> logic<CHECK_WIDTH> {
+        var data : logic<DATA_WIDTH> ;
+        var check: logic<CHECK_WIDTH>;
+        data  = code[CODE_WIDTH-1-:DATA_WIDTH];
+        check = code[0+:CHECK_WIDTH];
+        return encode(data) ^ check;
+    }
+
+    /// Determine the error position and flags (corrected/detected) from the syndrome.
+    /// A data-bit correction is honored only while its index is below the active width.
+    function decode (
+        syndrome: input logic<CHECK_WIDTH>,
+        width   : input u32               ,
+    ) -> decode_result {
+        // Boolean-selector switch (SV: case (1'b1)); the syndrome values are mutually
+        // exclusive, so the branches stay parallel while sharing the width gate.
+        // A data branch that fails its width guard falls through to default -> detected.
+        switch {
+            syndrome == 8'h00: return decode_result'{error_pos: 128'h00000000000000000000000000000000, corrected: false, detected: false}; // no error
+            syndrome == 8'h01: return decode_result'{error_pos: 128'h00000000000000000000000000000001, corrected: true, detected: false}; // check[0]
+            syndrome == 8'h02: return decode_result'{error_pos: 128'h00000000000000000000000000000002, corrected: true, detected: false}; // check[1]
+            syndrome == 8'h04: return decode_result'{error_pos: 128'h00000000000000000000000000000004, corrected: true, detected: false}; // check[2]
+            syndrome == 8'h08: return decode_result'{error_pos: 128'h00000000000000000000000000000008, corrected: true, detected: false}; // check[3]
+            syndrome == 8'h10: return decode_result'{error_pos: 128'h00000000000000000000000000000010, corrected: true, detected: false}; // check[4]
+            syndrome == 8'h20: return decode_result'{error_pos: 128'h00000000000000000000000000000020, corrected: true, detected: false}; // check[5]
+            syndrome == 8'h40: return decode_result'{error_pos: 128'h00000000000000000000000000000040, corrected: true, detected: false}; // check[6]
+            syndrome == 8'h80: return decode_result'{error_pos: 128'h00000000000000000000000000000080, corrected: true, detected: false}; // check[7]
+            syndrome == 8'h07 && width >= 1: return decode_result'{error_pos: 128'h00000000000000000000000000000100, corrected: true, detected: false}; // data[0]
+            syndrome == 8'h38 && width >= 2: return decode_result'{error_pos: 128'h00000000000000000000000000000200, corrected: true, detected: false}; // data[1]
+            syndrome == 8'h0b && width >= 3: return decode_result'{error_pos: 128'h00000000000000000000000000000400, corrected: true, detected: false}; // data[2]
+            syndrome == 8'h34 && width >= 4: return decode_result'{error_pos: 128'h00000000000000000000000000000800, corrected: true, detected: false}; // data[3]
+            syndrome == 8'h0d && width >= 5: return decode_result'{error_pos: 128'h00000000000000000000000000001000, corrected: true, detected: false}; // data[4]
+            syndrome == 8'h32 && width >= 6: return decode_result'{error_pos: 128'h00000000000000000000000000002000, corrected: true, detected: false}; // data[5]
+            syndrome == 8'h0e && width >= 7: return decode_result'{error_pos: 128'h00000000000000000000000000004000, corrected: true, detected: false}; // data[6]
+            syndrome == 8'h31 && width >= 8: return decode_result'{error_pos: 128'h00000000000000000000000000008000, corrected: true, detected: false}; // data[7]
+            syndrome == 8'h13 && width >= 9: return decode_result'{error_pos: 128'h00000000000000000000000000010000, corrected: true, detected: false}; // data[8]
+            syndrome == 8'h2c && width >= 10: return decode_result'{error_pos: 128'h00000000000000000000000000020000, corrected: true, detected: false}; // data[9]
+            syndrome == 8'h15 && width >= 11: return decode_result'{error_pos: 128'h00000000000000000000000000040000, corrected: true, detected: false}; // data[10]
+            syndrome == 8'h2a && width >= 12: return decode_result'{error_pos: 128'h00000000000000000000000000080000, corrected: true, detected: false}; // data[11]
+            syndrome == 8'h16 && width >= 13: return decode_result'{error_pos: 128'h00000000000000000000000000100000, corrected: true, detected: false}; // data[12]
+            syndrome == 8'h29 && width >= 14: return decode_result'{error_pos: 128'h00000000000000000000000000200000, corrected: true, detected: false}; // data[13]
+            syndrome == 8'h19 && width >= 15: return decode_result'{error_pos: 128'h00000000000000000000000000400000, corrected: true, detected: false}; // data[14]
+            syndrome == 8'h26 && width >= 16: return decode_result'{error_pos: 128'h00000000000000000000000000800000, corrected: true, detected: false}; // data[15]
+            syndrome == 8'h1a && width >= 17: return decode_result'{error_pos: 128'h00000000000000000000000001000000, corrected: true, detected: false}; // data[16]
+            syndrome == 8'h25 && width >= 18: return decode_result'{error_pos: 128'h00000000000000000000000002000000, corrected: true, detected: false}; // data[17]
+            syndrome == 8'h1c && width >= 19: return decode_result'{error_pos: 128'h00000000000000000000000004000000, corrected: true, detected: false}; // data[18]
+            syndrome == 8'h23 && width >= 20: return decode_result'{error_pos: 128'h00000000000000000000000008000000, corrected: true, detected: false}; // data[19]
+            syndrome == 8'h43 && width >= 21: return decode_result'{error_pos: 128'h00000000000000000000000010000000, corrected: true, detected: false}; // data[20]
+            syndrome == 8'h4c && width >= 22: return decode_result'{error_pos: 128'h00000000000000000000000020000000, corrected: true, detected: false}; // data[21]
+            syndrome == 8'h70 && width >= 23: return decode_result'{error_pos: 128'h00000000000000000000000040000000, corrected: true, detected: false}; // data[22]
+            syndrome == 8'h45 && width >= 24: return decode_result'{error_pos: 128'h00000000000000000000000080000000, corrected: true, detected: false}; // data[23]
+            syndrome == 8'h4a && width >= 25: return decode_result'{error_pos: 128'h00000000000000000000000100000000, corrected: true, detected: false}; // data[24]
+            syndrome == 8'hb0 && width >= 26: return decode_result'{error_pos: 128'h00000000000000000000000200000000, corrected: true, detected: false}; // data[25]
+            syndrome == 8'h46 && width >= 27: return decode_result'{error_pos: 128'h00000000000000000000000400000000, corrected: true, detected: false}; // data[26]
+            syndrome == 8'h49 && width >= 28: return decode_result'{error_pos: 128'h00000000000000000000000800000000, corrected: true, detected: false}; // data[27]
+            syndrome == 8'hd0 && width >= 29: return decode_result'{error_pos: 128'h00000000000000000000001000000000, corrected: true, detected: false}; // data[28]
+            syndrome == 8'he0 && width >= 30: return decode_result'{error_pos: 128'h00000000000000000000002000000000, corrected: true, detected: false}; // data[29]
+            syndrome == 8'h51 && width >= 31: return decode_result'{error_pos: 128'h00000000000000000000004000000000, corrected: true, detected: false}; // data[30]
+            syndrome == 8'h62 && width >= 32: return decode_result'{error_pos: 128'h00000000000000000000008000000000, corrected: true, detected: false}; // data[31]
+            syndrome == 8'h8c && width >= 33: return decode_result'{error_pos: 128'h00000000000000000000010000000000, corrected: true, detected: false}; // data[32]
+            syndrome == 8'h52 && width >= 34: return decode_result'{error_pos: 128'h00000000000000000000020000000000, corrected: true, detected: false}; // data[33]
+            syndrome == 8'h61 && width >= 35: return decode_result'{error_pos: 128'h00000000000000000000040000000000, corrected: true, detected: false}; // data[34]
+            syndrome == 8'hc4 && width >= 36: return decode_result'{error_pos: 128'h00000000000000000000080000000000, corrected: true, detected: false}; // data[35]
+            syndrome == 8'hc8 && width >= 37: return decode_result'{error_pos: 128'h00000000000000000000100000000000, corrected: true, detected: false}; // data[36]
+            syndrome == 8'h54 && width >= 38: return decode_result'{error_pos: 128'h00000000000000000000200000000000, corrected: true, detected: false}; // data[37]
+            syndrome == 8'h83 && width >= 39: return decode_result'{error_pos: 128'h00000000000000000000400000000000, corrected: true, detected: false}; // data[38]
+            syndrome == 8'ha8 && width >= 40: return decode_result'{error_pos: 128'h00000000000000000000800000000000, corrected: true, detected: false}; // data[39]
+            syndrome == 8'h58 && width >= 41: return decode_result'{error_pos: 128'h00000000000000000001000000000000, corrected: true, detected: false}; // data[40]
+            syndrome == 8'h85 && width >= 42: return decode_result'{error_pos: 128'h00000000000000000002000000000000, corrected: true, detected: false}; // data[41]
+            syndrome == 8'ha2 && width >= 43: return decode_result'{error_pos: 128'h00000000000000000004000000000000, corrected: true, detected: false}; // data[42]
+            syndrome == 8'h64 && width >= 44: return decode_result'{error_pos: 128'h00000000000000000008000000000000, corrected: true, detected: false}; // data[43]
+            syndrome == 8'h89 && width >= 45: return decode_result'{error_pos: 128'h00000000000000000010000000000000, corrected: true, detected: false}; // data[44]
+            syndrome == 8'h92 && width >= 46: return decode_result'{error_pos: 128'h00000000000000000020000000000000, corrected: true, detected: false}; // data[45]
+            syndrome == 8'h68 && width >= 47: return decode_result'{error_pos: 128'h00000000000000000040000000000000, corrected: true, detected: false}; // data[46]
+            syndrome == 8'h86 && width >= 48: return decode_result'{error_pos: 128'h00000000000000000080000000000000, corrected: true, detected: false}; // data[47]
+            syndrome == 8'h91 && width >= 49: return decode_result'{error_pos: 128'h00000000000000000100000000000000, corrected: true, detected: false}; // data[48]
+            syndrome == 8'h8a && width >= 50: return decode_result'{error_pos: 128'h00000000000000000200000000000000, corrected: true, detected: false}; // data[49]
+            syndrome == 8'h94 && width >= 51: return decode_result'{error_pos: 128'h00000000000000000400000000000000, corrected: true, detected: false}; // data[50]
+            syndrome == 8'ha1 && width >= 52: return decode_result'{error_pos: 128'h00000000000000000800000000000000, corrected: true, detected: false}; // data[51]
+            syndrome == 8'h98 && width >= 53: return decode_result'{error_pos: 128'h00000000000000001000000000000000, corrected: true, detected: false}; // data[52]
+            syndrome == 8'ha4 && width >= 54: return decode_result'{error_pos: 128'h00000000000000002000000000000000, corrected: true, detected: false}; // data[53]
+            syndrome == 8'hc1 && width >= 55: return decode_result'{error_pos: 128'h00000000000000004000000000000000, corrected: true, detected: false}; // data[54]
+            syndrome == 8'hc2 && width >= 56: return decode_result'{error_pos: 128'h00000000000000008000000000000000, corrected: true, detected: false}; // data[55]
+            syndrome == 8'h1f && width >= 57: return decode_result'{error_pos: 128'h00000000000000010000000000000000, corrected: true, detected: false}; // data[56]
+            syndrome == 8'h2f && width >= 58: return decode_result'{error_pos: 128'h00000000000000020000000000000000, corrected: true, detected: false}; // data[57]
+            syndrome == 8'h37 && width >= 59: return decode_result'{error_pos: 128'h00000000000000040000000000000000, corrected: true, detected: false}; // data[58]
+            syndrome == 8'hf8 && width >= 60: return decode_result'{error_pos: 128'h00000000000000080000000000000000, corrected: true, detected: false}; // data[59]
+            syndrome == 8'h3b && width >= 61: return decode_result'{error_pos: 128'h00000000000000100000000000000000, corrected: true, detected: false}; // data[60]
+            syndrome == 8'h3d && width >= 62: return decode_result'{error_pos: 128'h00000000000000200000000000000000, corrected: true, detected: false}; // data[61]
+            syndrome == 8'h3e && width >= 63: return decode_result'{error_pos: 128'h00000000000000400000000000000000, corrected: true, detected: false}; // data[62]
+            syndrome == 8'hc7 && width >= 64: return decode_result'{error_pos: 128'h00000000000000800000000000000000, corrected: true, detected: false}; // data[63]
+            syndrome == 8'h4f && width >= 65: return decode_result'{error_pos: 128'h00000000000001000000000000000000, corrected: true, detected: false}; // data[64]
+            syndrome == 8'h57 && width >= 66: return decode_result'{error_pos: 128'h00000000000002000000000000000000, corrected: true, detected: false}; // data[65]
+            syndrome == 8'h5b && width >= 67: return decode_result'{error_pos: 128'h00000000000004000000000000000000, corrected: true, detected: false}; // data[66]
+            syndrome == 8'h7c && width >= 68: return decode_result'{error_pos: 128'h00000000000008000000000000000000, corrected: true, detected: false}; // data[67]
+            syndrome == 8'h5d && width >= 69: return decode_result'{error_pos: 128'h00000000000010000000000000000000, corrected: true, detected: false}; // data[68]
+            syndrome == 8'h5e && width >= 70: return decode_result'{error_pos: 128'h00000000000020000000000000000000, corrected: true, detected: false}; // data[69]
+            syndrome == 8'he3 && width >= 71: return decode_result'{error_pos: 128'h00000000000040000000000000000000, corrected: true, detected: false}; // data[70]
+            syndrome == 8'h67 && width >= 72: return decode_result'{error_pos: 128'h00000000000080000000000000000000, corrected: true, detected: false}; // data[71]
+            syndrome == 8'h6b && width >= 73: return decode_result'{error_pos: 128'h00000000000100000000000000000000, corrected: true, detected: false}; // data[72]
+            syndrome == 8'hbc && width >= 74: return decode_result'{error_pos: 128'h00000000000200000000000000000000, corrected: true, detected: false}; // data[73]
+            syndrome == 8'h6d && width >= 75: return decode_result'{error_pos: 128'h00000000000400000000000000000000, corrected: true, detected: false}; // data[74]
+            syndrome == 8'hf2 && width >= 76: return decode_result'{error_pos: 128'h00000000000800000000000000000000, corrected: true, detected: false}; // data[75]
+            syndrome == 8'h6e && width >= 77: return decode_result'{error_pos: 128'h00000000001000000000000000000000, corrected: true, detected: false}; // data[76]
+            syndrome == 8'hf1 && width >= 78: return decode_result'{error_pos: 128'h00000000002000000000000000000000, corrected: true, detected: false}; // data[77]
+            syndrome == 8'h73 && width >= 79: return decode_result'{error_pos: 128'h00000000004000000000000000000000, corrected: true, detected: false}; // data[78]
+            syndrome == 8'h75 && width >= 80: return decode_result'{error_pos: 128'h00000000008000000000000000000000, corrected: true, detected: false}; // data[79]
+            syndrome == 8'h9e && width >= 81: return decode_result'{error_pos: 128'h00000000010000000000000000000000, corrected: true, detected: false}; // data[80]
+            syndrome == 8'h76 && width >= 82: return decode_result'{error_pos: 128'h00000000020000000000000000000000, corrected: true, detected: false}; // data[81]
+            syndrome == 8'h79 && width >= 83: return decode_result'{error_pos: 128'h00000000040000000000000000000000, corrected: true, detected: false}; // data[82]
+            syndrome == 8'h8f && width >= 84: return decode_result'{error_pos: 128'h00000000080000000000000000000000, corrected: true, detected: false}; // data[83]
+            syndrome == 8'h7a && width >= 85: return decode_result'{error_pos: 128'h00000000100000000000000000000000, corrected: true, detected: false}; // data[84]
+            syndrome == 8'h97 && width >= 86: return decode_result'{error_pos: 128'h00000000200000000000000000000000, corrected: true, detected: false}; // data[85]
+            syndrome == 8'had && width >= 87: return decode_result'{error_pos: 128'h00000000400000000000000000000000, corrected: true, detected: false}; // data[86]
+            syndrome == 8'h9b && width >= 88: return decode_result'{error_pos: 128'h00000000800000000000000000000000, corrected: true, detected: false}; // data[87]
+            syndrome == 8'hec && width >= 89: return decode_result'{error_pos: 128'h00000001000000000000000000000000, corrected: true, detected: false}; // data[88]
+            syndrome == 8'h9d && width >= 90: return decode_result'{error_pos: 128'h00000002000000000000000000000000, corrected: true, detected: false}; // data[89]
+            syndrome == 8'ha7 && width >= 91: return decode_result'{error_pos: 128'h00000004000000000000000000000000, corrected: true, detected: false}; // data[90]
+            syndrome == 8'hba && width >= 92: return decode_result'{error_pos: 128'h00000008000000000000000000000000, corrected: true, detected: false}; // data[91]
+            syndrome == 8'hab && width >= 93: return decode_result'{error_pos: 128'h00000010000000000000000000000000, corrected: true, detected: false}; // data[92]
+            syndrome == 8'hae && width >= 94: return decode_result'{error_pos: 128'h00000020000000000000000000000000, corrected: true, detected: false}; // data[93]
+            syndrome == 8'hd5 && width >= 95: return decode_result'{error_pos: 128'h00000040000000000000000000000000, corrected: true, detected: false}; // data[94]
+            syndrome == 8'hb3 && width >= 96: return decode_result'{error_pos: 128'h00000080000000000000000000000000, corrected: true, detected: false}; // data[95]
+            syndrome == 8'hdc && width >= 97: return decode_result'{error_pos: 128'h00000100000000000000000000000000, corrected: true, detected: false}; // data[96]
+            syndrome == 8'hb5 && width >= 98: return decode_result'{error_pos: 128'h00000200000000000000000000000000, corrected: true, detected: false}; // data[97]
+            syndrome == 8'hb6 && width >= 99: return decode_result'{error_pos: 128'h00000400000000000000000000000000, corrected: true, detected: false}; // data[98]
+            syndrome == 8'hcb && width >= 100: return decode_result'{error_pos: 128'h00000800000000000000000000000000, corrected: true, detected: false}; // data[99]
+            syndrome == 8'hb9 && width >= 101: return decode_result'{error_pos: 128'h00001000000000000000000000000000, corrected: true, detected: false}; // data[100]
+            syndrome == 8'hce && width >= 102: return decode_result'{error_pos: 128'h00002000000000000000000000000000, corrected: true, detected: false}; // data[101]
+            syndrome == 8'hcd && width >= 103: return decode_result'{error_pos: 128'h00004000000000000000000000000000, corrected: true, detected: false}; // data[102]
+            syndrome == 8'hd3 && width >= 104: return decode_result'{error_pos: 128'h00008000000000000000000000000000, corrected: true, detected: false}; // data[103]
+            syndrome == 8'hd6 && width >= 105: return decode_result'{error_pos: 128'h00010000000000000000000000000000, corrected: true, detected: false}; // data[104]
+            syndrome == 8'hd9 && width >= 106: return decode_result'{error_pos: 128'h00020000000000000000000000000000, corrected: true, detected: false}; // data[105]
+            syndrome == 8'he6 && width >= 107: return decode_result'{error_pos: 128'h00040000000000000000000000000000, corrected: true, detected: false}; // data[106]
+            syndrome == 8'hda && width >= 108: return decode_result'{error_pos: 128'h00080000000000000000000000000000, corrected: true, detected: false}; // data[107]
+            syndrome == 8'he5 && width >= 109: return decode_result'{error_pos: 128'h00100000000000000000000000000000, corrected: true, detected: false}; // data[108]
+            syndrome == 8'he9 && width >= 110: return decode_result'{error_pos: 128'h00200000000000000000000000000000, corrected: true, detected: false}; // data[109]
+            syndrome == 8'hea && width >= 111: return decode_result'{error_pos: 128'h00400000000000000000000000000000, corrected: true, detected: false}; // data[110]
+            syndrome == 8'hf4 && width >= 112: return decode_result'{error_pos: 128'h00800000000000000000000000000000, corrected: true, detected: false}; // data[111]
+            syndrome == 8'h7f && width >= 113: return decode_result'{error_pos: 128'h01000000000000000000000000000000, corrected: true, detected: false}; // data[112]
+            syndrome == 8'hbf && width >= 114: return decode_result'{error_pos: 128'h02000000000000000000000000000000, corrected: true, detected: false}; // data[113]
+            syndrome == 8'hdf && width >= 115: return decode_result'{error_pos: 128'h04000000000000000000000000000000, corrected: true, detected: false}; // data[114]
+            syndrome == 8'hef && width >= 116: return decode_result'{error_pos: 128'h08000000000000000000000000000000, corrected: true, detected: false}; // data[115]
+            syndrome == 8'hf7 && width >= 117: return decode_result'{error_pos: 128'h10000000000000000000000000000000, corrected: true, detected: false}; // data[116]
+            syndrome == 8'hfb && width >= 118: return decode_result'{error_pos: 128'h20000000000000000000000000000000, corrected: true, detected: false}; // data[117]
+            syndrome == 8'hfd && width >= 119: return decode_result'{error_pos: 128'h40000000000000000000000000000000, corrected: true, detected: false}; // data[118]
+            syndrome == 8'hfe && width >= 120: return decode_result'{error_pos: 128'h80000000000000000000000000000000, corrected: true, detected: false}; // data[119]
+            default: return decode_result'{error_pos: 128'h00000000000000000000000000000000, corrected: false, detected: true}; // undefined syndrome / out-of-range (multiple-bit error)
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/hamming_247_9_pkg.veryl
+++ b/crates/std/veryl/src/ecc/hamming_247_9_pkg.veryl
@@ -1,0 +1,333 @@
+#[fmt(skip)]
+pub package hamming_247_9_pkg {
+    // data width = 247 check width = 9
+    // row[8]: 1111111111111111111111111111001000000111111111111111111111111111111111111111100100101010100101001010101010100000101010101000010001001010010100100001010000100100100111111111111111111111110110100000000000000000010000000000000000000000000000000000100 | 100000000
+    // row[7]: 1111111111111111111100001000111111110111111111110101010101010000000010100000011011010101011010110101010101011111111111011111111111001010010100101001010100100100100111001000000000010000001001011111111011011011011001001100100000000000000000000000100 | 010000000
+    // row[6]: 1111111111111100000011111110111111101110101000001010101010101111111010001000011011010101011010111111110110100100101010101010010100110101101011010111111111100100100000100111000000001000001001110000000100100100101110111111011111000000000000000000100 | 001000000
+    // row[5]: 1111111101000011111011111101111111011001010111001010111101010100000101011010011011111101100101001010101001011011010101111010010100110101101011111101010100011011110000010000110010011100000000001010000100110010000100101000100100101010101010101010010 | 000100000
+    // row[4]: 1111001010111011110111111011111110111001011100110101000010101011010101011101011100101010011010110110101001011011101010100101101100110101111100101010101110011011101000101000001001000100100100000101010010000100100010010100100100010101010101101010010 | 000010000
+    // row[3]: 1100111011110111101111100111111101111101001001001101010010110101100110100111100011011010011111001001011011110100010101100101110010111110010011011010101101011110011000010100000100100010001100000100100101000110010001000010010010010101101010010101010 | 000001000
+    // row[2]: 1011100111101111011111010111111011111010100010110010110011001010101101100110110110100110110100111001100101101110010110010111001011101001110011100110110011011101011100000010000110000001100010001001001000101000101001000001001010011010010110010110001 | 000000100
+    // row[1]: 1101010111011110111110111111100111111010010011010011001100101100111010010101101101101001101101100110010110011101011001010110101011011011001110010111001011110011011010000000101000100001010001100000101010010001000010100001010001100110011001011001001 | 000000010
+    // row[0]: 1010111100111101111101111111010111111100100100101100101101010011011001111011100100010111100011010101011110100011100101011001101111000110101101011100101011101011011001000001010001000010010010010010010001001001000100010010001001101001100101100101001 | 000000001
+
+    const DATA_WIDTH : u32 = 247;
+    const CHECK_WIDTH: u32 = 9;
+    const CODE_WIDTH : u32 = DATA_WIDTH + CHECK_WIDTH;
+
+    // Coefficient matrix for check-bit generation.
+    const ENCODE_MATRIX_ROW_0: bit<DATA_WIDTH> = 247'h579efbfafe4965a9b3dc8bc6abd1cacde35ae575b20a21249224889134cb29; // check[0]
+    const ENCODE_MATRIX_ROW_1: bit<DATA_WIDTH> = 247'h6aef7dfcfd26999674adb4db32ceb2b56d9cb979b40510a30548850a3332c9; // check[1]
+    const ENCODE_MATRIX_ROW_2: bit<DATA_WIDTH> = 247'h5cf7bebf7d4596655b36d369ccb72cb974e7366eb810c0c4491452094d2cb1; // check[2]
+    const ENCODE_MATRIX_ROW_3: bit<DATA_WIDTH> = 247'h677bdf3fbe926a5acd3c6d3e4b7a2b2e5f26d5af30a0911824a322124ad4aa; // check[3]
+    const ENCODE_MATRIX_ROW_4: bit<DATA_WIDTH> = 247'h795defdfdcb9a855aaeb9535b52dd52d9af955cdd14122482a4244a48aab52; // check[4]
+    const ENCODE_MATRIX_ROW_5: bit<DATA_WIDTH> = 247'h7fa1f7efecae57aa0ad37eca552dabd29ad7ea8de0864e0050990944955552; // check[5]
+    const ENCODE_MATRIX_ROW_6: bit<DATA_WIDTH> = 247'h7ffe07f7f7505557f4436ab5fed255529ad6bff24138041380925dfbe00004; // check[6]
+    const ENCODE_MATRIX_ROW_7: bit<DATA_WIDTH> = 247'h7ffff847fbffaaa805036ab5aaaffeffe5294a924e400812ff6db264000004; // check[7]
+    const ENCODE_MATRIX_ROW_8: bit<DATA_WIDTH> = 247'h7ffffff903fffffffffc954a5550554225290a124fffffed00002000000004; // check[8]
+
+    struct decode_result {
+        error_pos: logic<CODE_WIDTH>, // error position (one-hot, [CHECK_WIDTH-1:0]=check, upper=data)
+        corrected: logic            , // a single-bit error was located and corrected
+        detected : logic            , // an uncorrectable error was detected
+    }
+
+    /// Compute the check bits (AND with the coefficient matrix, then XOR reduction).
+    function encode (
+        data: input logic<DATA_WIDTH>,
+    ) -> logic<CHECK_WIDTH> {
+        var check: logic<CHECK_WIDTH>;
+        check[0] = ^(ENCODE_MATRIX_ROW_0 & data);
+        check[1] = ^(ENCODE_MATRIX_ROW_1 & data);
+        check[2] = ^(ENCODE_MATRIX_ROW_2 & data);
+        check[3] = ^(ENCODE_MATRIX_ROW_3 & data);
+        check[4] = ^(ENCODE_MATRIX_ROW_4 & data);
+        check[5] = ^(ENCODE_MATRIX_ROW_5 & data);
+        check[6] = ^(ENCODE_MATRIX_ROW_6 & data);
+        check[7] = ^(ENCODE_MATRIX_ROW_7 & data);
+        check[8] = ^(ENCODE_MATRIX_ROW_8 & data);
+        return check;
+    }
+
+    /// Compute the syndrome (received check bits ^ recomputed check bits).
+    function calc_syndrome (
+        code: input logic<CODE_WIDTH>
+    ) -> logic<CHECK_WIDTH> {
+        var data : logic<DATA_WIDTH> ;
+        var check: logic<CHECK_WIDTH>;
+        data  = code[CODE_WIDTH-1-:DATA_WIDTH];
+        check = code[0+:CHECK_WIDTH];
+        return encode(data) ^ check;
+    }
+
+    /// Determine the error position and flags (corrected/detected) from the syndrome.
+    /// A data-bit correction is honored only while its index is below the active width.
+    function decode (
+        syndrome: input logic<CHECK_WIDTH>,
+        width   : input u32               ,
+    ) -> decode_result {
+        // Boolean-selector switch (SV: case (1'b1)); the syndrome values are mutually
+        // exclusive, so the branches stay parallel while sharing the width gate.
+        // A data branch that fails its width guard falls through to default -> detected.
+        switch {
+            syndrome == 9'h000: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000000, corrected: false, detected: false}; // no error
+            syndrome == 9'h001: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000001, corrected: true, detected: false}; // check[0]
+            syndrome == 9'h002: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000002, corrected: true, detected: false}; // check[1]
+            syndrome == 9'h004: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000004, corrected: true, detected: false}; // check[2]
+            syndrome == 9'h008: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000008, corrected: true, detected: false}; // check[3]
+            syndrome == 9'h010: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000010, corrected: true, detected: false}; // check[4]
+            syndrome == 9'h020: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000020, corrected: true, detected: false}; // check[5]
+            syndrome == 9'h040: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000040, corrected: true, detected: false}; // check[6]
+            syndrome == 9'h080: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000080, corrected: true, detected: false}; // check[7]
+            syndrome == 9'h100: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000100, corrected: true, detected: false}; // check[8]
+            syndrome == 9'h007 && width >= 1: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000200, corrected: true, detected: false}; // data[0]
+            syndrome == 9'h038 && width >= 2: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000400, corrected: true, detected: false}; // data[1]
+            syndrome == 9'h1c0 && width >= 3: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000800, corrected: true, detected: false}; // data[2]
+            syndrome == 9'h00b && width >= 4: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000001000, corrected: true, detected: false}; // data[3]
+            syndrome == 9'h034 && width >= 5: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000002000, corrected: true, detected: false}; // data[4]
+            syndrome == 9'h00d && width >= 6: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000004000, corrected: true, detected: false}; // data[5]
+            syndrome == 9'h032 && width >= 7: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000008000, corrected: true, detected: false}; // data[6]
+            syndrome == 9'h00e && width >= 8: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000010000, corrected: true, detected: false}; // data[7]
+            syndrome == 9'h031 && width >= 9: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000020000, corrected: true, detected: false}; // data[8]
+            syndrome == 9'h013 && width >= 10: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000040000, corrected: true, detected: false}; // data[9]
+            syndrome == 9'h02c && width >= 11: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000080000, corrected: true, detected: false}; // data[10]
+            syndrome == 9'h015 && width >= 12: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000100000, corrected: true, detected: false}; // data[11]
+            syndrome == 9'h02a && width >= 13: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000200000, corrected: true, detected: false}; // data[12]
+            syndrome == 9'h016 && width >= 14: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000400000, corrected: true, detected: false}; // data[13]
+            syndrome == 9'h029 && width >= 15: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000800000, corrected: true, detected: false}; // data[14]
+            syndrome == 9'h019 && width >= 16: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000001000000, corrected: true, detected: false}; // data[15]
+            syndrome == 9'h026 && width >= 17: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000002000000, corrected: true, detected: false}; // data[16]
+            syndrome == 9'h01a && width >= 18: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000004000000, corrected: true, detected: false}; // data[17]
+            syndrome == 9'h025 && width >= 19: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000008000000, corrected: true, detected: false}; // data[18]
+            syndrome == 9'h01c && width >= 20: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000010000000, corrected: true, detected: false}; // data[19]
+            syndrome == 9'h023 && width >= 21: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000020000000, corrected: true, detected: false}; // data[20]
+            syndrome == 9'h043 && width >= 22: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000040000000, corrected: true, detected: false}; // data[21]
+            syndrome == 9'h04c && width >= 23: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000080000000, corrected: true, detected: false}; // data[22]
+            syndrome == 9'h070 && width >= 24: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000100000000, corrected: true, detected: false}; // data[23]
+            syndrome == 9'h045 && width >= 25: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000200000000, corrected: true, detected: false}; // data[24]
+            syndrome == 9'h04a && width >= 26: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000400000000, corrected: true, detected: false}; // data[25]
+            syndrome == 9'h0b0 && width >= 27: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000800000000, corrected: true, detected: false}; // data[26]
+            syndrome == 9'h046 && width >= 28: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000001000000000, corrected: true, detected: false}; // data[27]
+            syndrome == 9'h049 && width >= 29: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000002000000000, corrected: true, detected: false}; // data[28]
+            syndrome == 9'h0d0 && width >= 30: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000004000000000, corrected: true, detected: false}; // data[29]
+            syndrome == 9'h0e0 && width >= 31: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000008000000000, corrected: true, detected: false}; // data[30]
+            syndrome == 9'h051 && width >= 32: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000010000000000, corrected: true, detected: false}; // data[31]
+            syndrome == 9'h062 && width >= 33: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000020000000000, corrected: true, detected: false}; // data[32]
+            syndrome == 9'h08c && width >= 34: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000040000000000, corrected: true, detected: false}; // data[33]
+            syndrome == 9'h052 && width >= 35: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000080000000000, corrected: true, detected: false}; // data[34]
+            syndrome == 9'h061 && width >= 36: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000100000000000, corrected: true, detected: false}; // data[35]
+            syndrome == 9'h0c4 && width >= 37: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000200000000000, corrected: true, detected: false}; // data[36]
+            syndrome == 9'h188 && width >= 38: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000400000000000, corrected: true, detected: false}; // data[37]
+            syndrome == 9'h054 && width >= 39: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000800000000000, corrected: true, detected: false}; // data[38]
+            syndrome == 9'h083 && width >= 40: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000001000000000000, corrected: true, detected: false}; // data[39]
+            syndrome == 9'h0a8 && width >= 41: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000002000000000000, corrected: true, detected: false}; // data[40]
+            syndrome == 9'h058 && width >= 42: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000004000000000000, corrected: true, detected: false}; // data[41]
+            syndrome == 9'h085 && width >= 43: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000008000000000000, corrected: true, detected: false}; // data[42]
+            syndrome == 9'h0a2 && width >= 44: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000010000000000000, corrected: true, detected: false}; // data[43]
+            syndrome == 9'h064 && width >= 45: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000020000000000000, corrected: true, detected: false}; // data[44]
+            syndrome == 9'h089 && width >= 46: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000040000000000000, corrected: true, detected: false}; // data[45]
+            syndrome == 9'h092 && width >= 47: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000080000000000000, corrected: true, detected: false}; // data[46]
+            syndrome == 9'h068 && width >= 48: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000100000000000000, corrected: true, detected: false}; // data[47]
+            syndrome == 9'h086 && width >= 49: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000200000000000000, corrected: true, detected: false}; // data[48]
+            syndrome == 9'h091 && width >= 50: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000400000000000000, corrected: true, detected: false}; // data[49]
+            syndrome == 9'h08a && width >= 51: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000800000000000000, corrected: true, detected: false}; // data[50]
+            syndrome == 9'h094 && width >= 52: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000001000000000000000, corrected: true, detected: false}; // data[51]
+            syndrome == 9'h0a1 && width >= 53: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000002000000000000000, corrected: true, detected: false}; // data[52]
+            syndrome == 9'h098 && width >= 54: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000004000000000000000, corrected: true, detected: false}; // data[53]
+            syndrome == 9'h0a4 && width >= 55: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000008000000000000000, corrected: true, detected: false}; // data[54]
+            syndrome == 9'h0c1 && width >= 56: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000010000000000000000, corrected: true, detected: false}; // data[55]
+            syndrome == 9'h142 && width >= 57: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000020000000000000000, corrected: true, detected: false}; // data[56]
+            syndrome == 9'h0c2 && width >= 58: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000040000000000000000, corrected: true, detected: false}; // data[57]
+            syndrome == 9'h105 && width >= 59: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000080000000000000000, corrected: true, detected: false}; // data[58]
+            syndrome == 9'h118 && width >= 60: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000100000000000000000, corrected: true, detected: false}; // data[59]
+            syndrome == 9'h0c8 && width >= 61: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000200000000000000000, corrected: true, detected: false}; // data[60]
+            syndrome == 9'h103 && width >= 62: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000400000000000000000, corrected: true, detected: false}; // data[61]
+            syndrome == 9'h114 && width >= 63: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000800000000000000000, corrected: true, detected: false}; // data[62]
+            syndrome == 9'h106 && width >= 64: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000001000000000000000000, corrected: true, detected: false}; // data[63]
+            syndrome == 9'h109 && width >= 65: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000002000000000000000000, corrected: true, detected: false}; // data[64]
+            syndrome == 9'h130 && width >= 66: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000004000000000000000000, corrected: true, detected: false}; // data[65]
+            syndrome == 9'h160 && width >= 67: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000008000000000000000000, corrected: true, detected: false}; // data[66]
+            syndrome == 9'h1a0 && width >= 68: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000010000000000000000000, corrected: true, detected: false}; // data[67]
+            syndrome == 9'h10a && width >= 69: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000020000000000000000000, corrected: true, detected: false}; // data[68]
+            syndrome == 9'h111 && width >= 70: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000040000000000000000000, corrected: true, detected: false}; // data[69]
+            syndrome == 9'h124 && width >= 71: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000080000000000000000000, corrected: true, detected: false}; // data[70]
+            syndrome == 9'h10c && width >= 72: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000100000000000000000000, corrected: true, detected: false}; // data[71]
+            syndrome == 9'h112 && width >= 73: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000200000000000000000000, corrected: true, detected: false}; // data[72]
+            syndrome == 9'h121 && width >= 74: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000400000000000000000000, corrected: true, detected: false}; // data[73]
+            syndrome == 9'h122 && width >= 75: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000800000000000000000000, corrected: true, detected: false}; // data[74]
+            syndrome == 9'h141 && width >= 76: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000001000000000000000000000, corrected: true, detected: false}; // data[75]
+            syndrome == 9'h144 && width >= 77: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000002000000000000000000000, corrected: true, detected: false}; // data[76]
+            syndrome == 9'h148 && width >= 78: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000004000000000000000000000, corrected: true, detected: false}; // data[77]
+            syndrome == 9'h190 && width >= 79: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000008000000000000000000000, corrected: true, detected: false}; // data[78]
+            syndrome == 9'h128 && width >= 80: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000010000000000000000000000, corrected: true, detected: false}; // data[79]
+            syndrome == 9'h150 && width >= 81: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000020000000000000000000000, corrected: true, detected: false}; // data[80]
+            syndrome == 9'h181 && width >= 82: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000040000000000000000000000, corrected: true, detected: false}; // data[81]
+            syndrome == 9'h182 && width >= 83: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000080000000000000000000000, corrected: true, detected: false}; // data[82]
+            syndrome == 9'h184 && width >= 84: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000100000000000000000000000, corrected: true, detected: false}; // data[83]
+            syndrome == 9'h01f && width >= 85: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000200000000000000000000000, corrected: true, detected: false}; // data[84]
+            syndrome == 9'h02f && width >= 86: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000400000000000000000000000, corrected: true, detected: false}; // data[85]
+            syndrome == 9'h1f0 && width >= 87: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000800000000000000000000000, corrected: true, detected: false}; // data[86]
+            syndrome == 9'h037 && width >= 88: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000001000000000000000000000000, corrected: true, detected: false}; // data[87]
+            syndrome == 9'h03b && width >= 89: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000002000000000000000000000000, corrected: true, detected: false}; // data[88]
+            syndrome == 9'h1cc && width >= 90: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000004000000000000000000000000, corrected: true, detected: false}; // data[89]
+            syndrome == 9'h03d && width >= 91: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000008000000000000000000000000, corrected: true, detected: false}; // data[90]
+            syndrome == 9'h03e && width >= 92: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000010000000000000000000000000, corrected: true, detected: false}; // data[91]
+            syndrome == 9'h1c3 && width >= 93: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000020000000000000000000000000, corrected: true, detected: false}; // data[92]
+            syndrome == 9'h04f && width >= 94: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000040000000000000000000000000, corrected: true, detected: false}; // data[93]
+            syndrome == 9'h057 && width >= 95: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000080000000000000000000000000, corrected: true, detected: false}; // data[94]
+            syndrome == 9'h0f8 && width >= 96: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000100000000000000000000000000, corrected: true, detected: false}; // data[95]
+            syndrome == 9'h05b && width >= 97: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000200000000000000000000000000, corrected: true, detected: false}; // data[96]
+            syndrome == 9'h1e4 && width >= 98: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000400000000000000000000000000, corrected: true, detected: false}; // data[97]
+            syndrome == 9'h05d && width >= 99: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000800000000000000000000000000, corrected: true, detected: false}; // data[98]
+            syndrome == 9'h1e2 && width >= 100: return decode_result'{error_pos: 256'h0000000000000000000000000000000000001000000000000000000000000000, corrected: true, detected: false}; // data[99]
+            syndrome == 9'h05e && width >= 101: return decode_result'{error_pos: 256'h0000000000000000000000000000000000002000000000000000000000000000, corrected: true, detected: false}; // data[100]
+            syndrome == 9'h067 && width >= 102: return decode_result'{error_pos: 256'h0000000000000000000000000000000000004000000000000000000000000000, corrected: true, detected: false}; // data[101]
+            syndrome == 9'h0b9 && width >= 103: return decode_result'{error_pos: 256'h0000000000000000000000000000000000008000000000000000000000000000, corrected: true, detected: false}; // data[102]
+            syndrome == 9'h06b && width >= 104: return decode_result'{error_pos: 256'h0000000000000000000000000000000000010000000000000000000000000000, corrected: true, detected: false}; // data[103]
+            syndrome == 9'h1b4 && width >= 105: return decode_result'{error_pos: 256'h0000000000000000000000000000000000020000000000000000000000000000, corrected: true, detected: false}; // data[104]
+            syndrome == 9'h06d && width >= 106: return decode_result'{error_pos: 256'h0000000000000000000000000000000000040000000000000000000000000000, corrected: true, detected: false}; // data[105]
+            syndrome == 9'h06e && width >= 107: return decode_result'{error_pos: 256'h0000000000000000000000000000000000080000000000000000000000000000, corrected: true, detected: false}; // data[106]
+            syndrome == 9'h193 && width >= 108: return decode_result'{error_pos: 256'h0000000000000000000000000000000000100000000000000000000000000000, corrected: true, detected: false}; // data[107]
+            syndrome == 9'h073 && width >= 109: return decode_result'{error_pos: 256'h0000000000000000000000000000000000200000000000000000000000000000, corrected: true, detected: false}; // data[108]
+            syndrome == 9'h19c && width >= 110: return decode_result'{error_pos: 256'h0000000000000000000000000000000000400000000000000000000000000000, corrected: true, detected: false}; // data[109]
+            syndrome == 9'h075 && width >= 111: return decode_result'{error_pos: 256'h0000000000000000000000000000000000800000000000000000000000000000, corrected: true, detected: false}; // data[110]
+            syndrome == 9'h076 && width >= 112: return decode_result'{error_pos: 256'h0000000000000000000000000000000001000000000000000000000000000000, corrected: true, detected: false}; // data[111]
+            syndrome == 9'h18b && width >= 113: return decode_result'{error_pos: 256'h0000000000000000000000000000000002000000000000000000000000000000, corrected: true, detected: false}; // data[112]
+            syndrome == 9'h079 && width >= 114: return decode_result'{error_pos: 256'h0000000000000000000000000000000004000000000000000000000000000000, corrected: true, detected: false}; // data[113]
+            syndrome == 9'h18e && width >= 115: return decode_result'{error_pos: 256'h0000000000000000000000000000000008000000000000000000000000000000, corrected: true, detected: false}; // data[114]
+            syndrome == 9'h07a && width >= 116: return decode_result'{error_pos: 256'h0000000000000000000000000000000010000000000000000000000000000000, corrected: true, detected: false}; // data[115]
+            syndrome == 9'h07c && width >= 117: return decode_result'{error_pos: 256'h0000000000000000000000000000000020000000000000000000000000000000, corrected: true, detected: false}; // data[116]
+            syndrome == 9'h187 && width >= 118: return decode_result'{error_pos: 256'h0000000000000000000000000000000040000000000000000000000000000000, corrected: true, detected: false}; // data[117]
+            syndrome == 9'h08f && width >= 119: return decode_result'{error_pos: 256'h0000000000000000000000000000000080000000000000000000000000000000, corrected: true, detected: false}; // data[118]
+            syndrome == 9'h0f1 && width >= 120: return decode_result'{error_pos: 256'h0000000000000000000000000000000100000000000000000000000000000000, corrected: true, detected: false}; // data[119]
+            syndrome == 9'h097 && width >= 121: return decode_result'{error_pos: 256'h0000000000000000000000000000000200000000000000000000000000000000, corrected: true, detected: false}; // data[120]
+            syndrome == 9'h1e8 && width >= 122: return decode_result'{error_pos: 256'h0000000000000000000000000000000400000000000000000000000000000000, corrected: true, detected: false}; // data[121]
+            syndrome == 9'h09b && width >= 123: return decode_result'{error_pos: 256'h0000000000000000000000000000000800000000000000000000000000000000, corrected: true, detected: false}; // data[122]
+            syndrome == 9'h09d && width >= 124: return decode_result'{error_pos: 256'h0000000000000000000000000000001000000000000000000000000000000000, corrected: true, detected: false}; // data[123]
+            syndrome == 9'h0e6 && width >= 125: return decode_result'{error_pos: 256'h0000000000000000000000000000002000000000000000000000000000000000, corrected: true, detected: false}; // data[124]
+            syndrome == 9'h09e && width >= 126: return decode_result'{error_pos: 256'h0000000000000000000000000000004000000000000000000000000000000000, corrected: true, detected: false}; // data[125]
+            syndrome == 9'h1e1 && width >= 127: return decode_result'{error_pos: 256'h0000000000000000000000000000008000000000000000000000000000000000, corrected: true, detected: false}; // data[126]
+            syndrome == 9'h0a7 && width >= 128: return decode_result'{error_pos: 256'h0000000000000000000000000000010000000000000000000000000000000000, corrected: true, detected: false}; // data[127]
+            syndrome == 9'h178 && width >= 129: return decode_result'{error_pos: 256'h0000000000000000000000000000020000000000000000000000000000000000, corrected: true, detected: false}; // data[128]
+            syndrome == 9'h0ab && width >= 130: return decode_result'{error_pos: 256'h0000000000000000000000000000040000000000000000000000000000000000, corrected: true, detected: false}; // data[129]
+            syndrome == 9'h1d4 && width >= 131: return decode_result'{error_pos: 256'h0000000000000000000000000000080000000000000000000000000000000000, corrected: true, detected: false}; // data[130]
+            syndrome == 9'h0ad && width >= 132: return decode_result'{error_pos: 256'h0000000000000000000000000000100000000000000000000000000000000000, corrected: true, detected: false}; // data[131]
+            syndrome == 9'h1d2 && width >= 133: return decode_result'{error_pos: 256'h0000000000000000000000000000200000000000000000000000000000000000, corrected: true, detected: false}; // data[132]
+            syndrome == 9'h0ae && width >= 134: return decode_result'{error_pos: 256'h0000000000000000000000000000400000000000000000000000000000000000, corrected: true, detected: false}; // data[133]
+            syndrome == 9'h1d1 && width >= 135: return decode_result'{error_pos: 256'h0000000000000000000000000000800000000000000000000000000000000000, corrected: true, detected: false}; // data[134]
+            syndrome == 9'h0b3 && width >= 136: return decode_result'{error_pos: 256'h0000000000000000000000000001000000000000000000000000000000000000, corrected: true, detected: false}; // data[135]
+            syndrome == 9'h0b5 && width >= 137: return decode_result'{error_pos: 256'h0000000000000000000000000002000000000000000000000000000000000000, corrected: true, detected: false}; // data[136]
+            syndrome == 9'h0ce && width >= 138: return decode_result'{error_pos: 256'h0000000000000000000000000004000000000000000000000000000000000000, corrected: true, detected: false}; // data[137]
+            syndrome == 9'h0b6 && width >= 139: return decode_result'{error_pos: 256'h0000000000000000000000000008000000000000000000000000000000000000, corrected: true, detected: false}; // data[138]
+            syndrome == 9'h0ba && width >= 140: return decode_result'{error_pos: 256'h0000000000000000000000000010000000000000000000000000000000000000, corrected: true, detected: false}; // data[139]
+            syndrome == 9'h14d && width >= 141: return decode_result'{error_pos: 256'h0000000000000000000000000020000000000000000000000000000000000000, corrected: true, detected: false}; // data[140]
+            syndrome == 9'h0bc && width >= 142: return decode_result'{error_pos: 256'h0000000000000000000000000040000000000000000000000000000000000000, corrected: true, detected: false}; // data[141]
+            syndrome == 9'h14b && width >= 143: return decode_result'{error_pos: 256'h0000000000000000000000000080000000000000000000000000000000000000, corrected: true, detected: false}; // data[142]
+            syndrome == 9'h0c7 && width >= 144: return decode_result'{error_pos: 256'h0000000000000000000000000100000000000000000000000000000000000000, corrected: true, detected: false}; // data[143]
+            syndrome == 9'h139 && width >= 145: return decode_result'{error_pos: 256'h0000000000000000000000000200000000000000000000000000000000000000, corrected: true, detected: false}; // data[144]
+            syndrome == 9'h0cb && width >= 146: return decode_result'{error_pos: 256'h0000000000000000000000000400000000000000000000000000000000000000, corrected: true, detected: false}; // data[145]
+            syndrome == 9'h174 && width >= 147: return decode_result'{error_pos: 256'h0000000000000000000000000800000000000000000000000000000000000000, corrected: true, detected: false}; // data[146]
+            syndrome == 9'h0cd && width >= 148: return decode_result'{error_pos: 256'h0000000000000000000000001000000000000000000000000000000000000000, corrected: true, detected: false}; // data[147]
+            syndrome == 9'h172 && width >= 149: return decode_result'{error_pos: 256'h0000000000000000000000002000000000000000000000000000000000000000, corrected: true, detected: false}; // data[148]
+            syndrome == 9'h0d3 && width >= 150: return decode_result'{error_pos: 256'h0000000000000000000000004000000000000000000000000000000000000000, corrected: true, detected: false}; // data[149]
+            syndrome == 9'h16c && width >= 151: return decode_result'{error_pos: 256'h0000000000000000000000008000000000000000000000000000000000000000, corrected: true, detected: false}; // data[150]
+            syndrome == 9'h0d5 && width >= 152: return decode_result'{error_pos: 256'h0000000000000000000000010000000000000000000000000000000000000000, corrected: true, detected: false}; // data[151]
+            syndrome == 9'h0d6 && width >= 153: return decode_result'{error_pos: 256'h0000000000000000000000020000000000000000000000000000000000000000, corrected: true, detected: false}; // data[152]
+            syndrome == 9'h12b && width >= 154: return decode_result'{error_pos: 256'h0000000000000000000000040000000000000000000000000000000000000000, corrected: true, detected: false}; // data[153]
+            syndrome == 9'h0d9 && width >= 155: return decode_result'{error_pos: 256'h0000000000000000000000080000000000000000000000000000000000000000, corrected: true, detected: false}; // data[154]
+            syndrome == 9'h12e && width >= 156: return decode_result'{error_pos: 256'h0000000000000000000000100000000000000000000000000000000000000000, corrected: true, detected: false}; // data[155]
+            syndrome == 9'h0da && width >= 157: return decode_result'{error_pos: 256'h0000000000000000000000200000000000000000000000000000000000000000, corrected: true, detected: false}; // data[156]
+            syndrome == 9'h0dc && width >= 158: return decode_result'{error_pos: 256'h0000000000000000000000400000000000000000000000000000000000000000, corrected: true, detected: false}; // data[157]
+            syndrome == 9'h127 && width >= 159: return decode_result'{error_pos: 256'h0000000000000000000000800000000000000000000000000000000000000000, corrected: true, detected: false}; // data[158]
+            syndrome == 9'h0e3 && width >= 160: return decode_result'{error_pos: 256'h0000000000000000000001000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[159]
+            syndrome == 9'h11d && width >= 161: return decode_result'{error_pos: 256'h0000000000000000000002000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[160]
+            syndrome == 9'h0e5 && width >= 162: return decode_result'{error_pos: 256'h0000000000000000000004000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[161]
+            syndrome == 9'h13a && width >= 163: return decode_result'{error_pos: 256'h0000000000000000000008000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[162]
+            syndrome == 9'h0e9 && width >= 164: return decode_result'{error_pos: 256'h0000000000000000000010000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[163]
+            syndrome == 9'h136 && width >= 165: return decode_result'{error_pos: 256'h0000000000000000000020000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[164]
+            syndrome == 9'h0ea && width >= 166: return decode_result'{error_pos: 256'h0000000000000000000040000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[165]
+            syndrome == 9'h0ec && width >= 167: return decode_result'{error_pos: 256'h0000000000000000000080000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[166]
+            syndrome == 9'h117 && width >= 168: return decode_result'{error_pos: 256'h0000000000000000000100000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[167]
+            syndrome == 9'h0f2 && width >= 169: return decode_result'{error_pos: 256'h0000000000000000000200000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[168]
+            syndrome == 9'h0f4 && width >= 170: return decode_result'{error_pos: 256'h0000000000000000000400000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[169]
+            syndrome == 9'h10f && width >= 171: return decode_result'{error_pos: 256'h0000000000000000000800000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[170]
+            syndrome == 9'h11b && width >= 172: return decode_result'{error_pos: 256'h0000000000000000001000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[171]
+            syndrome == 9'h12d && width >= 173: return decode_result'{error_pos: 256'h0000000000000000002000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[172]
+            syndrome == 9'h11e && width >= 174: return decode_result'{error_pos: 256'h0000000000000000004000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[173]
+            syndrome == 9'h171 && width >= 175: return decode_result'{error_pos: 256'h0000000000000000008000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[174]
+            syndrome == 9'h133 && width >= 176: return decode_result'{error_pos: 256'h0000000000000000010000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[175]
+            syndrome == 9'h18d && width >= 177: return decode_result'{error_pos: 256'h0000000000000000020000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[176]
+            syndrome == 9'h135 && width >= 178: return decode_result'{error_pos: 256'h0000000000000000040000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[177]
+            syndrome == 9'h1ca && width >= 179: return decode_result'{error_pos: 256'h0000000000000000080000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[178]
+            syndrome == 9'h13c && width >= 180: return decode_result'{error_pos: 256'h0000000000000000100000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[179]
+            syndrome == 9'h147 && width >= 181: return decode_result'{error_pos: 256'h0000000000000000200000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[180]
+            syndrome == 9'h153 && width >= 182: return decode_result'{error_pos: 256'h0000000000000000400000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[181]
+            syndrome == 9'h14e && width >= 183: return decode_result'{error_pos: 256'h0000000000000000800000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[182]
+            syndrome == 9'h159 && width >= 184: return decode_result'{error_pos: 256'h0000000000000001000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[183]
+            syndrome == 9'h155 && width >= 185: return decode_result'{error_pos: 256'h0000000000000002000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[184]
+            syndrome == 9'h16a && width >= 186: return decode_result'{error_pos: 256'h0000000000000004000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[185]
+            syndrome == 9'h156 && width >= 187: return decode_result'{error_pos: 256'h0000000000000008000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[186]
+            syndrome == 9'h1a9 && width >= 188: return decode_result'{error_pos: 256'h0000000000000010000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[187]
+            syndrome == 9'h15a && width >= 189: return decode_result'{error_pos: 256'h0000000000000020000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[188]
+            syndrome == 9'h1a5 && width >= 190: return decode_result'{error_pos: 256'h0000000000000040000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[189]
+            syndrome == 9'h15c && width >= 191: return decode_result'{error_pos: 256'h0000000000000080000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[190]
+            syndrome == 9'h1a3 && width >= 192: return decode_result'{error_pos: 256'h0000000000000100000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[191]
+            syndrome == 9'h163 && width >= 193: return decode_result'{error_pos: 256'h0000000000000200000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[192]
+            syndrome == 9'h1ac && width >= 194: return decode_result'{error_pos: 256'h0000000000000400000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[193]
+            syndrome == 9'h165 && width >= 195: return decode_result'{error_pos: 256'h0000000000000800000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[194]
+            syndrome == 9'h19a && width >= 196: return decode_result'{error_pos: 256'h0000000000001000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[195]
+            syndrome == 9'h166 && width >= 197: return decode_result'{error_pos: 256'h0000000000002000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[196]
+            syndrome == 9'h199 && width >= 198: return decode_result'{error_pos: 256'h0000000000004000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[197]
+            syndrome == 9'h169 && width >= 199: return decode_result'{error_pos: 256'h0000000000008000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[198]
+            syndrome == 9'h196 && width >= 200: return decode_result'{error_pos: 256'h0000000000010000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[199]
+            syndrome == 9'h195 && width >= 201: return decode_result'{error_pos: 256'h0000000000020000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[200]
+            syndrome == 9'h1aa && width >= 202: return decode_result'{error_pos: 256'h0000000000040000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[201]
+            syndrome == 9'h1a6 && width >= 203: return decode_result'{error_pos: 256'h0000000000080000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[202]
+            syndrome == 9'h1b1 && width >= 204: return decode_result'{error_pos: 256'h0000000000100000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[203]
+            syndrome == 9'h1d8 && width >= 205: return decode_result'{error_pos: 256'h0000000000200000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[204]
+            syndrome == 9'h1b2 && width >= 206: return decode_result'{error_pos: 256'h0000000000400000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[205]
+            syndrome == 9'h1c5 && width >= 207: return decode_result'{error_pos: 256'h0000000000800000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[206]
+            syndrome == 9'h1b8 && width >= 208: return decode_result'{error_pos: 256'h0000000001000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[207]
+            syndrome == 9'h1c6 && width >= 209: return decode_result'{error_pos: 256'h0000000002000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[208]
+            syndrome == 9'h1c9 && width >= 210: return decode_result'{error_pos: 256'h0000000004000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[209]
+            syndrome == 9'h07f && width >= 211: return decode_result'{error_pos: 256'h0000000008000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[210]
+            syndrome == 9'h0bf && width >= 212: return decode_result'{error_pos: 256'h0000000010000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[211]
+            syndrome == 9'h0df && width >= 213: return decode_result'{error_pos: 256'h0000000020000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[212]
+            syndrome == 9'h0ef && width >= 214: return decode_result'{error_pos: 256'h0000000040000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[213]
+            syndrome == 9'h0f7 && width >= 215: return decode_result'{error_pos: 256'h0000000080000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[214]
+            syndrome == 9'h0fb && width >= 216: return decode_result'{error_pos: 256'h0000000100000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[215]
+            syndrome == 9'h1fc && width >= 217: return decode_result'{error_pos: 256'h0000000200000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[216]
+            syndrome == 9'h0fd && width >= 218: return decode_result'{error_pos: 256'h0000000400000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[217]
+            syndrome == 9'h0fe && width >= 219: return decode_result'{error_pos: 256'h0000000800000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[218]
+            syndrome == 9'h13f && width >= 220: return decode_result'{error_pos: 256'h0000001000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[219]
+            syndrome == 9'h15f && width >= 221: return decode_result'{error_pos: 256'h0000002000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[220]
+            syndrome == 9'h16f && width >= 222: return decode_result'{error_pos: 256'h0000004000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[221]
+            syndrome == 9'h1f3 && width >= 223: return decode_result'{error_pos: 256'h0000008000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[222]
+            syndrome == 9'h177 && width >= 224: return decode_result'{error_pos: 256'h0000010000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[223]
+            syndrome == 9'h17b && width >= 225: return decode_result'{error_pos: 256'h0000020000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[224]
+            syndrome == 9'h17d && width >= 226: return decode_result'{error_pos: 256'h0000040000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[225]
+            syndrome == 9'h17e && width >= 227: return decode_result'{error_pos: 256'h0000080000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[226]
+            syndrome == 9'h19f && width >= 228: return decode_result'{error_pos: 256'h0000100000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[227]
+            syndrome == 9'h1af && width >= 229: return decode_result'{error_pos: 256'h0000200000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[228]
+            syndrome == 9'h1b7 && width >= 230: return decode_result'{error_pos: 256'h0000400000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[229]
+            syndrome == 9'h1bb && width >= 231: return decode_result'{error_pos: 256'h0000800000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[230]
+            syndrome == 9'h1bd && width >= 232: return decode_result'{error_pos: 256'h0001000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[231]
+            syndrome == 9'h1be && width >= 233: return decode_result'{error_pos: 256'h0002000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[232]
+            syndrome == 9'h1cf && width >= 234: return decode_result'{error_pos: 256'h0004000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[233]
+            syndrome == 9'h1d7 && width >= 235: return decode_result'{error_pos: 256'h0008000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[234]
+            syndrome == 9'h1db && width >= 236: return decode_result'{error_pos: 256'h0010000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[235]
+            syndrome == 9'h1dd && width >= 237: return decode_result'{error_pos: 256'h0020000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[236]
+            syndrome == 9'h1ee && width >= 238: return decode_result'{error_pos: 256'h0040000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[237]
+            syndrome == 9'h1de && width >= 239: return decode_result'{error_pos: 256'h0080000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[238]
+            syndrome == 9'h1e7 && width >= 240: return decode_result'{error_pos: 256'h0100000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[239]
+            syndrome == 9'h1f9 && width >= 241: return decode_result'{error_pos: 256'h0200000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[240]
+            syndrome == 9'h1eb && width >= 242: return decode_result'{error_pos: 256'h0400000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[241]
+            syndrome == 9'h1ed && width >= 243: return decode_result'{error_pos: 256'h0800000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[242]
+            syndrome == 9'h1f6 && width >= 244: return decode_result'{error_pos: 256'h1000000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[243]
+            syndrome == 9'h1f5 && width >= 245: return decode_result'{error_pos: 256'h2000000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[244]
+            syndrome == 9'h1fa && width >= 246: return decode_result'{error_pos: 256'h4000000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[245]
+            syndrome == 9'h1ff && width >= 247: return decode_result'{error_pos: 256'h8000000000000000000000000000000000000000000000000000000000000000, corrected: true, detected: false}; // data[246]
+            default: return decode_result'{error_pos: 256'h0000000000000000000000000000000000000000000000000000000000000000, corrected: false, detected: true}; // undefined syndrome / out-of-range (multiple-bit error)
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/hamming_26_6_pkg.veryl
+++ b/crates/std/veryl/src/ecc/hamming_26_6_pkg.veryl
@@ -1,0 +1,100 @@
+#[fmt(skip)]
+pub package hamming_26_6_pkg {
+    // data width = 26 check width = 6
+    // row[5]: 11111010101010101010101010 | 100000
+    // row[4]: 11110101010101010110101010 | 010000
+    // row[3]: 11101101010110101001010110 | 001000
+    // row[2]: 11011101101001011001011001 | 000100
+    // row[1]: 10111110011001100101100101 | 000010
+    // row[0]: 01111110100110010110010101 | 000001
+
+    const DATA_WIDTH : u32 = 26;
+    const CHECK_WIDTH: u32 = 6;
+    const CODE_WIDTH : u32 = DATA_WIDTH + CHECK_WIDTH;
+
+    // Coefficient matrix for check-bit generation.
+    const ENCODE_MATRIX_ROW_0: bit<DATA_WIDTH> = 26'h1fa6595; // check[0]
+    const ENCODE_MATRIX_ROW_1: bit<DATA_WIDTH> = 26'h2f99965; // check[1]
+    const ENCODE_MATRIX_ROW_2: bit<DATA_WIDTH> = 26'h3769659; // check[2]
+    const ENCODE_MATRIX_ROW_3: bit<DATA_WIDTH> = 26'h3b56a56; // check[3]
+    const ENCODE_MATRIX_ROW_4: bit<DATA_WIDTH> = 26'h3d555aa; // check[4]
+    const ENCODE_MATRIX_ROW_5: bit<DATA_WIDTH> = 26'h3eaaaaa; // check[5]
+
+    struct decode_result {
+        error_pos: logic<CODE_WIDTH>, // error position (one-hot, [CHECK_WIDTH-1:0]=check, upper=data)
+        corrected: logic            , // a single-bit error was located and corrected
+        detected : logic            , // an uncorrectable error was detected
+    }
+
+    /// Compute the check bits (AND with the coefficient matrix, then XOR reduction).
+    function encode (
+        data: input logic<DATA_WIDTH>,
+    ) -> logic<CHECK_WIDTH> {
+        var check: logic<CHECK_WIDTH>;
+        check[0] = ^(ENCODE_MATRIX_ROW_0 & data);
+        check[1] = ^(ENCODE_MATRIX_ROW_1 & data);
+        check[2] = ^(ENCODE_MATRIX_ROW_2 & data);
+        check[3] = ^(ENCODE_MATRIX_ROW_3 & data);
+        check[4] = ^(ENCODE_MATRIX_ROW_4 & data);
+        check[5] = ^(ENCODE_MATRIX_ROW_5 & data);
+        return check;
+    }
+
+    /// Compute the syndrome (received check bits ^ recomputed check bits).
+    function calc_syndrome (
+        code: input logic<CODE_WIDTH>
+    ) -> logic<CHECK_WIDTH> {
+        var data : logic<DATA_WIDTH> ;
+        var check: logic<CHECK_WIDTH>;
+        data  = code[CODE_WIDTH-1-:DATA_WIDTH];
+        check = code[0+:CHECK_WIDTH];
+        return encode(data) ^ check;
+    }
+
+    /// Determine the error position and flags (corrected/detected) from the syndrome.
+    /// A data-bit correction is honored only while its index is below the active width.
+    function decode (
+        syndrome: input logic<CHECK_WIDTH>,
+        width   : input u32               ,
+    ) -> decode_result {
+        // Boolean-selector switch (SV: case (1'b1)); the syndrome values are mutually
+        // exclusive, so the branches stay parallel while sharing the width gate.
+        // A data branch that fails its width guard falls through to default -> detected.
+        switch {
+            syndrome == 6'h00: return decode_result'{error_pos: 32'h00000000, corrected: false, detected: false}; // no error
+            syndrome == 6'h01: return decode_result'{error_pos: 32'h00000001, corrected: true, detected: false}; // check[0]
+            syndrome == 6'h02: return decode_result'{error_pos: 32'h00000002, corrected: true, detected: false}; // check[1]
+            syndrome == 6'h04: return decode_result'{error_pos: 32'h00000004, corrected: true, detected: false}; // check[2]
+            syndrome == 6'h08: return decode_result'{error_pos: 32'h00000008, corrected: true, detected: false}; // check[3]
+            syndrome == 6'h10: return decode_result'{error_pos: 32'h00000010, corrected: true, detected: false}; // check[4]
+            syndrome == 6'h20: return decode_result'{error_pos: 32'h00000020, corrected: true, detected: false}; // check[5]
+            syndrome == 6'h07 && width >= 1: return decode_result'{error_pos: 32'h00000040, corrected: true, detected: false}; // data[0]
+            syndrome == 6'h38 && width >= 2: return decode_result'{error_pos: 32'h00000080, corrected: true, detected: false}; // data[1]
+            syndrome == 6'h0b && width >= 3: return decode_result'{error_pos: 32'h00000100, corrected: true, detected: false}; // data[2]
+            syndrome == 6'h34 && width >= 4: return decode_result'{error_pos: 32'h00000200, corrected: true, detected: false}; // data[3]
+            syndrome == 6'h0d && width >= 5: return decode_result'{error_pos: 32'h00000400, corrected: true, detected: false}; // data[4]
+            syndrome == 6'h32 && width >= 6: return decode_result'{error_pos: 32'h00000800, corrected: true, detected: false}; // data[5]
+            syndrome == 6'h0e && width >= 7: return decode_result'{error_pos: 32'h00001000, corrected: true, detected: false}; // data[6]
+            syndrome == 6'h31 && width >= 8: return decode_result'{error_pos: 32'h00002000, corrected: true, detected: false}; // data[7]
+            syndrome == 6'h13 && width >= 9: return decode_result'{error_pos: 32'h00004000, corrected: true, detected: false}; // data[8]
+            syndrome == 6'h2c && width >= 10: return decode_result'{error_pos: 32'h00008000, corrected: true, detected: false}; // data[9]
+            syndrome == 6'h15 && width >= 11: return decode_result'{error_pos: 32'h00010000, corrected: true, detected: false}; // data[10]
+            syndrome == 6'h2a && width >= 12: return decode_result'{error_pos: 32'h00020000, corrected: true, detected: false}; // data[11]
+            syndrome == 6'h16 && width >= 13: return decode_result'{error_pos: 32'h00040000, corrected: true, detected: false}; // data[12]
+            syndrome == 6'h29 && width >= 14: return decode_result'{error_pos: 32'h00080000, corrected: true, detected: false}; // data[13]
+            syndrome == 6'h19 && width >= 15: return decode_result'{error_pos: 32'h00100000, corrected: true, detected: false}; // data[14]
+            syndrome == 6'h26 && width >= 16: return decode_result'{error_pos: 32'h00200000, corrected: true, detected: false}; // data[15]
+            syndrome == 6'h1a && width >= 17: return decode_result'{error_pos: 32'h00400000, corrected: true, detected: false}; // data[16]
+            syndrome == 6'h25 && width >= 18: return decode_result'{error_pos: 32'h00800000, corrected: true, detected: false}; // data[17]
+            syndrome == 6'h1c && width >= 19: return decode_result'{error_pos: 32'h01000000, corrected: true, detected: false}; // data[18]
+            syndrome == 6'h23 && width >= 20: return decode_result'{error_pos: 32'h02000000, corrected: true, detected: false}; // data[19]
+            syndrome == 6'h1f && width >= 21: return decode_result'{error_pos: 32'h04000000, corrected: true, detected: false}; // data[20]
+            syndrome == 6'h2f && width >= 22: return decode_result'{error_pos: 32'h08000000, corrected: true, detected: false}; // data[21]
+            syndrome == 6'h37 && width >= 23: return decode_result'{error_pos: 32'h10000000, corrected: true, detected: false}; // data[22]
+            syndrome == 6'h3b && width >= 24: return decode_result'{error_pos: 32'h20000000, corrected: true, detected: false}; // data[23]
+            syndrome == 6'h3d && width >= 25: return decode_result'{error_pos: 32'h40000000, corrected: true, detected: false}; // data[24]
+            syndrome == 6'h3e && width >= 26: return decode_result'{error_pos: 32'h80000000, corrected: true, detected: false}; // data[25]
+            default: return decode_result'{error_pos: 32'h00000000, corrected: false, detected: true}; // undefined syndrome / out-of-range (multiple-bit error)
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/hamming_57_7_pkg.veryl
+++ b/crates/std/veryl/src/ecc/hamming_57_7_pkg.veryl
@@ -1,0 +1,135 @@
+#[fmt(skip)]
+pub package hamming_57_7_pkg {
+    // data width = 57 check width = 7
+    // row[6]: 111111111111111001000011111111111111100000000000000000000 | 1000000
+    // row[5]: 111111110100010111111011101000000010010101010101010101010 | 0100000
+    // row[4]: 111100101011110111110100010111000010001010101010110101010 | 0010000
+    // row[3]: 110011101111001111101100011000101001001010110101001010110 | 0001000
+    // row[2]: 101110011110101111011110000100010101001101001011001011001 | 0000100
+    // row[1]: 110101011101111100111101000010011000110011001100101100101 | 0000010
+    // row[0]: 101011110011111010111100100001100100110100110010110010101 | 0000001
+
+    const DATA_WIDTH : u32 = 57;
+    const CHECK_WIDTH: u32 = 7;
+    const CODE_WIDTH : u32 = DATA_WIDTH + CHECK_WIDTH;
+
+    // Coefficient matrix for check-bit generation.
+    const ENCODE_MATRIX_ROW_0: bit<DATA_WIDTH> = 57'h15e7d790c9a6595; // check[0]
+    const ENCODE_MATRIX_ROW_1: bit<DATA_WIDTH> = 57'h1abbe7a13199965; // check[1]
+    const ENCODE_MATRIX_ROW_2: bit<DATA_WIDTH> = 57'h173d7bc22a69659; // check[2]
+    const ENCODE_MATRIX_ROW_3: bit<DATA_WIDTH> = 57'h19de7d8c5256a56; // check[3]
+    const ENCODE_MATRIX_ROW_4: bit<DATA_WIDTH> = 57'h1e57be8b84555aa; // check[4]
+    const ENCODE_MATRIX_ROW_5: bit<DATA_WIDTH> = 57'h1fe8bf7404aaaaa; // check[5]
+    const ENCODE_MATRIX_ROW_6: bit<DATA_WIDTH> = 57'h1fffc87fff00000; // check[6]
+
+    struct decode_result {
+        error_pos: logic<CODE_WIDTH>, // error position (one-hot, [CHECK_WIDTH-1:0]=check, upper=data)
+        corrected: logic            , // a single-bit error was located and corrected
+        detected : logic            , // an uncorrectable error was detected
+    }
+
+    /// Compute the check bits (AND with the coefficient matrix, then XOR reduction).
+    function encode (
+        data: input logic<DATA_WIDTH>,
+    ) -> logic<CHECK_WIDTH> {
+        var check: logic<CHECK_WIDTH>;
+        check[0] = ^(ENCODE_MATRIX_ROW_0 & data);
+        check[1] = ^(ENCODE_MATRIX_ROW_1 & data);
+        check[2] = ^(ENCODE_MATRIX_ROW_2 & data);
+        check[3] = ^(ENCODE_MATRIX_ROW_3 & data);
+        check[4] = ^(ENCODE_MATRIX_ROW_4 & data);
+        check[5] = ^(ENCODE_MATRIX_ROW_5 & data);
+        check[6] = ^(ENCODE_MATRIX_ROW_6 & data);
+        return check;
+    }
+
+    /// Compute the syndrome (received check bits ^ recomputed check bits).
+    function calc_syndrome (
+        code: input logic<CODE_WIDTH>
+    ) -> logic<CHECK_WIDTH> {
+        var data : logic<DATA_WIDTH> ;
+        var check: logic<CHECK_WIDTH>;
+        data  = code[CODE_WIDTH-1-:DATA_WIDTH];
+        check = code[0+:CHECK_WIDTH];
+        return encode(data) ^ check;
+    }
+
+    /// Determine the error position and flags (corrected/detected) from the syndrome.
+    /// A data-bit correction is honored only while its index is below the active width.
+    function decode (
+        syndrome: input logic<CHECK_WIDTH>,
+        width   : input u32               ,
+    ) -> decode_result {
+        // Boolean-selector switch (SV: case (1'b1)); the syndrome values are mutually
+        // exclusive, so the branches stay parallel while sharing the width gate.
+        // A data branch that fails its width guard falls through to default -> detected.
+        switch {
+            syndrome == 7'h00: return decode_result'{error_pos: 64'h0000000000000000, corrected: false, detected: false}; // no error
+            syndrome == 7'h01: return decode_result'{error_pos: 64'h0000000000000001, corrected: true, detected: false}; // check[0]
+            syndrome == 7'h02: return decode_result'{error_pos: 64'h0000000000000002, corrected: true, detected: false}; // check[1]
+            syndrome == 7'h04: return decode_result'{error_pos: 64'h0000000000000004, corrected: true, detected: false}; // check[2]
+            syndrome == 7'h08: return decode_result'{error_pos: 64'h0000000000000008, corrected: true, detected: false}; // check[3]
+            syndrome == 7'h10: return decode_result'{error_pos: 64'h0000000000000010, corrected: true, detected: false}; // check[4]
+            syndrome == 7'h20: return decode_result'{error_pos: 64'h0000000000000020, corrected: true, detected: false}; // check[5]
+            syndrome == 7'h40: return decode_result'{error_pos: 64'h0000000000000040, corrected: true, detected: false}; // check[6]
+            syndrome == 7'h07 && width >= 1: return decode_result'{error_pos: 64'h0000000000000080, corrected: true, detected: false}; // data[0]
+            syndrome == 7'h38 && width >= 2: return decode_result'{error_pos: 64'h0000000000000100, corrected: true, detected: false}; // data[1]
+            syndrome == 7'h0b && width >= 3: return decode_result'{error_pos: 64'h0000000000000200, corrected: true, detected: false}; // data[2]
+            syndrome == 7'h34 && width >= 4: return decode_result'{error_pos: 64'h0000000000000400, corrected: true, detected: false}; // data[3]
+            syndrome == 7'h0d && width >= 5: return decode_result'{error_pos: 64'h0000000000000800, corrected: true, detected: false}; // data[4]
+            syndrome == 7'h32 && width >= 6: return decode_result'{error_pos: 64'h0000000000001000, corrected: true, detected: false}; // data[5]
+            syndrome == 7'h0e && width >= 7: return decode_result'{error_pos: 64'h0000000000002000, corrected: true, detected: false}; // data[6]
+            syndrome == 7'h31 && width >= 8: return decode_result'{error_pos: 64'h0000000000004000, corrected: true, detected: false}; // data[7]
+            syndrome == 7'h13 && width >= 9: return decode_result'{error_pos: 64'h0000000000008000, corrected: true, detected: false}; // data[8]
+            syndrome == 7'h2c && width >= 10: return decode_result'{error_pos: 64'h0000000000010000, corrected: true, detected: false}; // data[9]
+            syndrome == 7'h15 && width >= 11: return decode_result'{error_pos: 64'h0000000000020000, corrected: true, detected: false}; // data[10]
+            syndrome == 7'h2a && width >= 12: return decode_result'{error_pos: 64'h0000000000040000, corrected: true, detected: false}; // data[11]
+            syndrome == 7'h16 && width >= 13: return decode_result'{error_pos: 64'h0000000000080000, corrected: true, detected: false}; // data[12]
+            syndrome == 7'h29 && width >= 14: return decode_result'{error_pos: 64'h0000000000100000, corrected: true, detected: false}; // data[13]
+            syndrome == 7'h19 && width >= 15: return decode_result'{error_pos: 64'h0000000000200000, corrected: true, detected: false}; // data[14]
+            syndrome == 7'h26 && width >= 16: return decode_result'{error_pos: 64'h0000000000400000, corrected: true, detected: false}; // data[15]
+            syndrome == 7'h1a && width >= 17: return decode_result'{error_pos: 64'h0000000000800000, corrected: true, detected: false}; // data[16]
+            syndrome == 7'h25 && width >= 18: return decode_result'{error_pos: 64'h0000000001000000, corrected: true, detected: false}; // data[17]
+            syndrome == 7'h1c && width >= 19: return decode_result'{error_pos: 64'h0000000002000000, corrected: true, detected: false}; // data[18]
+            syndrome == 7'h23 && width >= 20: return decode_result'{error_pos: 64'h0000000004000000, corrected: true, detected: false}; // data[19]
+            syndrome == 7'h43 && width >= 21: return decode_result'{error_pos: 64'h0000000008000000, corrected: true, detected: false}; // data[20]
+            syndrome == 7'h4c && width >= 22: return decode_result'{error_pos: 64'h0000000010000000, corrected: true, detected: false}; // data[21]
+            syndrome == 7'h70 && width >= 23: return decode_result'{error_pos: 64'h0000000020000000, corrected: true, detected: false}; // data[22]
+            syndrome == 7'h45 && width >= 24: return decode_result'{error_pos: 64'h0000000040000000, corrected: true, detected: false}; // data[23]
+            syndrome == 7'h4a && width >= 25: return decode_result'{error_pos: 64'h0000000080000000, corrected: true, detected: false}; // data[24]
+            syndrome == 7'h46 && width >= 26: return decode_result'{error_pos: 64'h0000000100000000, corrected: true, detected: false}; // data[25]
+            syndrome == 7'h49 && width >= 27: return decode_result'{error_pos: 64'h0000000200000000, corrected: true, detected: false}; // data[26]
+            syndrome == 7'h51 && width >= 28: return decode_result'{error_pos: 64'h0000000400000000, corrected: true, detected: false}; // data[27]
+            syndrome == 7'h52 && width >= 29: return decode_result'{error_pos: 64'h0000000800000000, corrected: true, detected: false}; // data[28]
+            syndrome == 7'h54 && width >= 30: return decode_result'{error_pos: 64'h0000001000000000, corrected: true, detected: false}; // data[29]
+            syndrome == 7'h68 && width >= 31: return decode_result'{error_pos: 64'h0000002000000000, corrected: true, detected: false}; // data[30]
+            syndrome == 7'h58 && width >= 32: return decode_result'{error_pos: 64'h0000004000000000, corrected: true, detected: false}; // data[31]
+            syndrome == 7'h61 && width >= 33: return decode_result'{error_pos: 64'h0000008000000000, corrected: true, detected: false}; // data[32]
+            syndrome == 7'h62 && width >= 34: return decode_result'{error_pos: 64'h0000010000000000, corrected: true, detected: false}; // data[33]
+            syndrome == 7'h64 && width >= 35: return decode_result'{error_pos: 64'h0000020000000000, corrected: true, detected: false}; // data[34]
+            syndrome == 7'h1f && width >= 36: return decode_result'{error_pos: 64'h0000040000000000, corrected: true, detected: false}; // data[35]
+            syndrome == 7'h2f && width >= 37: return decode_result'{error_pos: 64'h0000080000000000, corrected: true, detected: false}; // data[36]
+            syndrome == 7'h37 && width >= 38: return decode_result'{error_pos: 64'h0000100000000000, corrected: true, detected: false}; // data[37]
+            syndrome == 7'h3b && width >= 39: return decode_result'{error_pos: 64'h0000200000000000, corrected: true, detected: false}; // data[38]
+            syndrome == 7'h7c && width >= 40: return decode_result'{error_pos: 64'h0000400000000000, corrected: true, detected: false}; // data[39]
+            syndrome == 7'h3d && width >= 41: return decode_result'{error_pos: 64'h0000800000000000, corrected: true, detected: false}; // data[40]
+            syndrome == 7'h3e && width >= 42: return decode_result'{error_pos: 64'h0001000000000000, corrected: true, detected: false}; // data[41]
+            syndrome == 7'h4f && width >= 43: return decode_result'{error_pos: 64'h0002000000000000, corrected: true, detected: false}; // data[42]
+            syndrome == 7'h73 && width >= 44: return decode_result'{error_pos: 64'h0004000000000000, corrected: true, detected: false}; // data[43]
+            syndrome == 7'h57 && width >= 45: return decode_result'{error_pos: 64'h0008000000000000, corrected: true, detected: false}; // data[44]
+            syndrome == 7'h5b && width >= 46: return decode_result'{error_pos: 64'h0010000000000000, corrected: true, detected: false}; // data[45]
+            syndrome == 7'h5d && width >= 47: return decode_result'{error_pos: 64'h0020000000000000, corrected: true, detected: false}; // data[46]
+            syndrome == 7'h6e && width >= 48: return decode_result'{error_pos: 64'h0040000000000000, corrected: true, detected: false}; // data[47]
+            syndrome == 7'h5e && width >= 49: return decode_result'{error_pos: 64'h0080000000000000, corrected: true, detected: false}; // data[48]
+            syndrome == 7'h67 && width >= 50: return decode_result'{error_pos: 64'h0100000000000000, corrected: true, detected: false}; // data[49]
+            syndrome == 7'h79 && width >= 51: return decode_result'{error_pos: 64'h0200000000000000, corrected: true, detected: false}; // data[50]
+            syndrome == 7'h6b && width >= 52: return decode_result'{error_pos: 64'h0400000000000000, corrected: true, detected: false}; // data[51]
+            syndrome == 7'h6d && width >= 53: return decode_result'{error_pos: 64'h0800000000000000, corrected: true, detected: false}; // data[52]
+            syndrome == 7'h76 && width >= 54: return decode_result'{error_pos: 64'h1000000000000000, corrected: true, detected: false}; // data[53]
+            syndrome == 7'h75 && width >= 55: return decode_result'{error_pos: 64'h2000000000000000, corrected: true, detected: false}; // data[54]
+            syndrome == 7'h7a && width >= 56: return decode_result'{error_pos: 64'h4000000000000000, corrected: true, detected: false}; // data[55]
+            syndrome == 7'h7f && width >= 57: return decode_result'{error_pos: 64'h8000000000000000, corrected: true, detected: false}; // data[56]
+            default: return decode_result'{error_pos: 64'h0000000000000000, corrected: false, detected: true}; // undefined syndrome / out-of-range (multiple-bit error)
+        }
+    }
+}

--- a/crates/std/veryl/src/ecc/test_ecc.veryl
+++ b/crates/std/veryl/src/ecc/test_ecc.veryl
@@ -1,0 +1,338 @@
+module test_ecc_wrapper #(
+    param DATA_WIDTH: u32 = 8                                  ,
+    param CODE_WIDTH: u32 = ecc_pkg::get_code_width(DATA_WIDTH),
+) (
+    i_data     : input  logic<DATA_WIDTH>,
+    i_error    : input  logic<CODE_WIDTH>,
+    o_data     : output logic<DATA_WIDTH>,
+    o_corrected: output logic            ,
+    o_detected : output logic            ,
+) {
+    var code      : logic<CODE_WIDTH>;
+    var code_error: logic<CODE_WIDTH>;
+
+    inst u_encoder: ecc_encoder #(
+        WIDTH: DATA_WIDTH,
+    ) (
+        i_enable: true  ,
+        i_data  : i_data,
+        o_code  : code  ,
+    );
+
+    assign code_error = code ^ i_error;
+
+    inst u_decoder: ecc_decoder #(
+        WIDTH: DATA_WIDTH,
+    ) (
+        i_enable   : true       ,
+        i_code     : code_error ,
+        o_data     : o_data     ,
+        o_corrected: o_corrected,
+        o_detected : o_detected ,
+    );
+}
+
+#[test(test_ecc_8)]
+module test_ecc_8 {
+    const CODE_WIDTH: u32 = ecc_pkg::get_code_width(8);
+
+    inst u_clock: $tb::clock_gen;
+
+    var data_gen : $tb::random::<u8>            ;
+    var data     : logic            <2, 8>      ;
+    var error    : logic            <CODE_WIDTH>;
+    var corrected: logic                        ;
+    var detected : logic                        ;
+
+    inst duv: test_ecc_wrapper #(
+        DATA_WIDTH: 8,
+    ) (
+        i_data     : data[0]  ,
+        i_error    : error    ,
+        o_data     : data[1]  ,
+        o_corrected: corrected,
+        o_detected : detected ,
+    );
+
+    initial {
+        data[0] = '0;
+        error   = '0;
+
+        for _i in 0..10 {
+            data[0] = data_gen.get();
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(!corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..CODE_WIDTH {
+            data[0]  = data_gen.get();
+            error    = '0;
+            error[i] = '1;
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..(CODE_WIDTH / 2) {
+            data[0]               = data_gen.get();
+            error                 = '0;
+            error[i]              = '1;
+            error[CODE_WIDTH - i] = '1;
+
+            u_clock.next();
+            $assert(!corrected);
+            $assert(detected);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_ecc_16)]
+module test_ecc_16 {
+    const CODE_WIDTH: u32 = ecc_pkg::get_code_width(16);
+
+    inst u_clock: $tb::clock_gen;
+
+    var data_gen : $tb::random::<u16>            ;
+    var data     : logic             <2, 16>     ;
+    var error    : logic             <CODE_WIDTH>;
+    var corrected: logic                         ;
+    var detected : logic                         ;
+
+    inst duv: test_ecc_wrapper #(
+        DATA_WIDTH: 16,
+    ) (
+        i_data     : data[0]  ,
+        i_error    : error    ,
+        o_data     : data[1]  ,
+        o_corrected: corrected,
+        o_detected : detected ,
+    );
+
+    initial {
+        data[0] = '0;
+        error   = '0;
+
+        for _i in 0..10 {
+            data[0] = data_gen.get();
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(!corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..CODE_WIDTH {
+            data[0]  = data_gen.get();
+            error    = '0;
+            error[i] = '1;
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..(CODE_WIDTH / 2) {
+            data[0]               = data_gen.get();
+            error                 = '0;
+            error[i]              = '1;
+            error[CODE_WIDTH - i] = '1;
+
+            u_clock.next();
+            $assert(!corrected);
+            $assert(detected);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_ecc_32)]
+module test_ecc_32 {
+    const CODE_WIDTH: u32 = ecc_pkg::get_code_width(32);
+
+    inst u_clock: $tb::clock_gen;
+
+    var data_gen : $tb::random::<u32>            ;
+    var data     : logic             <2, 32>     ;
+    var error    : logic             <CODE_WIDTH>;
+    var corrected: logic                         ;
+    var detected : logic                         ;
+
+    inst duv: test_ecc_wrapper #(
+        DATA_WIDTH: 32,
+    ) (
+        i_data     : data[0]  ,
+        i_error    : error    ,
+        o_data     : data[1]  ,
+        o_corrected: corrected,
+        o_detected : detected ,
+    );
+
+    initial {
+        data[0] = '0;
+        error   = '0;
+
+        for _i in 0..10 {
+            data[0] = data_gen.get();
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(!corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..CODE_WIDTH {
+            data[0]  = data_gen.get();
+            error    = '0;
+            error[i] = '1;
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..(CODE_WIDTH / 2) {
+            data[0]               = data_gen.get();
+            error                 = '0;
+            error[i]              = '1;
+            error[CODE_WIDTH - i] = '1;
+
+            u_clock.next();
+            $assert(!corrected);
+            $assert(detected);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_ecc_64)]
+module test_ecc_64 {
+    const CODE_WIDTH: u32 = ecc_pkg::get_code_width(64);
+
+    inst u_clock: $tb::clock_gen;
+
+    var data_gen : $tb::random::<u64>            ;
+    var data     : logic             <2, 64>     ;
+    var error    : logic             <CODE_WIDTH>;
+    var corrected: logic                         ;
+    var detected : logic                         ;
+
+    inst duv: test_ecc_wrapper #(
+        DATA_WIDTH: 64,
+    ) (
+        i_data     : data[0]  ,
+        i_error    : error    ,
+        o_data     : data[1]  ,
+        o_corrected: corrected,
+        o_detected : detected ,
+    );
+
+    initial {
+        data[0] = '0;
+        error   = '0;
+
+        for _i in 0..10 {
+            data[0] = data_gen.get();
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(!corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..CODE_WIDTH {
+            data[0]  = data_gen.get();
+            error    = '0;
+            error[i] = '1;
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..(CODE_WIDTH / 2) {
+            data[0]               = data_gen.get();
+            error                 = '0;
+            error[i]              = '1;
+            error[CODE_WIDTH - i] = '1;
+
+            u_clock.next();
+            $assert(!corrected);
+            $assert(detected);
+        }
+
+        $finish();
+    }
+}
+
+#[test(test_ecc_128)]
+module test_ecc_128 {
+    const CODE_WIDTH: u32 = ecc_pkg::get_code_width(128);
+
+    inst u_clock: $tb::clock_gen;
+
+    var data_gen : $tb::random::<u64>            ;
+    var data     : logic             <2, 128>    ;
+    var error    : logic             <CODE_WIDTH>;
+    var corrected: logic                         ;
+    var detected : logic                         ;
+
+    inst duv: test_ecc_wrapper #(
+        DATA_WIDTH: 128,
+    ) (
+        i_data     : data[0]  ,
+        i_error    : error    ,
+        o_data     : data[1]  ,
+        o_corrected: corrected,
+        o_detected : detected ,
+    );
+
+    initial {
+        data[0] = '0;
+        error   = '0;
+
+        for _i in 0..10 {
+            data[0] = {data_gen.get(), data_gen.get()};
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(!corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..CODE_WIDTH {
+            data[0]  = {data_gen.get(), data_gen.get()};
+            error    = '0;
+            error[i] = '1;
+
+            u_clock.next();
+            $assert(data[0] == data[1]);
+            $assert(corrected);
+            $assert(!detected);
+        }
+
+        for i in 0..(CODE_WIDTH / 2) {
+            data[0]               = {data_gen.get(), data_gen.get()};
+            error                 = '0;
+            error[i]              = '1;
+            error[CODE_WIDTH - i] = '1;
+
+            u_clock.next();
+            $assert(!corrected);
+            $assert(detected);
+        }
+
+        $finish();
+    }
+}


### PR DESCRIPTION
This PR adds ECC encoder and decoder modules as the `std` libaray.
These ECC modules supports:

* Data width: 1 - 247 bits
* 1 error correct/2 errors detect with Hamming code