### PR TITLE
unalias base path of rust style import

### DIFF
--- a/crates/analyzer/src/reference_table.rs
+++ b/crates/analyzer/src/reference_table.rs
@@ -811,7 +811,9 @@ impl ReferenceTable {
                     self.check_complex_identifier(&arg.into(), &token, false);
                 }
                 ReferenceCandidate::ImportItem { base, arg } => {
-                    let Ok(base_symbol) = symbol_table::resolve(base) else {
+                    let mut base_path: GenericSymbolPath = base.into();
+                    base_path.unalias(None);
+                    let Ok(base_symbol) = symbol_table::resolve(&base_path) else {
                         continue;
                     };
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -6549,6 +6549,22 @@ fn undefined_identifier() {
 
     let errors = analyze_multiple_inputs(&inputs);
     assert!(errors.is_empty());
+
+    let code = r#"
+    package ab_pkg::<a: u32, b: u32> {
+        const A: u32 = a;
+        const B: u32 = b;
+    }
+    alias package ab_16_32_pkg = ab_pkg::<16, 32>;
+    module c_module {
+        import ab_16_32_pkg::{A, B};
+        let _a: u32 = A;
+        let _b: u32 = B;
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(errors.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
fix veryl-lang/veryl#3126

Base path of rust style import should be unaliased if it point alias package but currently not.
This causes #3126.