### PR TITLE
Issue#3130 forloop overflow

### DIFF
--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -758,6 +758,21 @@ pub enum AnalyzerError {
 
     #[diagnostic(
         severity(Error),
+        code(for_loop_overflow),
+        help("keep the loop variable within the 32-bit signed range, or narrow the range or step"),
+        url("https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#{}", self.code().unwrap())
+    )]
+    #[error("for-loop step overflows the 32-bit signed loop variable")]
+    ForLoopOverflow {
+        #[source_code]
+        input: MultiSources,
+        #[label("Error location")]
+        error_location: SourceSpan,
+        token_source: TokenSource,
+    },
+
+    #[diagnostic(
+        severity(Error),
         code(invalid_test),
         help(""),
         url("https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#{}", self.code().unwrap())
@@ -2016,6 +2031,7 @@ impl AnalyzerError {
             AnalyzerError::DuplicateEnumVariant { input, .. } => input,
             AnalyzerError::ExceedLimit { input, .. } => input,
             AnalyzerError::FixedTypeWithSignedModifier { input, .. } => input,
+            AnalyzerError::ForLoopOverflow { input, .. } => input,
             AnalyzerError::GenericInferenceFailed { input, .. } => input,
             AnalyzerError::ImplicitClockConversion { input, .. } => input,
             AnalyzerError::IncludeFailure { input, .. } => input,
@@ -2131,6 +2147,7 @@ impl AnalyzerError {
             AnalyzerError::DuplicatedIdentifier { token_source, .. } => *token_source,
             AnalyzerError::ExceedLimit { token_source, .. } => *token_source,
             AnalyzerError::FixedTypeWithSignedModifier { token_source, .. } => *token_source,
+            AnalyzerError::ForLoopOverflow { token_source, .. } => *token_source,
             AnalyzerError::IncludeFailure { token_source, .. } => *token_source,
             AnalyzerError::IncompatProto { token_source, .. } => *token_source,
             AnalyzerError::InfiniteRecursion { token_source, .. } => *token_source,
@@ -2641,6 +2658,13 @@ impl AnalyzerError {
     pub fn invalid_for_step(cause: InvalidForStepKind, token: &TokenRange) -> Self {
         AnalyzerError::InvalidForStep {
             cause,
+            input: source(token),
+            error_location: token.into(),
+            token_source: token.source(),
+        }
+    }
+    pub fn for_loop_overflow(token: &TokenRange) -> Self {
+        AnalyzerError::ForLoopOverflow {
             input: source(token),
             error_location: token.into(),
             token_source: token.source(),

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -1780,23 +1780,30 @@ fn build_for_range_inner(
                 ));
                 return Err(ir_error!(token));
             }
-            // With const bounds, also catch value-dependent stalls (e.g.
-            // `*= 2` starting at 0, or `|= k` once k's bits are set).
-            if let (Some(start_val), Some(end_val)) =
-                (beg.eval_value(context), end.eval_value(context))
-            {
-                let end_val = if inclusive {
+            const INDUCTION_MAX: usize = i32::MAX as usize;
+            let end_val = end.eval_value(context).map(|end_val| {
+                if inclusive {
                     end_val.saturating_add(1)
                 } else {
                     end_val
-                };
+                }
+            });
+            let scannable = end_val.is_some() || !matches!(op, ir::Op::Add);
+            if let Some(start_val) = beg.eval_value(context)
+                && scannable
+            {
                 let limit = context.config.evaluate_size_limit;
                 let mut i = start_val;
                 let mut n = 0usize;
-                while i < end_val && n <= limit {
+                while end_val.is_none_or(|end_val| i < end_val) && n <= limit {
                     match op.eval(i, step_val) {
+                        Some(next) if next > INDUCTION_MAX => {
+                            let token: TokenRange = expr.into();
+                            context.insert_error(AnalyzerError::for_loop_overflow(&token));
+                            return Err(ir_error!(token));
+                        }
                         Some(next) if next > i => i = next,
-                        _ => {
+                        _ if end_val.is_some() => {
                             let token: TokenRange = expr.into();
                             context.insert_error(AnalyzerError::invalid_for_step(
                                 InvalidForStepKind::StopsAdvancing,
@@ -1804,6 +1811,7 @@ fn build_for_range_inner(
                             ));
                             return Err(ir_error!(token));
                         }
+                        _ => break,
                     }
                     n += 1;
                 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -16236,6 +16236,130 @@ fn regression_rev_for_non_additive_step_rejected() {
 }
 
 #[test]
+fn for_step_overflowing_induction_variable_rejected() {
+    // https://github.com/veryl-lang/veryl/issues/3130
+    let mul_repro = r#"
+    module Top (
+        end_bound: input signed logic<64>,
+        hits     : output       logic<32>,
+    ) {
+        always_comb {
+            hits = 0;
+            for _i in 1500000000..end_bound step *= 2 {
+                hits += 1;
+            }
+        }
+    }
+    "#;
+    let errors = analyze(mul_repro);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::ForLoopOverflow { .. })),
+        "`*= 2` overflowing the loop variable should be rejected: {errors:?}"
+    );
+
+    let shl_repro = r#"
+    module Top (
+        end_bound: input signed logic<64>,
+        hits     : output       logic<32>,
+    ) {
+        always_comb {
+            hits = 0;
+            for _i in 1073741824..end_bound step <<= 1 {
+                hits += 1;
+            }
+        }
+    }
+    "#;
+    let errors = analyze(shl_repro);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::ForLoopOverflow { .. })),
+        "`<<= 1` overflowing the loop variable should be rejected: {errors:?}"
+    );
+
+    let const_bounds = r#"
+    module Top (
+        o: output logic<32>,
+    ) {
+        var sum: logic<32>;
+        always_comb {
+            sum = 0;
+            for i in 1500000000..2000000000 step *= 2 {
+                sum += i;
+            }
+            o = sum;
+        }
+    }
+    "#;
+    let errors = analyze(const_bounds);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::ForLoopOverflow { .. })),
+        "const-bounds overflow should be rejected: {errors:?}"
+    );
+}
+
+#[test]
+fn for_step_within_induction_variable_range_accepted() {
+    for range in [
+        "1..10 step *= 2",
+        "0..10 step += 2",
+        "1..1000000 step <<= 1",
+    ] {
+        let code = format!(
+            r#"
+        module Top (
+            o: output logic<32>,
+        ) {{
+            var sum: logic<32>;
+            always_comb {{
+                sum = 0;
+                for i in {range} {{
+                    sum += i;
+                }}
+                o = sum;
+            }}
+        }}
+        "#
+        );
+        let errors = analyze(&code);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, AnalyzerError::ForLoopOverflow { .. })),
+            "`{range}` stays within range and should be accepted: {errors:?}"
+        );
+    }
+
+    let runtime_additive = r#"
+    module Top (
+        n: input  logic<32>,
+        o: output logic<32>,
+    ) {
+        var sum: logic<32>;
+        always_comb {
+            sum = 0;
+            for i in 0..n step += 1 {
+                sum += i;
+            }
+            o = sum;
+        }
+    }
+    "#;
+    let errors = analyze(runtime_additive);
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, AnalyzerError::ForLoopOverflow { .. })),
+        "runtime additive loop should be accepted: {errors:?}"
+    );
+}
+
+#[test]
 fn no_panic_on_oversized_based_literal() {
     // Regression: a based literal whose value needs >64 bits while its declared
     // width is <=64 previously panicked in ValueBigUint::to_value_u64

--- a/crates/tests/src/snapshots/for_loop_overflow.snap
+++ b/crates/tests/src/snapshots/for_loop_overflow.snap
@@ -1,0 +1,15 @@
+---
+source: crates/tests/src/lib.rs
+expression: out
+---
+for_loop_overflow (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#for_loop_overflow)
+
+  × for-loop step overflows the 32-bit signed loop variable
+   ╭─[../../testcases/error/for_loop_overflow.veryl:7:49]
+ 6 │         hits = 0;
+ 7 │         for _i in 1500000000..end_bound step *= 2 {
+   ·                                                 ┬
+   ·                                                 ╰── Error location
+ 8 │             hits += 1;
+   ╰────
+  help: keep the loop variable within the 32-bit signed range, or narrow the range or step

--- a/testcases/error/for_loop_overflow.veryl
+++ b/testcases/error/for_loop_overflow.veryl
@@ -1,0 +1,11 @@
+module for_loop_overflow (
+    end_bound: input  signed logic<64>,
+    hits     : output logic       <32>,
+) {
+    always_comb {
+        hits = 0;
+        for _i in 1500000000..end_bound step *= 2 {
+            hits += 1;
+        }
+    }
+}


### PR DESCRIPTION
Refs #3130.

The loop variable is emitted as a 32-bit signed `int` while the simulator
iterates at a wider width, so a step that goes past i32::MAX makes the two
disagree on the trip count.

This rejects those loops at analysis time, same approach as 3319e4f0 for
degenerate steps. The scan is anchored on a constant start so it still works
when the end bound is only known at runtime, which is the case in the report.

Catches both repros from the issue, plus the case where both bounds fit but the
step still carries past the limit. No emitter change, so no golden output moves.

What this doesn't cover:

- A non-constant start, e.g. `for i in start_port..end_port step *= 2` - there's
  nothing to anchor the scan on. @tignear's 1.5e9 -> 1.6e9 example is this shape.
- Runtime end bound with an additive step. A geometric step reaches the limit in
  ~30 iterations, but `+= 1` would need 2^31, so scanning it isn't practical.
- The simulator side. The interpreter keeps the counter in an unmasked 64-bit
  value and the Cranelift backend zero-extends to 32-bit unsigned, so the
  backends still disagree with each other. Happy to do that here or separately.

One thing to flag: as @tignear pointed out, overflow doesn't always mean an
infinite loop - it can wrap past the bound and stop. This check rejects those
cases too, on the grounds that the interpreter and emitted SV still disagree on
the iteration count. Tell me if that's too strict.

#3134 is not really related to this I will see and make a seprate PR for it