### PR TITLE
feat(analyzer): diagnose modification of for-loop bounds

### DIFF
--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -3,6 +3,7 @@ use crate::attribute_table;
 use crate::comb_loop_detect;
 use crate::conv::{Context, Conv};
 use crate::definition_table;
+use crate::dynamic_for_check;
 use crate::generic_inference_table;
 use crate::handlers::*;
 use crate::ir::{Ir, IrResult};
@@ -266,6 +267,7 @@ impl Analyzer {
 
         ret.append(&mut symbol_table::check_unused_variable());
         ret.append(&mut symbol_table::check_wavedrom());
+        ret.append(&mut dynamic_for_check::check(ir));
         ret.append(&mut comb_loop_detect::check(ir));
 
         ret

--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -741,6 +741,23 @@ pub enum AnalyzerError {
     },
 
     #[diagnostic(
+        severity(Warning),
+        code(mutable_for_bound),
+        help("move the assignment outside the loop or iterate over a separate, stable bound; this will become an error in a future release"),
+        url("https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#{}", self.code().unwrap())
+    )]
+    #[error(
+        "for-loop continuation bound is modified by the loop body, so backends may execute different iteration counts"
+    )]
+    MutableForBound {
+        #[source_code]
+        input: MultiSources,
+        #[label("Warning location")]
+        error_location: SourceSpan,
+        token_source: TokenSource,
+    },
+
+    #[diagnostic(
         severity(Error),
         code(invalid_for_step),
         help("make the step strictly advance the induction variable toward the end of the range"),
