### PR TITLE
Introduce `$prop` namespace

### DIFF
--- a/Veryl.lock
+++ b/Veryl.lock
@@ -45,19 +45,19 @@ revision = "52fc06237c5b70d42d67ea0910874ba111a6ef98"
 [projects.properties]
 
 [[projects]]
-name = "veryl_sample4"
-source = "testcases/sample"
-dependencies = []
-
-[projects.properties]
-QUX_0_VALUE = 16
-QUX_1_VALUE = false
-
-[[projects]]
 name = "veryl_sample5"
 source = "testcases/sample"
 dependencies = []
 
 [projects.properties]
-QUX_0_VALUE = 32
-QUX_1_VALUE = true
+QUX_0 = 32
+QUX_1 = true
+
+[[projects]]
+name = "veryl_sample4"
+source = "testcases/sample"
+dependencies = []
+
+[projects.properties]
+QUX_0 = 16
+QUX_1 = false

--- a/Veryl.toml
+++ b/Veryl.toml
@@ -31,5 +31,5 @@ compile_args = ["-full64"]
 veryl_sample  = {version = "0.16.0", github = "veryl-lang/sample"}
 veryl_sample2 = {version = "0.17.0", project = "veryl_sample", github = "veryl-lang/sample"}
 veryl_sample3 = {version = "0.18.0", project = "veryl_sample", git = "https://github.com/veryl-lang/sample"}
-veryl_sample4 = {path = "testcases/sample", properties = {QUX_0_VALUE = 16}}
-veryl_sample5 = {path = "testcases/sample", properties = {QUX_1_VALUE = true}}
+veryl_sample4 = {path = "testcases/sample", properties = {QUX_0 = 16}}
+veryl_sample5 = {path = "testcases/sample", properties = {QUX_1 = true}}

