### PR TITLE
fix(simulator): support array literal function arguments

### DIFF
--- a/crates/analyzer/src/ir/function.rs
+++ b/crates/analyzer/src/ir/function.rs
@@ -1,5 +1,7 @@
 use crate::conv::Context;
-use crate::conv::utils::{check_compatibility, check_implicit_clock_conversion};
+use crate::conv::utils::{
+    check_compatibility, check_implicit_clock_conversion, eval_array_literal,
+};
 use crate::ir::assign_table::{AssignContext, AssignTable};
 use crate::ir::ff_table::AssignTarget;
 use crate::ir::{
@@ -523,6 +525,17 @@ impl Arguments {
                 match direction {
                     Direction::Input => {
                         let arg_type = &arg.comptime.r#type;
+                        // Argument expressions are initially converted without a
+                        // destination type. Apply the resolved formal shape here,
+                        // where the actual-to-formal binding is first available.
+                        if matches!(expr, Expression::ArrayLiteral(..)) {
+                            eval_array_literal(
+                                context,
+                                Some(&arg_type.array),
+                                Some(arg_type.width()),
+                                &mut expr,
+                            )?;
+                        }
                         if arg_type.is_clock() || arg_type.is_reset() {
                             let expr_comptime = expr.eval_comptime(context, None);
                             let expr_token = expr_comptime.token;

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -15680,6 +15680,40 @@ fn multiple_default_array_literal() {
 }
 
 #[test]
+fn invalid_array_literal_function_arguments() {
+    let code = r#"
+    module ModuleA (
+        n: input logic<2>,
+        out: output logic<8>,
+    ) {
+        function pick (x: input logic<8> [2]) -> logic<8> {
+            return x[1];
+        }
+        assign out = pick('{8'h11 repeat n});
+    }
+    "#;
+
+    let errors = analyze_with_ir(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(errors[0], AnalyzerError::InvalidOperand { .. }));
+
+    let code = r#"
+    module ModuleA (
+        out: output logic<8>,
+    ) {
+        function pick (x: input logic<8> [2]) -> logic<8> {
+            return x[1];
+        }
+        assign out = pick('{default: 8'h11, default: 8'h22});
+    }
+    "#;
+
+    let errors = analyze_with_ir(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(errors[0], AnalyzerError::MultipleDefault { .. }));
+}
+
+#[test]
 fn mismatch_dimension_array() {
     let code = r#"
     module ModuleA {

--- a/crates/simulator/src/ir/statement.rs
+++ b/crates/simulator/src/ir/statement.rs
@@ -4051,11 +4051,67 @@ impl Conv<&FunctionCall> for Vec<ProtoStatement> {
         for (var_path, expr) in &src.inputs {
             let arg_var_id = body.arg_map.get(var_path).unwrap();
 
+            let arg_meta_clone = context.scope().variable_meta.get(arg_var_id).cloned();
+            // Array literals need the formal argument shape before their elements
+            // can be converted into scalar simulator expressions.
+            if let Some(arg_meta) = arg_meta_clone.as_ref()
+                && matches!(expr, air::Expression::ArrayLiteral(..))
+            {
+                let mut expr = expr.clone();
+                let array_exprs = eval_array_literal(
+                    &mut context.scope().analyzer_context,
+                    Some(&arg_meta.r#type.array),
+                    Some(arg_meta.r#type.width()),
+                    &mut expr,
+                )
+                .map_err(|_| SimulatorError::unsupported_description(&src.comptime.token))?
+                .ok_or_else(|| SimulatorError::unsupported_description(&src.comptime.token))?;
+
+                for array_expr in array_exprs {
+                    let arg_index = arg_meta
+                        .r#type
+                        .array
+                        .calc_index(&array_expr.index)
+                        .ok_or_else(|| {
+                            SimulatorError::unsupported_description(&src.comptime.token)
+                        })?;
+                    let select = if array_expr.select.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            array_expr
+                                .to_var_select()
+                                .eval_value(
+                                    &mut context.scope().analyzer_context,
+                                    &arg_meta.r#type,
+                                    false,
+                                )
+                                .ok_or_else(|| {
+                                    SimulatorError::unsupported_description(&src.comptime.token)
+                                })?,
+                        )
+                    };
+                    let mut proto_expr: ProtoExpression = Conv::conv(context, &array_expr.expr)?;
+                    size_fill_literal_rhs(&mut proto_expr, select, None, arg_meta.width);
+                    let arg_element = &arg_meta.elements[arg_index];
+                    result.push(ProtoStatement::Assign(ProtoAssignStatement {
+                        dst: arg_element.current,
+                        dst_width: arg_meta.width,
+                        select,
+                        dynamic_select: None,
+                        rhs_select: None,
+                        expr: proto_expr,
+                        dst_ff_current_offset: 0,
+                        token: TokenRange::default(),
+                    }));
+                }
+                continue;
+            }
+
             // Array argument fed by a bare or constant partial-index
             // variable (`arr` or `arr[0]`): copy per-element. The generic
             // path treats the argument as a scalar and panics at
             // `calc_index().unwrap()` on a whole-array reference.
-            let arg_meta_clone = context.scope().variable_meta.get(arg_var_id).cloned();
             if let Some(arg_meta) = arg_meta_clone.as_ref()
                 && arg_meta.elements.len() > 1
                 && let air::Expression::Term(factor) = expr

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -5477,9 +5477,12 @@ fn function_call_array_literal_arg_shapes() {
         b: input  logic<4>,
         c: input  logic<4>,
         d: input  logic<4>,
+        row: input logic,
+        col: input logic,
         single: output logic<4>,
         repeated: output logic<12>,
         matrix: output logic<16>,
+        indexed: output logic<4>,
         packed_out: output logic,
         packed_value: output logic<4>,
     ) {
@@ -5507,6 +5510,14 @@ fn function_call_array_literal_arg_shapes() {
             return {x[0][0], x[0][1], x[1][0], x[1][1]};
         }
 
+        function pick2x2 (
+            x: input logic<4> [2, 2],
+            row: input logic,
+            col: input logic,
+        ) -> logic<4> {
+            return x[row][col];
+        }
+
         function packed_bit (
             x: input logic<2, 2> [2],
         ) -> logic {
@@ -5522,6 +5533,11 @@ fn function_call_array_literal_arg_shapes() {
         assign single = pick1('{a});
         assign repeated = pack3('{identity(a) repeat 2, default: identity(b)});
         assign matrix = pack2x2('{'{a, b}, '{c, d}});
+        assign indexed = pick2x2(
+            '{'{a, b} repeat 1, default: '{c, d}},
+            row,
+            col,
+        );
         assign packed_out = packed_bit('{'{'{0, 0}, '{0, 0}}, '{'{0, 0}, '{0, 1}}});
         assign packed_value = packed_pattern('{1, 0, 0, 1});
     }
@@ -5537,7 +5553,17 @@ fn function_call_array_literal_arg_shapes() {
         sim.set("b", Value::new(0xb, 4, false));
         sim.set("c", Value::new(0xc, 4, false));
         sim.set("d", Value::new(0xd, 4, false));
-        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        for (row, col, expected) in [(0, 0, 0xa), (0, 1, 0xb), (1, 0, 0xc), (1, 1, 0xd)] {
+            sim.set("row", Value::new(row, 1, false));
+            sim.set("col", Value::new(col, 1, false));
+            sim.step(&Event::Clock(VarId::SYNTHETIC));
+            assert_eq!(
+                sim.get("indexed").unwrap(),
+                Value::new(expected, 4, false),
+                "row={row} col={col} config={config:?}",
+            );
+        }
 
         assert_eq!(sim.get("single").unwrap(), Value::new(0xa, 4, false));
         assert_eq!(sim.get("repeated").unwrap(), Value::new(0xaab, 12, false));

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -5432,6 +5432,121 @@ fn function_call_array_arg() {
     }
 }
 
+#[test]
+fn function_call_array_literal_arg_in_ff() {
+    let code = r#"
+    module Top (
+        clk   : input  clock,
+        in_hi : input  logic<4>,
+        in_lo : input  logic<4>,
+        out_q : output logic<4>,
+    ) {
+        function pick (
+            x: input logic<4> [2],
+        ) -> logic<4> {
+            return x[1];
+        }
+
+        always_ff (clk) {
+            out_q = pick('{in_hi, in_lo});
+        }
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        let clk = sim.get_clock("clk").unwrap();
+
+        sim.set("in_hi", Value::new(0xa, 4, false));
+        sim.set("in_lo", Value::new(0x3, 4, false));
+        sim.step(&clk);
+
+        assert_eq!(sim.get("out_q").unwrap(), Value::new(0x3, 4, false));
+    }
+}
+
+#[test]
+fn function_call_array_literal_arg_shapes() {
+    let code = r#"
+    module Top (
+        a: input  logic<4>,
+        b: input  logic<4>,
+        c: input  logic<4>,
+        d: input  logic<4>,
+        single: output logic<4>,
+        repeated: output logic<12>,
+        matrix: output logic<16>,
+        packed_out: output logic,
+        packed_value: output logic<4>,
+    ) {
+        function identity (
+            x: input logic<4>,
+        ) -> logic<4> {
+            return x;
+        }
+
+        function pick1 (
+            x: input logic<4> [1],
+        ) -> logic<4> {
+            return x[0];
+        }
+
+        function pack3 (
+            x: input logic<4> [3],
+        ) -> logic<12> {
+            return {x[0], x[1], x[2]};
+        }
+
+        function pack2x2 (
+            x: input logic<4> [2, 2],
+        ) -> logic<16> {
+            return {x[0][0], x[0][1], x[1][0], x[1][1]};
+        }
+
+        function packed_bit (
+            x: input logic<2, 2> [2],
+        ) -> logic {
+            return x[1][1][1];
+        }
+
+        function packed_pattern (
+            x: input logic<4>,
+        ) -> logic<4> {
+            return x;
+        }
+
+        assign single = pick1('{a});
+        assign repeated = pack3('{identity(a) repeat 2, default: identity(b)});
+        assign matrix = pack2x2('{'{a, b}, '{c, d}});
+        assign packed_out = packed_bit('{'{'{0, 0}, '{0, 0}}, '{'{0, 0}, '{0, 1}}});
+        assign packed_value = packed_pattern('{1, 0, 0, 1});
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.set("a", Value::new(0xa, 4, false));
+        sim.set("b", Value::new(0xb, 4, false));
+        sim.set("c", Value::new(0xc, 4, false));
+        sim.set("d", Value::new(0xd, 4, false));
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        assert_eq!(sim.get("single").unwrap(), Value::new(0xa, 4, false));
+        assert_eq!(sim.get("repeated").unwrap(), Value::new(0xaab, 12, false));
+        assert_eq!(sim.get("matrix").unwrap(), Value::new(0xabcd, 16, false));
+        assert_eq!(sim.get("packed_out").unwrap(), Value::new(1, 1, false));
+        assert_eq!(sim.get("packed_value").unwrap(), Value::new(9, 4, false));
+    }
+}
+
 // Partial constant-index of a multi-dim parent array as a function argument
 // (e.g. `pick(arr[0], ...)` on a `logic [N, M]` parent → 1D array param).
 #[test]


### PR DESCRIPTION
Expand array literals using the formal function argument type before converting their elements into simulator expressions. Previously, passing an array literal directly to a function caused the simulator to panic with `unhandled Expression variant`.

```veryl
function pick (
    x: input logic<4> [2],
) -> logic<4> {
    return x[1];
}

always_ff (clk) {
    out_q = pick('{in_hi, in_lo});
}
```

The added tests cover unpacked, packed, single-element, repeated, default-filled, and multidimensional literals, including nested function calls.