@@ -2076,6 +2093,7 @@ impl AnalyzerError {
             AnalyzerError::MissingTri { input, .. } => input,
             AnalyzerError::MixedFunctionArgument { input, .. } => input,
             AnalyzerError::MixedStructUnionMember { input, .. } => input,
+            AnalyzerError::MutableForBound { input, .. } => input,
             AnalyzerError::MultipleAssignment { input, .. } => input,
             AnalyzerError::MultipleDefault { input, .. } => input,
             AnalyzerError::NonConstantSelectWidth { input, .. } => input,
@@ -2197,6 +2215,7 @@ impl AnalyzerError {
             AnalyzerError::MissingTri { token_source, .. } => *token_source,
             AnalyzerError::MixedFunctionArgument { token_source, .. } => *token_source,
             AnalyzerError::MixedStructUnionMember { token_source, .. } => *token_source,
+            AnalyzerError::MutableForBound { token_source, .. } => *token_source,
             AnalyzerError::MultipleAssignment { token_source, .. } => *token_source,
             AnalyzerError::MultipleDefault { token_source, .. } => *token_source,
             AnalyzerError::PrivateMember { token_source, .. } => *token_source,
@@ -2633,6 +2652,13 @@ impl AnalyzerError {
         AnalyzerError::InvalidForRange {
             help: kind.help().to_string(),
             kind,
+            input: source(token),
+            error_location: token.into(),
+            token_source: token.source(),
+        }
+    }
+    pub fn mutable_for_bound(token: &TokenRange) -> Self {
+        AnalyzerError::MutableForBound {
             input: source(token),
             error_location: token.into(),
             token_source: token.source(),

--- a/crates/analyzer/src/attribute.rs
+++ b/crates/analyzer/src/attribute.rs
@@ -196,6 +196,7 @@ struct Pattern {
     pub missing_reset_statement: StrId,
     pub unused_variable: StrId,
     pub unassign_variable: StrId,
+    pub mutable_for_bound: StrId,
     pub enum_encoding: StrId,
     pub sequential: StrId,
     pub onehot: StrId,
@@ -231,6 +232,7 @@ impl Pattern {
             missing_reset_statement: resource_table::insert_str("missing_reset_statement"),
             unused_variable: resource_table::insert_str("unused_variable"),
             unassign_variable: resource_table::insert_str("unassign_variable"),
+            mutable_for_bound: resource_table::insert_str("mutable_for_bound"),
             enum_encoding: resource_table::insert_str("enum_encoding"),
             sequential: resource_table::insert_str("sequential"),
             onehot: resource_table::insert_str("onehot"),
@@ -347,6 +349,9 @@ impl TryFrom<&veryl_parser::veryl_grammar_trait::Attribute> for Attribute {
                         }
                         x if x == pat.unassign_variable => {
                             Ok(Attribute::Allow(AllowItem::UnassignVariable))
+                        }
+                        x if x == pat.mutable_for_bound => {
+                            Ok(Attribute::Allow(AllowItem::MutableForBound))
                         }
                         _ => Err(err),
                     }
@@ -536,6 +541,7 @@ pub enum AllowItem {
     MissingResetStatement,
     UnusedVariable,
     UnassignVariable,
+    MutableForBound,
 }
 
 impl AllowItem {
@@ -558,6 +564,7 @@ impl fmt::Display for AllowItem {
             AllowItem::MissingResetStatement => "missing_reset_statement",
             AllowItem::UnusedVariable => "unused_variable",
             AllowItem::UnassignVariable => "unassign_variable",
+            AllowItem::MutableForBound => "mutable_for_bound",
         };
         text.fmt(f)
     }

--- a/crates/analyzer/src/dynamic_for_check.rs
+++ b/crates/analyzer/src/dynamic_for_check.rs
@@ -1,0 +1,594 @@
+//! Reports procedural `for` loops whose body can visibly mutate an input of
+//! the continuation bound. Writes that retain true FF/NBA semantics are
+//! intentionally ignored because they do not become visible until the loop
+//! has completed.
+
+use crate::analyzer_error::AnalyzerError;
+use crate::attribute::{AllowItem, Attribute};
+use crate::attribute_table;
+use crate::conv::Context;
+use crate::ir::{
+    AssignDestination, CasePattern, Component, Declaration, Expression, Factor, ForBound, ForRange,
+    ForStatement, FunctionCall, Ir, Module, Statement, SystemFunctionCall, SystemFunctionKind,
+    VarId, VarIndex, VarSelect,
+};
+use crate::symbol::Affiliation;
+use crate::value::ValueBigUint;
+use crate::{BigUint, HashSet};
+
+#[derive(Clone)]
+struct Access {
+    id: VarId,
+    /// A flattened array element. `None` means any element may be accessed.
+    index: Option<usize>,
+    mask: BigUint,
+    /// The write is deferred until NBA commit and is invisible to this loop.
+    nba: bool,
+}
+
+pub fn check(ir: &Ir) -> Vec<AnalyzerError> {
+    let mut errors = Vec::new();
+    for component in &ir.components {
+        if let Component::Module(module) = component {
+            check_module(module, &mut errors);
+        }
+    }
+    errors
+}
+
+fn check_module(module: &Module, errors: &mut Vec<AnalyzerError>) {
+    if module.suppress_unassigned {
+        return;
+    }
+    let mut context = Context::default();
+    context.variables = module.variables.clone();
+    context.functions = module.functions.clone();
+
+    for declaration in &module.declarations {
+        let statements = match declaration {
+            Declaration::Comb(x) => Some((x.statements.as_slice(), false)),
+            Declaration::Ff(x) => Some((x.statements.as_slice(), true)),
+            Declaration::Initial(x) => Some((x.statements.as_slice(), false)),
+            Declaration::Final(x) => Some((x.statements.as_slice(), false)),
+            Declaration::Inst(_)
+            | Declaration::External(_)
+            | Declaration::Unsupported(_)
+            | Declaration::Null => None,
+        };
+        if let Some((statements, from_ff)) = statements {
+            check_statements(statements, module, &mut context, errors, from_ff);
+        }
+    }
+
+    for function in module.functions.values() {
+        for body in &function.functions {
+            check_statements(&body.statements, module, &mut context, errors, false);
+        }
+    }
+}
+
+fn check_statements(
+    statements: &[Statement],
+    module: &Module,
+    context: &mut Context,
+    errors: &mut Vec<AnalyzerError>,
+    from_ff: bool,
+) {
+    for statement in statements {
+        match statement {
+            Statement::If(x) => {
+                check_statements(&x.true_side, module, context, errors, from_ff);
+                check_statements(&x.false_side, module, context, errors, from_ff);
+            }
+            Statement::IfReset(x) => {
+                check_statements(&x.true_side, module, context, errors, from_ff);
+                check_statements(&x.false_side, module, context, errors, from_ff);
+            }
+            Statement::Case(x) => {
+                for arm in &x.arms {
+                    check_statements(&arm.body, module, context, errors, from_ff);
+                }
+                check_statements(&x.default, module, context, errors, from_ff);
+            }
+            Statement::For(x) => {
+                check_for(x, module, context, errors, from_ff);
+                check_statements(&x.body, module, context, errors, from_ff);
+            }
+            Statement::Assign(_)
+            | Statement::FunctionCall(_)
+            | Statement::SystemFunctionCall(_)
+            | Statement::TbMethodCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => {}
+        }
+    }
+}
+
+fn check_for(
+    statement: &ForStatement,
+    module: &Module,
+    context: &mut Context,
+    errors: &mut Vec<AnalyzerError>,
+    from_ff: bool,
+) {
+    let bound = match &statement.range {
+        ForRange::Forward { end, .. } | ForRange::Stepped { end, .. } => end,
+        ForRange::Reverse { start, .. } => start,
+    };
+    let ForBound::Expression(bound) = bound else {
+        return;
+    };
+
+    let mut reads = Vec::new();
+    let mut visited = HashSet::default();
+    collect_expr_reads(bound, module, context, &mut reads, &mut visited);
+
+    let mut writes = Vec::new();
+    let mut visited = HashSet::default();
+    collect_writes(
+        &statement.body,
+        module,
+        context,
+        &mut writes,
+        &mut visited,
+        from_ff,
+    );
+
+    if reads
+        .iter()
+        .any(|read| writes.iter().any(|write| accesses_conflict(read, write)))
+        && !attribute_table::contains(
+            &statement.token.beg,
+            Attribute::Allow(AllowItem::MutableForBound),
+        )
+    {
+        errors.push(AnalyzerError::mutable_for_bound(&statement.token));
+    }
+}
+
+fn accesses_conflict(read: &Access, write: &Access) -> bool {
+    if write.nba || read.id != write.id || (&read.mask & &write.mask) == BigUint::default() {
+        return false;
+    }
+    if let (Some(read), Some(write)) = (read.index, write.index)
+        && read != write
+    {
+        return false;
+    }
+
+    true
+}
+
+fn collect_writes(
+    statements: &[Statement],
+    module: &Module,
+    context: &mut Context,
+    writes: &mut Vec<Access>,
+    visited_functions: &mut HashSet<VarId>,
+    from_ff: bool,
+) {
+    for statement in statements {
+        match statement {
+            Statement::Assign(x) => {
+                for destination in &x.dst {
+                    push_destination(destination, context, writes, from_ff);
+                }
+            }
+            Statement::If(x) => {
+                collect_writes(
+                    &x.true_side,
+                    module,
+                    context,
+                    writes,
+                    visited_functions,
+                    from_ff,
+                );
+                collect_writes(
+                    &x.false_side,
+                    module,
+                    context,
+                    writes,
+                    visited_functions,
+                    from_ff,
+                );
+            }
+            Statement::IfReset(x) => {
+                collect_writes(
+                    &x.true_side,
+                    module,
+                    context,
+                    writes,
+                    visited_functions,
+                    from_ff,
+                );
+                collect_writes(
+                    &x.false_side,
+                    module,
+                    context,
+                    writes,
+                    visited_functions,
+                    from_ff,
+                );
+            }
+            Statement::Case(x) => {
+                for arm in &x.arms {
+                    collect_writes(
+                        &arm.body,
+                        module,
+                        context,
+                        writes,
+                        visited_functions,
+                        from_ff,
+                    );
+                }
+                collect_writes(
+                    &x.default,
+                    module,
+                    context,
+                    writes,
+                    visited_functions,
+                    from_ff,
+                );
+            }
+            Statement::For(x) => {
+                collect_writes(&x.body, module, context, writes, visited_functions, from_ff);
+            }
+            Statement::FunctionCall(call) => {
+                for destinations in call.outputs.values() {
+                    for destination in destinations {
+                        push_destination(destination, context, writes, from_ff);
+                    }
+                }
+                collect_function_writes(call, module, context, writes, visited_functions);
+            }
+            Statement::SystemFunctionCall(call) => {
+                if let SystemFunctionKind::Readmemh(_, output) = &call.kind {
+                    for destination in &output.0 {
+                        push_destination(destination, context, writes, from_ff);
+                    }
+                }
+            }
+            Statement::TbMethodCall(call) => {
+                if let Some(destination) = &call.ret {
+                    push_destination(destination, context, writes, from_ff);
+                }
+            }
+            Statement::Break | Statement::Unsupported(_) | Statement::Null => {}
+        }
+    }
+}
+
+fn collect_function_writes(
+    call: &FunctionCall,
+    module: &Module,
+    context: &mut Context,
+    writes: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    if !visited.insert(call.id) {
+        return;
+    }
+    if let Some(function) = module.functions.get(&call.id) {
+        let body = call
+            .index
+            .as_deref()
+            .and_then(|index| function.get_function(index))
+            .or_else(|| function.get_function(&[]));
+        if let Some(body) = body {
+            let start = writes.len();
+            // Assignments inside a function body use blocking semantics.
+            // Output actuals were recorded above in the caller's context.
+            collect_writes(&body.statements, module, context, writes, visited, false);
+            writes[start..].iter_mut().for_each(|access| {
+                if module
+                    .variables
+                    .get(&access.id)
+                    .is_some_and(|variable| variable.affiliation == Affiliation::Function)
+                {
+                    access.mask = BigUint::default();
+                }
+            });
+        }
+    }
+    visited.remove(&call.id);
+}
+
+fn collect_expr_reads(
+    expression: &Expression,
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited_functions: &mut HashSet<VarId>,
+) {
+    match expression {
+        Expression::Term(factor) => {
+            collect_factor_reads(factor, module, context, reads, visited_functions)
+        }
+        Expression::Unary(_, expression, _) => {
+            collect_expr_reads(expression, module, context, reads, visited_functions)
+        }
+        Expression::Binary(lhs, _, rhs, _) => {
+            collect_expr_reads(lhs, module, context, reads, visited_functions);
+            collect_expr_reads(rhs, module, context, reads, visited_functions);
+        }
+        Expression::Ternary(cond, lhs, rhs, _) => {
+            collect_expr_reads(cond, module, context, reads, visited_functions);
+            collect_expr_reads(lhs, module, context, reads, visited_functions);
+            collect_expr_reads(rhs, module, context, reads, visited_functions);
+        }
+        Expression::Concatenation(elements, _) => {
+            for (expression, repeat) in elements {
+                collect_expr_reads(expression, module, context, reads, visited_functions);
+                if let Some(repeat) = repeat {
+                    collect_expr_reads(repeat, module, context, reads, visited_functions);
+                }
+            }
+        }
+        Expression::StructConstructor(_, fields, _) => {
+            for (_, expression) in fields {
+                collect_expr_reads(expression, module, context, reads, visited_functions);
+            }
+        }
+        Expression::ArrayLiteral(_, _) => {}
+    }
+}
+
+fn collect_factor_reads(
+    factor: &Factor,
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    match factor {
+        Factor::Variable(id, index, select, _) => {
+            collect_index_reads(index, module, context, reads, visited);
+            collect_select_reads(select, module, context, reads, visited);
+            if let Some(access) = variable_access(*id, index, select, context, false) {
+                reads.push(access);
+            }
+        }
+        Factor::FunctionCall(call) => {
+            for input in call.inputs.values() {
+                collect_expr_reads(input, module, context, reads, visited);
+            }
+            collect_function_reads(call, module, context, reads, visited);
+        }
+        Factor::SystemFunctionCall(call) => {
+            collect_system_function_reads(call, module, context, reads, visited)
+        }
+        Factor::HierVariable(x) => {
+            collect_index_reads(&x.index, module, context, reads, visited);
+            collect_select_reads(&x.select, module, context, reads, visited);
+        }
+        Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => {}
+    }
+}
+
+fn collect_function_reads(
+    call: &FunctionCall,
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    if !visited.insert(call.id) {
+        return;
+    }
+    if let Some(function) = module.functions.get(&call.id) {
+        let body = call
+            .index
+            .as_deref()
+            .and_then(|index| function.get_function(index))
+            .or_else(|| function.get_function(&[]));
+        if let Some(body) = body {
+            let start = reads.len();
+            collect_statement_reads(&body.statements, module, context, reads, visited);
+            reads[start..].iter_mut().for_each(|access| {
+                if module
+                    .variables
+                    .get(&access.id)
+                    .is_some_and(|variable| variable.affiliation == Affiliation::Function)
+                {
+                    access.mask = BigUint::default();
+                }
+            });
+        }
+    }
+    visited.remove(&call.id);
+}
+
+fn collect_statement_reads(
+    statements: &[Statement],
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    for statement in statements {
+        match statement {
+            Statement::Assign(x) => collect_expr_reads(&x.expr, module, context, reads, visited),
+            Statement::If(x) => {
+                collect_expr_reads(&x.cond, module, context, reads, visited);
+                collect_statement_reads(&x.true_side, module, context, reads, visited);
+                collect_statement_reads(&x.false_side, module, context, reads, visited);
+            }
+            Statement::IfReset(x) => {
+                collect_statement_reads(&x.true_side, module, context, reads, visited);
+                collect_statement_reads(&x.false_side, module, context, reads, visited);
+            }
+            Statement::Case(x) => {
+                collect_expr_reads(&x.case_target, module, context, reads, visited);
+                for arm in &x.arms {
+                    for pattern in &arm.patterns {
+                        match pattern {
+                            CasePattern::Eq(expression) => {
+                                collect_expr_reads(expression, module, context, reads, visited)
+                            }
+                            CasePattern::Range { lo, hi, .. } => {
+                                collect_expr_reads(lo, module, context, reads, visited);
+                                collect_expr_reads(hi, module, context, reads, visited);
+                            }
+                        }
+                    }
+                    collect_statement_reads(&arm.body, module, context, reads, visited);
+                }
+                collect_statement_reads(&x.default, module, context, reads, visited);
+            }
+            Statement::For(x) => {
+                for bound in x.range.dynamic_bounds() {
+                    collect_expr_reads(bound, module, context, reads, visited);
+                }
+                collect_statement_reads(&x.body, module, context, reads, visited);
+            }
+            Statement::FunctionCall(call) => {
+                for input in call.inputs.values() {
+                    collect_expr_reads(input, module, context, reads, visited);
+                }
+                collect_function_reads(call, module, context, reads, visited);
+            }
+            Statement::SystemFunctionCall(call) => {
+                collect_system_function_reads(call, module, context, reads, visited)
+            }
+            Statement::TbMethodCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => {}
+        }
+    }
+}
+
+fn collect_system_function_reads(
+    call: &SystemFunctionCall,
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    let mut collect =
+        |expression: &Expression| collect_expr_reads(expression, module, context, reads, visited);
+    match &call.kind {
+        SystemFunctionKind::Bits(x)
+        | SystemFunctionKind::Size(x)
+        | SystemFunctionKind::Clog2(x)
+        | SystemFunctionKind::Onehot(x)
+        | SystemFunctionKind::Signed(x)
+        | SystemFunctionKind::Unsigned(x) => collect(&x.0),
+        SystemFunctionKind::Readmemh(filename, _) => collect(&filename.0),
+        SystemFunctionKind::Display(args) | SystemFunctionKind::Write(args) => {
+            for argument in args {
+                collect(&argument.0);
+            }
+        }
+        SystemFunctionKind::Assert { cond, args, .. } => {
+            collect(&cond.0);
+            for argument in args {
+                collect(&argument.0);
+            }
+        }
+        SystemFunctionKind::Finish => {}
+    }
+}
+
+fn collect_index_reads(
+    index: &VarIndex,
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    for expression in &index.0 {
+        collect_expr_reads(expression, module, context, reads, visited);
+    }
+}
+
+fn collect_select_reads(
+    select: &VarSelect,
+    module: &Module,
+    context: &mut Context,
+    reads: &mut Vec<Access>,
+    visited: &mut HashSet<VarId>,
+) {
+    for expression in &select.0 {
+        collect_expr_reads(expression, module, context, reads, visited);
+    }
+    if let Some((_, expression)) = &select.1 {
+        collect_expr_reads(expression, module, context, reads, visited);
+    }
+}
+
+fn push_destination(
+    destination: &AssignDestination,
+    context: &mut Context,
+    accesses: &mut Vec<Access>,
+    from_ff: bool,
+) {
+    let nba = from_ff
+        && context
+            .variables
+            .get(&destination.id)
+            .is_some_and(|variable| {
+                variable.kind != crate::ir::VarKind::Let
+                    && variable.affiliation != Affiliation::AlwaysFf
+            });
+    if let Some(access) = variable_access(
+        destination.id,
+        &destination.index,
+        &destination.select,
+        context,
+        nba,
+    ) {
+        accesses.push(access);
+    }
+}
+
+fn variable_access(
+    id: VarId,
+    index: &VarIndex,
+    select: &VarSelect,
+    context: &mut Context,
+    nba: bool,
+) -> Option<Access> {
+    let variable = context.variables.get(&id)?.clone();
+    let index = index
+        .is_const()
+        .then(|| index.eval_value(context))
+        .flatten()
+        .and_then(|index| variable.r#type.array.calc_index(&index));
+    let mask = if select.is_const_with_range() {
+        select
+            .eval_value(context, &variable.r#type, false)
+            .map(|(beg, end)| ValueBigUint::gen_mask_range(beg, end))
+    } else {
+        None
+    }
+    .or_else(|| variable.total_width().map(ValueBigUint::gen_mask))?;
+    Some(Access {
+        id,
+        index,
+        mask,
+        nba,
+    })
+}
+
+trait DynamicBounds {
+    fn dynamic_bounds(&self) -> Vec<&Expression>;
+}
+
+impl DynamicBounds for ForRange {
+    fn dynamic_bounds(&self) -> Vec<&Expression> {
+        let (start, end) = match self {
+            ForRange::Forward { start, end, .. }
+            | ForRange::Reverse { start, end, .. }
+            | ForRange::Stepped { start, end, .. } => (start, end),
+        };
+        [start, end]
+            .into_iter()
+            .filter_map(|bound| match bound {
+                ForBound::Expression(expression) => Some(expression.as_ref()),
+                ForBound::Const(_) => None,
+            })
+            .collect()
+    }
+}

--- a/crates/analyzer/src/lib.rs
+++ b/crates/analyzer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod component_manifest_table;
 pub mod connect_operation_table;
 pub mod conv;
 pub mod definition_table;
+pub mod dynamic_for_check;
 pub mod fragment_cache;
 pub mod fragment_codec;
 pub mod generic_inference_table;

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -8989,6 +8989,389 @@ fn unassign_variable() {
 }
 
 #[test]
+fn mutable_dynamic_for_continuation_bound_is_warned() {
+    let code = r#"
+    module ModuleA {
+        var limits: logic<8>[4];
+        var index: logic<2>;
+        var selector: logic;
+        var limit: logic<8>;
+        var count: logic<8>;
+
+        function shrink_bound (
+            bound: output logic<8>,
+        ) {
+            bound = 1;
+        }
+
+        always_comb {
+            limits = '{1, 1, 4, 1};
+            index = 2;
+            count = 0;
+            for _i in 0..limits[index] {
+                count += 1;
+                limits[2] = 1;
+            }
+
+            limits = '{1, 1, 4, 1};
+            index = 2;
+            for _i in 0..limits[2] {
+                limits[index] = 1;
+            }
+
+            limits = '{1, 1, 4, 1};
+            selector = 1;
+            for _i in 0..(if selector ? limits[2] : limits[0]) {
+                selector = 0;
+            }
+
+            limit = 4;
+            for _i in 0..limit {
+                for _j in 0..1 {
+                    limit = 1;
+                }
+            }
+
+            limit = 4;
+            selector = 0;
+            for _i in 0..limit {
+                case selector {
+                    0: limit = 1;
+                    default: {}
+                }
+            }
+
+            limit = 4;
+            for _i in 0..limit {
+                shrink_bound(limit);
+            }
+
+            limit = 1;
+            for _i in 0..=limit {
+                limit = 4;
+            }
+
+            limits = '{1, 1, 0, 1};
+            index = 2;
+            for _i in rev limits[index]..4 {
+                limits[2] = 3;
+            }
+
+            limits = '{2, 1, 8, 1};
+            selector = 1;
+            for _i in 1..(if selector ? limits[2] : limits[0]) step *= 2 {
+                selector = 0;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    let mutable_bounds: Vec<_> = errors
+        .iter()
+        .filter(|error| matches!(error, AnalyzerError::MutableForBound { .. }))
+        .collect();
+    assert_eq!(mutable_bounds.len(), 9, "{errors:?}");
+    assert!(
+        mutable_bounds.iter().all(|warning| !warning.is_error()),
+        "{errors:?}",
+    );
+}
+
+#[test]
+fn mutable_dynamic_for_bound_warning_can_be_allowed() {
+    let code = r#"
+    module ModuleA {
+        var limit: logic<8>;
+        var count: logic<8>;
+
+        always_comb {
+            limit = 4;
+            count = 0;
+            #[allow(mutable_for_bound)]
+            for _i in 0..limit {
+                count += 1;
+                limit = 1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+}
+
+#[test]
+fn mutable_dynamic_for_bound_is_warned_in_functions_and_testbenches() {
+    let function_code = r#"
+    module ModuleA {
+        function count() -> u32 {
+            var limit: u32;
+            var result: u32;
+            limit = 4;
+            result = 0;
+            for _i in 0..limit {
+                result += 1;
+                limit = 1;
+            }
+            return result;
+        }
+        const RESULT: u32 = count();
+    }
+    "#;
+    let errors = analyze(function_code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+
+    let testbench_code = r#"
+    #[test(test_dynamic_bound)]
+    module test_dynamic_bound {
+        var limit: logic<32>;
+        initial {
+            limit = 4;
+            for _i in 0..limit {
+                limit = 1;
+            }
+            $finish();
+        }
+    }
+    "#;
+    let errors = analyze(testbench_code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+}
+
+#[test]
+fn mutable_dynamic_for_bound_tracks_function_global_dependencies() {
+    let code = r#"
+    module ModuleA {
+        var limit: logic<8>;
+        var count: logic<8>;
+
+        function read_limit() -> logic<8> {
+            return limit;
+        }
+
+        function shrink_limit() {
+            limit = 1;
+        }
+
+        always_comb {
+            limit = 4;
+            count = 0;
+            for _i in 0..read_limit() {
+                count += 1;
+                limit = 1;
+            }
+
+            limit = 4;
+            for _i in 0..limit {
+                shrink_limit();
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    let mutable_bounds = errors
+        .iter()
+        .filter(|error| matches!(error, AnalyzerError::MutableForBound { .. }))
+        .count();
+    assert_eq!(mutable_bounds, 2, "{errors:?}");
+}
+
+#[test]
+fn dynamic_for_mutable_bound_dependency_is_bit_precise() {
+    let allowed = r#"
+    module ModuleA {
+        var bits: logic<8>;
+        var count: logic<8>;
+        always_comb {
+            bits = 4;
+            count = 0;
+            for _i in 0..bits[3:0] {
+                count += 1;
+                bits[7:4] = 1;
+            }
+        }
+    }
+    "#;
+    let errors = analyze(allowed);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+
+    let rejected = r#"
+    module ModuleB {
+        var bits: logic<8>;
+        var count: logic<8>;
+        always_comb {
+            bits = 4;
+            count = 0;
+            for _i in 0..bits[3:0] {
+                count += 1;
+                bits[2:1] = 1;
+            }
+        }
+    }
+    "#;
+    let errors = analyze(rejected);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+}
+
+#[test]
+fn dynamic_for_allows_invisible_ff_writes_and_noncontinuation_writes() {
+    let code = r#"
+    module ModuleA (
+        clk: input clock,
+        rst: input reset,
+    ) {
+        var limit: logic<8>;
+        var limits: logic<8>[4];
+        var selector: logic<2>;
+
+        function read_limit() -> logic<8> {
+            return limit;
+        }
+
+        always_ff {
+            if_reset {
+                limit = 4;
+                limits = '{1, 1, 4, 1};
+                selector = 2;
+            } else {
+                var count: logic<8>;
+                var index: logic<2>;
+
+                count = 0;
+                for _i in 0..limit {
+                    count += 1;
+                    limit = 1;
+                }
+
+                count = 0;
+                for _i in 0..read_limit() {
+                    count += 1;
+                    limit = 1;
+                }
+
+                index = 2;
+                for _i in 0..limits[2] {
+                    limits[index] = 1;
+                }
+
+                count = 0;
+                for _i in 0..limits[selector] {
+                    count += 1;
+                    selector = 0;
+                }
+            }
+        }
+    }
+
+    module ModuleB {
+        var start: logic<8>;
+        var limits: logic<8>[2];
+        var count: logic<8>;
+        always_comb {
+            start = 0;
+            count = 0;
+            for _i in start..4 {
+                count += 1;
+                start = 3;
+            }
+
+            limits = '{4, 4};
+            for _i in 0..limits[0] {
+                limits[1] = 1;
+            }
+        }
+    }
+    "#;
+
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+
+    let local_code = r#"
+    module ModuleC (
+        clk: input clock,
+        rst: input reset,
+    ) {
+        always_ff {
+            if_reset {
+            } else {
+                var limit: logic<8>;
+                limit = 4;
+                for _i in 0..limit {
+                    limit = 1;
+                }
+            }
+        }
+    }
+    "#;
+    let errors = analyze(local_code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+
+    let local_selector_code = r#"
+    module ModuleD (
+        clk: input clock,
+        rst: input reset,
+    ) {
+        var limits: logic<8>[4];
+        always_ff {
+            if_reset {
+                limits = '{1, 1, 4, 1};
+            } else {
+                var index: logic<2>;
+                index = 2;
+                for _i in 0..limits[index] {
+                    index = 0;
+                }
+            }
+        }
+    }
+    "#;
+    let errors = analyze(local_selector_code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::MutableForBound { .. })),
+        "{errors:?}",
+    );
+}
+
+#[test]
 fn unassignable_output() {
     let code = r#"
     module ModuleA {

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -14260,6 +14260,66 @@ fn for_break_in_dynamic_range_function() {
 }
 
 #[test]
+fn dynamic_for_bound_ignores_ff_nba_writes() {
+    let code = r#"
+    module Top (
+        clk           : input  clock,
+        rst           : input  reset,
+        direct_count  : output logic<8>,
+        selector_count: output logic<8>,
+    ) {
+        var direct_bound: logic<8>;
+        var limits: logic<8>[4];
+        var selector: logic<2>;
+
+        always_ff {
+            if_reset {
+                direct_bound = 4;
+                limits = '{1, 1, 4, 1};
+                selector = 2;
+                direct_count = 0;
+                selector_count = 0;
+            } else {
+                var count: logic<8>;
+
+                count = 0;
+                for _i in 0..direct_bound {
+                    count += 1;
+                    direct_bound = 1;
+                }
+                direct_count = count;
+
+                count = 0;
+                for _i in 0..limits[selector] {
+                    count += 1;
+                    selector = 0;
+                }
+                selector_count = count;
+            }
+        }
+    }
+    "#;
+
+    for config in Config::all() {
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+        let clk = sim.get_clock("clk").unwrap();
+        let rst = sim.get_reset("rst").unwrap();
+
+        sim.step(&rst);
+        sim.step(&clk);
+
+        for name in ["direct_count", "selector_count"] {
+            assert_eq!(
+                sim.get(name).unwrap(),
+                Value::new(4, 8, false),
+                "FF/NBA bound {name}: config={config:?}",
+            );
+        }
+    }
+}
+
+#[test]
 fn dynamic_for_range_in_function() {
     let code = r#"
     module Top #(

--- a/crates/tests/src/snapshots/mismatch_attribute_args.snap
+++ b/crates/tests/src/snapshots/mismatch_attribute_args.snap
@@ -4,7 +4,7 @@ expression: out
 ---
 mismatch_attribute_args (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#mismatch_attribute_args)
 
-  × Arguments of "allow" is expected to "rule: (missing_port|missing_reset_statement|unused_variable|unassign_variable)"
+  × Arguments of "allow" is expected to "rule: (missing_port|missing_reset_statement|unused_variable|unassign_variable|mutable_for_bound)"
    ╭─[../../testcases/error/mismatch_attribute_args.veryl:1:3]
  1 │ #[allow(dummy_name)]
    ·   ──┬──


### PR DESCRIPTION
## Status and request for feedback

I started this PR with the expectation that checking the continuation-bound reads against writes in the loop body would be a reasonably local analyzer change.

While implementing and reviewing it, the problem turned out to be substantially larger:

- direct procedural mutation can be checked locally;
- indirect combinational feedback depends on the whole combinational dependency analysis;
- the current DAG analyzer deliberately omits several classes of dependencies;
- opaque and cross-hierarchy effects require an explicit unknown or incomplete result; and
- time-advancing testbench loops require a different event-mediated analysis.

The current patch detects a useful subset of problematic loops, but it does not appear to solve the underlying problem, and extending it further in its current form risks duplicating or further coupling several existing dependency collectors.

I am therefore not attached to merging this implementation, or even to keeping this exact diagnostic design. I opened the PR because the local check initially seemed like a reasonable first step, but the investigation has made it much less clear that this is the right architectural direction.

If anyone has a cleaner language rule, dependency-analysis model, migration strategy, or entirely different approach, please comment. I would be happy for this PR to be replaced or closed if it helps converge on a more complete solution.

## Summary

Add the `mutable_for_bound` warning when the analyzer can establish that a procedural `for` loop body immediately writes storage read by its continuation bound.

```veryl
var limit: u32 = 4;

for i in 0..limit {
    limit = 1; // warning: mutable_for_bound
}
```

Assignments unrelated to the continuation bound remain valid. Writes with true FF/NBA semantics are also permitted because their updated values are not visible until after the current procedural execution completes.

```veryl
always_ff (clk) {
    for i in 0..limit {
        limit = 1; // permitted: the new FF value is not visible in this loop
    }
}
```

Procedural locals inside `always_ff` still use immediate assignment semantics and are diagnosed when modified.

The warning can be suppressed during migration:

```veryl
#[allow(mutable_for_bound)]
for i in 0..limit {
    limit = 1;
}
```

This PR intentionally implements only the immediate procedural-write check. It does not claim that every indirect or cross-hierarchy influence is currently diagnosed.

## Motivation

Veryl currently does not document when a procedural `for` loop continuation bound is evaluated.

The native simulator captures the bound before entering the loop, while emitted SystemVerilog evaluates the continuation condition before each iteration. Modifying a bound from the loop body can therefore change the iteration count or termination behavior depending on the backend.

Rather than choosing one evaluation strategy immediately, Veryl can preserve implementation freedom by diagnosing programs that can observe the difference.

For synthesizable code, the intended argument is:

- an immediate procedural write to storage read by the bound must be diagnosed;
- an indirect combinational path from a body write back to the bound forms a combinational cycle, because the bound also controls execution of that body write;
- a path through an FF/NBA boundary is not visible during the current loop execution; and
- a module input cannot be written by the current procedural execution.

Under a sound combinational DAG restriction, rejecting immediate procedural mutation is therefore sufficient to make capture-on-entry and per-iteration evaluation equivalent for ordinary synthesizable code.

This PR addresses the immediate-mutation part of that argument.

## Why this is initially a warning

The direct check implemented here is deliberately conservative but incomplete.

It currently handles:

- module and procedural variables;
- statically known array elements and bit ranges;
- conservative whole-object aliasing for dynamic indices and selects;
- writes in nested control flow and nested loops;
- function output arguments;
- reads and writes reached through known Veryl function bodies; and
- the distinction between immediate procedural writes and FF/NBA writes.

It does not construct the complete combinational dependency relation of the elaborated design. In particular, this checker does not independently resolve:

- indirect feedback through other combinational variables or module ports;
- cross-hierarchy aliases and instance connectivity;
- hierarchical testbench storage;
- effects hidden behind opaque or unsupported IR nodes;
- testbench or external component method effects; or
- changes mediated by time advancement or event execution.

Some indirect cases should already be rejected by Veryl's combinational-loop rule. However, the current combinational-loop analyzer also contains deliberate under-detection paths. Among other cases, it may omit dependencies involving SystemVerilog black boxes, `inout` ports, oversized arrays, or modules whose assignment analysis was suppressed.

Consequently, an indirect feedback path that is invalid according to the language-level DAG rule may still be missed by the current implementation. This PR plus the existing DAG analyzer therefore does not yet guarantee that every warning-free program is independent of the bound-evaluation strategy.

Making the new diagnostic a warning exposes the known immediate cases without presenting the surrounding dependency analysis as complete or immediately rejecting existing programs.

## Intended diagnostic model

The eventual analysis should distinguish three outcomes:

| Analysis result | Diagnostic |
| --- | --- |
| A forbidden immediate mutation or combinational feedback is established | Error |
| Stability is established | No diagnostic |
| The relevant dependency or effect analysis is incomplete | Warning |

Improving analysis precision may refine a warning into either an error or no diagnostic. An analysis limitation must not be represented by silently dropping dependency edges and treating the result as proof of stability.

This does not require a flat whole-design graph. A future implementation can use total module-local dependency graphs and compositional module summaries which preserve an explicit incomplete or unknown result.

The warning introduced by this PR is a first migration step toward that model.

## Testbench code

The warning also applies to known immediate mutation in testbench loops because such code would directly observe the same evaluation-strategy choice.

The synthesizable-code DAG argument does not extend to time-advancing testbench bodies. A testbench may yield, update FF state, or observe changed DUT outputs before the next continuation test without creating a combinational cycle.

This PR does not attempt that event-mediated analysis. Such cases may require a separate conservative warning based on event and write closures.

## Alternatives considered

### Re-evaluate the bound in the native simulator

The simulator could match emitted SystemVerilog by evaluating the continuation bound before every iteration.

This would define useful behavior for a fragile pattern and would impose repeated evaluation in the common case unless each simulator backend performed loop-invariance analysis.

### Capture the bound in emitted SystemVerilog

The emitter could introduce a temporary which captures the continuation bound before entering the loop.

This would match the current native simulator but make emitted SystemVerilog more verbose and commit Veryl to capture-on-entry semantics.

### Specify one-time range evaluation

Rust, whose range syntax Veryl resembles, evaluates the range expression before iteration.

Veryl currently has no documented semantics under which mutating a continuation bound is useful. Choosing this model would constrain future backends even though well-formed programs need not observe the choice.

### Expand this PR into a complete dependency-analysis rewrite

A complete solution could replace the current overlapping dependency collectors with a total, sound, conservative dependency representation shared by combinational-loop detection and continuation-bound analysis.

That is substantially larger than this diagnostic and should be handled separately. This PR keeps the directly observable procedural case visible while that design is considered.

## Compatibility and future work

Programs diagnosed by this PR remain accepted and produce a warning. The warning may be suppressed with `#[allow(mutable_for_bound)]`.

Known immediate mutation can be promoted to an error after the language rule and migration policy are agreed. Analysis-incomplete cases should remain warnings until they can be resolved conservatively.

A warning-free-program guarantee additionally requires the combinational dependency analysis to stop silently omitting relevant edges. That work is not part of this PR.