--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -77,12 +77,12 @@ fn insert_namespace_symbol(name: &str, public: bool) -> StrId {
 }
 
 fn insert_project_property_symbols(
-    prject_name: StrId,
+    project_name: StrId,
     properties: &BTreeMap<String, ProjectProperty>,
 ) {
-    let mut namespace = Namespace::new();
-    namespace.push(prject_name);
+    let prop_symbol = create_prop_namespace_symbol(project_name);
 
+    let namespace = prop_symbol.inner_namespace();
     for (prop_name, prop_value) in properties {
         let token = Token::from_external_text(prop_name);
         let value_property = ProjectPropertyValueProperty::new(prop_value, token.into());
@@ -95,6 +95,23 @@ fn insert_project_property_symbols(
         );
         symbol_table::insert(&token, symbol);
     }
+}
+
+fn create_prop_namespace_symbol(project_name: StrId) -> Symbol {
+    let mut namespace = Namespace::new();
+    namespace.push(project_name);
+
+    let token = Token::builtin_text("$prop");
+    let symbol = Symbol::new(
+        &token,
+        SymbolKind::PropNamespace,
+        &namespace,
+        false,
+        DocComment::default(),
+    );
+    symbol_table::insert(&token, symbol.clone());
+
+    symbol
 }
 
 impl Analyzer {

--- a/crates/analyzer/src/sv_system_function.rs
+++ b/crates/analyzer/src/sv_system_function.rs
@@ -5,7 +5,7 @@ use crate::symbol::{
 };
 use crate::symbol_table::SymbolTable;
 use veryl_parser::token_range::TokenRange;
-use veryl_parser::veryl_token::{Token, TokenSource, VerylToken};
+use veryl_parser::veryl_token::{Token, VerylToken};
 
 pub struct SvSystemFunction {
     pub name: String,
@@ -28,12 +28,12 @@ pub fn insert_symbols(symbol_table: &mut SymbolTable, namespace: &Namespace) {
     let mut namespace = namespace.clone();
 
     for func in sv_system_functions() {
-        let token = Token::new(&func.name, 0, 0, 0, 0, TokenSource::Builtin);
+        let token = Token::builtin_text(&func.name);
         let mut ports = Vec::new();
 
         namespace.push(token.text);
         for (name, direction) in &func.ports {
-            let token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
+            let token = Token::builtin_text(name);
             let r#type = Type {
                 modifier: vec![],
                 kind: TypeKind::Any,

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -1047,6 +1047,7 @@ pub enum SymbolKind {
     Embed,
     TbComponent(TbComponentProperty),
     ProjectProperty(ProjectPropertyValueProperty),
+    PropNamespace,
 }
 
 impl SymbolKind {
@@ -1141,6 +1142,7 @@ impl SymbolKind {
             SymbolKind::Embed => "embed".to_string(),
             SymbolKind::TbComponent(x) => format!("testbench {}", x.kind),
             SymbolKind::ProjectProperty(_) => "project property".to_string(),
+            SymbolKind::PropNamespace => "$prop namespace".to_string(),
         }
     }
 
@@ -1445,6 +1447,7 @@ impl fmt::Display for SymbolKind {
                     x.value.value_string()
                 )
             }
+            SymbolKind::PropNamespace => "$prop namespace".to_string(),
         };
         text.fmt(f)
     }

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -205,7 +205,7 @@ impl SymbolTable {
         let namespace = Namespace::new();
 
         for func in DEFINED_NAMESPACES {
-            let token = Token::new(func, 0, 0, 0, 0, TokenSource::Builtin);
+            let token = Token::builtin_text(func);
             let symbol = Symbol::new(
                 &token,
                 SymbolKind::Namespace,
@@ -688,7 +688,7 @@ impl SymbolTable {
             SymbolKind::AliasPackage(x) => {
                 context = self.trace_type_path(context, &x.target)?;
             }
-            SymbolKind::Enum(_) | SymbolKind::Namespace => {
+            SymbolKind::Enum(_) | SymbolKind::Namespace | SymbolKind::PropNamespace => {
                 context.set_inner(found);
                 context.inner = true;
             }
@@ -824,6 +824,7 @@ impl SymbolTable {
             _ => false,
         };
         let via_namespace = matches!(last_found.kind, SymbolKind::Namespace);
+        let via_prop_namespace = matches!(last_found.kind, SymbolKind::PropNamespace);
         let via_tb_component = matches!(last_found_type, Some(SymbolKind::TbComponent(_)));
 
         match &found.kind {
@@ -863,6 +864,8 @@ impl SymbolTable {
                 // defined in a packge or for generic component defined in other project
                 via_pacakge || via_namespace
             }
+            SymbolKind::ProjectProperty(_) => via_prop_namespace,
+            SymbolKind::PropNamespace => !via_namespace,
             _ => via_namespace,
         }
     }

--- a/crates/analyzer/src/tb_component.rs
+++ b/crates/analyzer/src/tb_component.rs
@@ -7,7 +7,7 @@ use crate::symbol::{
 use crate::symbol_path::{GenericSymbol, GenericSymbolPath, GenericSymbolPathKind};
 use crate::symbol_table::SymbolTable;
 use veryl_parser::token_range::TokenRange;
-use veryl_parser::veryl_token::{Token, TokenSource, VerylToken};
+use veryl_parser::veryl_token::{Token, VerylToken};
 
 /// A builtin `Type` with no width/array (widths for fixed types are derived
 /// from the `TypeKind` itself).
@@ -54,13 +54,13 @@ fn insert_method(
     port_defs: &[(&str, Direction)],
     ret: Option<Type>,
 ) {
-    let func_token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
+    let func_token = Token::builtin_text(name);
     let mut func_ns = parent_ns.clone();
     func_ns.push(func_token.text);
 
     let mut ports = Vec::new();
     for (port_name, direction) in port_defs {
-        let port_token = Token::new(port_name, 0, 0, 0, 0, TokenSource::Builtin);
+        let port_token = Token::builtin_text(port_name);
         let port_type = Type {
             modifier: vec![],
             kind: TypeKind::Any,
@@ -125,11 +125,11 @@ fn insert_method(
 /// registered; the component interface is only known at simulator load time.
 pub fn insert_external_components(names: &[&str]) {
     let mut ns = Namespace::new();
-    let component_token = Token::new("$comp", 0, 0, 0, 0, TokenSource::Builtin);
+    let component_token = Token::builtin_text("$comp");
     ns.push(component_token.text);
 
     for name in names {
-        let token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
+        let token = Token::builtin_text(name);
         let symbol = Symbol::new(
             &token,
             SymbolKind::TbComponent(TbComponentProperty {
@@ -151,10 +151,10 @@ pub fn insert_external_components(names: &[&str]) {
 /// component keys never contain `::`, so the two sets cannot collide.
 pub fn insert_dependency_components(project: &str, names: &[&str]) {
     let mut ns = Namespace::new();
-    let component_token = Token::new("$comp", 0, 0, 0, 0, TokenSource::Builtin);
+    let component_token = Token::builtin_text("$comp");
     ns.push(component_token.text);
 
-    let project_token = Token::new(project, 0, 0, 0, 0, TokenSource::Builtin);
+    let project_token = Token::builtin_text(project);
     let project_symbol = Symbol::new(
         &project_token,
         SymbolKind::Namespace,
@@ -166,7 +166,7 @@ pub fn insert_dependency_components(project: &str, names: &[&str]) {
     ns.push(project_token.text);
 
     for name in names {
-        let token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
+        let token = Token::builtin_text(name);
         let key = veryl_parser::resource_table::insert_str(&format!("{project}::{name}"));
         let symbol = Symbol::new(
             &token,
@@ -190,7 +190,7 @@ fn insert_component(
     name: &str,
     kind: TbComponentKind,
 ) -> Namespace {
-    let token = Token::new(name, 0, 0, 0, 0, TokenSource::Builtin);
+    let token = Token::builtin_text(name);
     let symbol = Symbol::new(
         &token,
         SymbolKind::TbComponent(TbComponentProperty {
@@ -253,14 +253,14 @@ fn insert_file(symbol_table: &mut SymbolTable, tb_ns: &Namespace) {
 }
 
 fn insert_random(symbol_table: &mut SymbolTable, tb_ns: &Namespace) {
-    let random_token = Token::new("random", 0, 0, 0, 0, TokenSource::Builtin);
+    let random_token = Token::builtin_text("random");
     let mut ns = tb_ns.clone();
     ns.push(random_token.text);
 
     // Synthesize the generic type parameter `T` inside the `$tb::random`
     // namespace so member methods can return `-> T`, resolved through the
     // normal generic pipeline at the call site.
-    let t_token = Token::new("T", 0, 0, 0, 0, TokenSource::Builtin);
+    let t_token = Token::builtin_text("T");
     let t_symbol = Symbol::new(
         &t_token,
         SymbolKind::GenericParameter(GenericParameterProperty {
@@ -325,7 +325,7 @@ pub fn insert_symbols(symbol_table: &mut SymbolTable, namespace: &Namespace) {
     let mut tb_ns = namespace.clone();
 
     // Push into $tb namespace (already created by DEFINED_NAMESPACES)
-    let tb_token = Token::new("$tb", 0, 0, 0, 0, TokenSource::Builtin);
+    let tb_token = Token::builtin_text("$tb");
     tb_ns.push(tb_token.text);
 
     insert_clock_gen(symbol_table, &tb_ns);

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -17010,14 +17010,14 @@ fn scope_tree_matches_namespace() {
 fn project_properties() {
     let code = r#"
     module ModuleA {
-        const A: i64   = PROP_A;
-        const B: bbool = PROP_B;
+        const A: i64   = $prop::A;
+        const B: bbool = $prop::B;
     }
     "#;
 
     let mut properties = HashMap::new();
-    properties.insert("PROP_A".to_string(), ProjectProperty::Int(32));
-    properties.insert("PROP_B".to_string(), ProjectProperty::Bool(true));
+    properties.insert("A".to_string(), ProjectProperty::Int(32));
+    properties.insert("B".to_string(), ProjectProperty::Bool(true));
 
     let errors = analyze_with_project_properties(code, properties);
     assert!(errors.is_empty());

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -6800,7 +6800,8 @@ pub fn symbol_string(
         | SymbolKind::EnumMemberMangled
         | SymbolKind::Test(_)
         | SymbolKind::Embed
-        | SymbolKind::TbComponent(_) => {
+        | SymbolKind::TbComponent(_)
+        | SymbolKind::PropNamespace => {
             unreachable!()
         }
     }

--- a/crates/emitter/src/tests.rs
+++ b/crates/emitter/src/tests.rs
@@ -4263,8 +4263,8 @@ module ModuleA (
 #[test]
 fn project_properties() {
     let code = r#"module ModuleA {
-    const A: i64   = PROP_A;
-    const B: bbool = PROP_B;
+    const A: i64   = $prop::A;
+    const B: bbool = $prop::B;
 }
 "#;
 
@@ -4278,10 +4278,10 @@ endmodule
     let mut metadata = Metadata::create_default("prj").unwrap();
     metadata
         .properties
-        .insert("PROP_A".to_string(), ProjectProperty::Int(32));
+        .insert("A".to_string(), ProjectProperty::Int(32));
     metadata
         .properties
-        .insert("PROP_B".to_string(), ProjectProperty::Bool(true));
+        .insert("B".to_string(), ProjectProperty::Bool(true));
 
     let ret = if cfg!(windows) {
         emit(&metadata, code).replace("\r\n", "\n")

--- a/crates/languageserver/src/server.rs
+++ b/crates/languageserver/src/server.rs
@@ -441,6 +441,7 @@ impl Server {
                     VerylSymbolKind::Embed => SymbolKind::NAMESPACE,
                     VerylSymbolKind::TbComponent(_) => SymbolKind::MODULE,
                     VerylSymbolKind::ProjectProperty(_) => SymbolKind::CONSTANT,
+                    VerylSymbolKind::PropNamespace => SymbolKind::NAMESPACE,
                 };
                 if let Some(location) = to_location(&symbol.token) {
                     #[allow(deprecated)]
@@ -1668,12 +1669,11 @@ mod tests {
     #[test]
     fn external_component_member_completion() {
         use veryl_analyzer::symbol::{DocComment, TbComponentProperty};
-        use veryl_parser::veryl_token::TokenSource;
 
         let key = resource_table::insert_str("golden");
         component_manifest_table::insert(key, manifest());
 
-        let token = Token::new("golden", 0, 0, 0, 0, TokenSource::Builtin);
+        let token = Token::builtin_text("golden");
         let symbol = Symbol::new(
             &token,
             VerylSymbolKind::TbComponent(TbComponentProperty {

--- a/crates/parser/src/veryl_token.rs
+++ b/crates/parser/src/veryl_token.rs
@@ -117,6 +117,10 @@ impl Token {
         Self::new(text, 0, 0, 0, 0, TokenSource::External)
     }
 
+    pub fn builtin_text(text: &str) -> Self {
+        Self::new(text, 0, 0, 0, 0, TokenSource::Builtin)
+    }
+
     pub fn generate(text: StrId, path: PathId) -> Self {
         let id = resource_table::new_token_id();
         Token {

--- a/testcases/sample/Veryl.toml
+++ b/testcases/sample/Veryl.toml
@@ -3,8 +3,8 @@ name    = "veryl_sample"
 version = "0.1.0"
 
 [properties]
-QUX_0_VALUE = 32
-QUX_1_VALUE = false
+QUX_0 = 32
+QUX_1 = false
 
 [build]
 clock_type    = "posedge"

--- a/testcases/sample/src/qux_pkg.veryl
+++ b/testcases/sample/src/qux_pkg.veryl
@@ -1,4 +1,4 @@
 pub package qux_pkg {
-    const QUX_0: i64   = QUX_0_VALUE;
-    const QUX_1: bbool = QUX_1_VALUE;
+    const QUX_0: i64   = $prop::QUX_0;
+    const QUX_1: bbool = $prop::QUX_1;
 }


### PR DESCRIPTION
close veryl-lang/veryl#3111

Symbol for `$prob` namespace is inserted directly under the project namespace. Project properties are inserted into the namespace.