### PR TITLE
feat(analyzer): rebuild combinational analysis with sparse region MemorySSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6123,6 +6123,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
+ "petgraph",
  "postcard",
  "rayon",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6124,6 +6124,7 @@ dependencies = [
  "num-traits",
  "paste",
  "postcard",
+ "rayon",
  "serde",
  "serde_json",
  "similar 3.1.1",
@@ -6134,6 +6135,7 @@ dependencies = [
  "thiserror",
  "toml",
  "vcd",
+ "veryl-causal",
  "veryl-component-sys",
  "veryl-metadata",
  "veryl-parser",
@@ -6151,6 +6153,10 @@ dependencies = [
  "toml",
  "veryl-path",
 ]
+
+[[package]]
+name = "veryl-causal"
+version = "0.20.3"
 
 [[package]]
 name = "veryl-component"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/aligner",
     "crates/analyzer",
     "crates/cache",
+    "crates/causal",
     "crates/component",
     "crates/component/macros",
     "crates/component/sys",
@@ -69,6 +70,7 @@ pprof               = {version = "0.15.0", features = ["flamegraph"]}
 pulldown-cmark      = "0.13.4"
 rand                = {version = "0.10", default-features = false}
 rand_pcg            = "0.10"
+rayon               = "1.12"
 regex               = "1.12.4"
 scnr2               = "0.5.2"
 semver              = {version = "1.0", features = ["serde"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ once_cell           = "1.21"
 parol               = "5.0"
 parol_runtime       = "5.0"
 paste               = "1.0"
+petgraph            = "0.8.3"
 postcard            = {version = "1.1", features = ["alloc"]}
 pprof               = {version = "0.15.0", features = ["flamegraph"]}
 pulldown-cmark      = "0.13.4"

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -1,96 +1,288 @@
 # Combinational loop analysis
 
-This document specifies the user-visible acceptance bounds of Veryl's
-combinational loop analysis. It intentionally does not prescribe an analyzer
-IR, a graph representation, or the precision of individual operator models.
+This document specifies the user-visible contract of Veryl's combinational
+loop analysis. It defines the required and permitted acceptance sets, not a
+particular analyzer IR, graph representation, or operator implementation.
+
+The words **shall**, **shall not**, **may**, and **need not** are normative.
+Examples explain the rules but do not add requirements.
 
 ## Purpose
 
 Veryl diagnoses combinational feedback before a design is passed to a synthesis
 tool. The analysis is synthesis-oriented. It is not a definition of
 SystemVerilog event scheduling, `always_comb` sensitivity, or four-state
-simulation behavior, and it is not required to reproduce the diagnostics of a
-particular synthesis tool.
+simulation behavior, and it need not reproduce the diagnostics or internal
+netlist of a particular synthesis tool.
 
-The analysis considers value, control, and address dependencies in the
-elaborated design. Procedural statement order, overwrites, branch exits,
-function calls, and module connections are part of that design and are not
-optional sources of analysis precision.
+The contract deliberately leaves room for implementations to become more
+precise. A compiler may reject a conservative feedback candidate which a more
+precise compiler accepts. That latitude is bounded below: it cannot be used to
+invent feedback outside the elaborated design.
+
+## Terms and analysis domain
+
+The **elaborated design** is the design after generate conditions, generate
+loops, parameters, and concrete generic specializations have been resolved.
+Declarations absent from the elaborated design do not participate in this
+analysis.
+
+An **object** is a signal, variable, port, function argument, function result,
+or other value-bearing entity in the elaborated design. A **region** is some
+part of an object, such as a packed bit range, struct field, or unpacked array
+element. Region precision is an implementation choice unless this document
+states otherwise.
+
+A **dependency** is a directed causal relation from a read region to a written
+region. Dependencies can arise from:
+
+- a value used to compute the written value;
+- a condition which controls whether or what value is written; or
+- a value used to select the source or destination of an access.
+
+The analysis covers combinational procedures, continuous assignments and
+connections, combinational effects of called functions, and combinational
+feedthrough across known module instances. Concurrent declarations have no
+source ordering between them. Procedural ordering applies within one procedure
+and through functions executed by that procedure.
+
+State-holding and verification-only constructs do not create combinational
+paths merely because they read and write the same objects. Clocked procedures
+break a combinational path at the stored value. Initial, final, timed, and event
+behavior is outside this analysis unless a combinational effect can be
+established independently of that behavior.
+
+## Required causal semantics
+
+Analysis precision is optional; language ordering and connectivity are not.
+Every implementation shall observe the following rules before applying the
+acceptance latitude described below.
+
+### Procedural order and reaching values
+
+- A read before a write in the same procedure observes the value entering the
+  procedure. A read after a write observes the latest reaching write on that
+  path.
+- A complete later write supersedes earlier writes which cannot reach a
+  procedure exit or another observable effect. A dead, overwritten write shall
+  not by itself form a loop.
+- Branch joins, early exits, and loop exits shall preserve every definition
+  which can reach the join. A write which may select only part of an object is
+  a partial or weak write for the regions it does not certainly replace.
+- Statements in distinct concurrent declarations shall not be ordered to make
+  a cycle disappear.
+
+These requirements concern the behavior being modeled. An implementation may
+use SSA, MemorySSA, dataflow equations, direct netlist construction, or another
+equivalent method.
+
+### Value, control, and address use
+
+An evaluated right-hand-side operand is a value dependency of the assignment.
+A condition is a control dependency of writes whose execution or selected
+value it controls. A selector is an address dependency of the read or write it
+selects. An implementation may later prove that one of these conservative
+dependencies is irrelevant.
+
+A read performed only for observation, such as an argument of a display-like
+operation, does not define a signal value and need not create a value
+dependency. Side effects of functions evaluated by such an operation remain
+ordinary procedural effects.
+
+Implicit `always_comb` sensitivity is not a dependency graph. In particular,
+sensitivity inclusion or exclusion does not create or remove a value, control,
+or address dependency.
+
+### Partial assignment and retained state
+
+An unassigned region retains its entering value and may require an
+incomplete-assignment or latch diagnostic. Retention alone is not a
+combinational feedback edge. An explicit read of the entering value is a
+dependency and can participate in a loop.
+
+The same rule applies to a conditional without a covering arm, a zero-trip
+loop, and a dynamic write which cannot certainly cover the whole destination.
+A complete write before or after such a construct can remove retention when it
+dominates every relevant exit.
+
+### Functions
+
+Dependencies through function inputs, outputs, return values, and
+module-scope captures are part of the caller's combinational behavior. Writes
+performed by a function occur at the call position for procedural-order
+purposes. Function-local values participate only when they can affect a return,
+an output, a capture, or another observable effect.
+
+Concrete generic function specializations are distinct elaborated call
+targets. An implementation may share their analysis, but it shall not transfer
+a dependency from one specialization to another without a connection in the
+elaborated design. A recursive call boundary which cannot be summarized is
+incomplete; it shall not silently erase dependencies established before or
+after the call.
+
+### Modules and design boundaries
+
+Known input-to-output feedthrough of a child module is a dependency in its
+parent. Port mapping shall respect direction and the parent expressions and
+destinations actually connected to the instance. Expressions used as input
+actuals and output destination selectors follow the ordinary value, address,
+and function-effect rules.
+
+Concrete generic module specializations are distinct elaborated components. An
+implementation may share their analysis, but dependencies shall be projected
+through the specialization and actual connections being instantiated. A loop
+inside a known child remains a loop whether or not a parent creates a return
+path through that child.
+
+No return dependency is implied merely because a path reaches a module port or
+the top of the design. The external environment shall not be modeled as an
+implicit edge from an output back to an input.
+
+SystemVerilog components, unknown external components, unresolved hierarchy,
+and `inout` behavior are opaque unless their feedthrough is otherwise known.
+An opaque boundary shall not be replaced by guessed feedthrough and used to
+produce a hard combinational-loop error.
 
 ## Acceptance bounds
 
-An implementation may model an evaluated operand conservatively as a dependency
-of the whole result. This whole-dependency interpretation is the conservative
-boundary of the analysis. It applies only to operands, results, and connections
-that exist in the elaborated design; it does not permit dependencies to be
-invented between otherwise disconnected objects or across an opaque boundary.
+The **whole-dependency interpretation** is the conservative boundary. Within a
+known expression or connection, it may treat every source region as affecting
+every destination region. It still observes elaboration, procedural order,
+dead overwrites, state boundaries, port direction, and actual connectivity. It
+does not connect unrelated objects or cross an opaque boundary.
 
-An implementation may accept additional programs by using more precise
-information. No particular refinement is required. In particular, an
-implementation may, but need not, use bit positions, constant values, value
-ranges, relationships between operands, or facts established by optimization
-and lowering.
+An implementation may accept additional programs by refining those
+dependencies. No particular refinement is required. Subject to other Veryl
+errors, a complete analysis shall satisfy these bounds:
 
-Subject to other Veryl errors, the following requirements define the permitted
-acceptance range:
-
-- A program that is acyclic under the whole-dependency interpretation shall be
-  accepted.
+- A program which is acyclic under the whole-dependency interpretation shall
+  be accepted.
 - A program whose known dependencies contain a cycle under every permitted
   refinement shall be rejected.
-- A program that is cyclic only under a conservative interpretation may be
+- A program which is cyclic only under a conservative interpretation may be
   accepted or rejected according to the precision of the implementation.
 
-Equivalently, for the combinational-loop rule alone:
+Equivalently:
 
 `whole-dependency acyclic programs ⊆ accepted programs ⊆ programs without an unavoidable known-dependency cycle`
 
-The third category is deliberate. Such a program is not guaranteed to be
-accepted by every analyzer version or implementation. Increasing analysis
-precision should normally move programs from this category into the accepted
-set; it need not change the language rule or the conservative boundary.
+The middle category is deliberate. Such a program is not guaranteed to be
+accepted by every analyzer version or implementation. Increasing precision
+normally enlarges the accepted set without changing either bound.
 
-The latitude above concerns the precision of dependencies inside known
-constructs. It does not make procedural semantics implementation-defined. A
-later complete assignment, for example, removes an earlier reaching definition
-when required by the language's statement ordering. Likewise, an implementation
-that cannot model a function or module connection shall treat that connection
-as incomplete rather than silently omit it from an otherwise complete result.
+This latitude applies independently to expressions, selectors, aggregates,
+functions, and module summaries. It does not make the required causal semantics
+above optional.
 
-## State and incomplete boundaries
+## Permitted precision
 
-Retention caused by an incomplete assignment is state, not by itself a
-combinational feedback edge. It is handled by the corresponding assignment or
-latch diagnostic. An explicit read of the previous value is still a dependency
-and can participate in a combinational loop.
+An implementation may use any fact which is valid for the representation it
+analyzes. It may analyze optimized or unoptimized input. It may, but need not,
+use:
 
-If the behavior of a boundary cannot be established, the analysis may report an
-incomplete result. Examples include opaque SystemVerilog components, `inout`
-connections, unresolved hierarchy, recursive boundaries, and effects which
-cannot be represented by the analyzer. An opaque boundary alone shall not be
-replaced by guessed feedthrough and used to produce a hard combinational-loop
-error. Incomplete information does not suppress a loop established entirely by
-known dependencies elsewhere in the design.
+- packed bit positions and unpacked element positions;
+- constant values, unreachable control-flow paths, and short-circuit facts;
+- value ranges and relationships between selector expressions;
+- relationships between operands or between branches of an expression;
+- width, signedness, extension, truncation, and aggregate layout;
+- facts introduced or retained by earlier optimization and lowering; and
+- operator-specific dependencies.
 
-## Examples of permitted precision
+No algebraic simplification, value-range analysis, or correlation analysis is
+required. Conversely, this contract does not require the analyzer to discard
+such facts before loop detection.
 
-These examples illustrate implementation choices; they are not additional
-requirements.
+Refinement means using valid information to omit a conservative candidate. It
+does not permit a known causal effect to be dropped merely because the
+implementation has no model for it. Such a gap is incomplete or an
+implementation defect, depending on whether the construct is opaque or is part
+of the supported analyzer IR.
+
+Examples of permitted choices include:
 
 - Addition and subtraction may be modeled as whole-result dependencies. An
   implementation may instead recognize that a result bit is independent of
-  some higher operand bits and thereby accept a bit-disjoint feedback candidate.
+  some higher operand bits.
 - A constant shift may be treated conservatively, or its shifted positions,
   vacated positions, and sign fill may be tracked separately.
 - Casts, concatenations, aggregate constructors, and repeated values may use
   their statically known bit or element placement.
-- A dynamic selector may conservatively cover its enclosing object. An
-  implementation may use a proven value range or a relationship between
-  selector expressions to narrow that set.
-- Algebraic relationships between operands, identical branches, and facts
-  introduced by an optimizer may remove dependencies. An implementation is not
-  required to discover or preserve those facts for this analysis.
+- A dynamic selector may conservatively cover its enclosing object. A proven
+  value range or relationship between selectors may narrow that set.
+- Identical operands or branches may remain structurally dependent, or an
+  optimizer may establish that their contribution cancels or is constant.
 
-These choices affect only programs between the required-acceptance and
-required-rejection bounds. They cannot justify a dependency outside the
-elaborated design or turn an unknown external effect into a proven loop.
+The result of a refinement may remove a conservative loop candidate. It shall
+not justify an edge between source and destination objects which are not
+connected by the elaborated program.
+
+## Loops and control flow
+
+Finite source loops have the procedural meaning of their iterations, including
+zero iterations and `break`. An implementation may expand them, summarize
+them, or use facts about iterator values. It need not use the same strategy or
+limit for every loop form.
+
+If a loop cannot be analyzed within an implementation limit, the result is
+incomplete for the affected behavior. Known dependencies found in the loop or
+the surrounding procedure remain usable. Treating an unanalyzed loop as always
+zero-trip or silently dropping all of its effects is not a complete result.
+
+The same rule applies when an implementation declines to evaluate a bound
+which could in principle be evaluated. Resource limits may reduce completeness;
+they shall not create guessed edges outside the whole-dependency boundary.
+
+## Incomplete analysis
+
+An analysis is **incomplete** when some relevant dependency cannot be placed
+within the acceptance bounds. Causes include opaque boundaries, `inout`,
+unresolved hierarchy, recursive functions or modules, unevaluated generic
+shapes, unanalyzed loops, timed or event effects, and legal constructs not yet
+represented by the analyzer.
+
+The acceptance equation above applies to the portion for which analysis is
+complete. Incomplete behavior has these rules:
+
+- Unknown behavior shall not be promoted to guessed feedthrough for a hard
+  loop error.
+- A known cycle shall still be reported even when unrelated or adjacent
+  behavior is incomplete.
+- Known dependencies shall not be discarded merely because the same procedure
+  or module also contains an incomplete effect.
+- An implementation may expose incompleteness separately from ordinary loop
+  diagnostics. Absence of a loop error is not proof of acyclicity when the
+  result is incomplete.
+- Failure to represent otherwise valid analyzer IR is an implementation defect,
+  not a new user-language restriction.
+
+## Diagnostics
+
+A hard combinational-loop diagnostic shall be backed by a directed cycle in
+the dependency interpretation selected by the implementation. The diagnostic
+shall identify a simple source-backed cycle rather than list unrelated members
+of a larger strongly connected component. It need not find the globally
+shortest possible cycle.
+
+Multiple cycles in one strongly connected component may be represented by one
+diagnostic. For identical source, configuration, and analysis precision, cycle
+selection and diagnostic ordering shall be deterministic.
+
+An incomplete result does not weaken a simultaneously established cycle. When
+both exist, the hard diagnostic is issued for the established cycle and the
+unknown behavior remains incomplete.
+
+## Classification examples
+
+- A value assigned directly or transitively from itself with no intervening
+  state boundary has an unavoidable cycle and is rejected.
+- Two concurrent combinational declarations which drive `a` from `b` and `b`
+  from `a` have an unavoidable cycle. Source order cannot make them acyclic.
+- A self-dependent temporary write which is completely overwritten before it
+  can affect a procedure exit or side effect does not form a loop.
+- A partial assignment which never reads the previous value is a state-coverage
+  problem, not by itself a combinational loop.
+- Feedback which appears only because addition, a cast, or a dynamic selector
+  was modeled as a whole dependency lies in the implementation-precision
+  category. A more precise implementation may accept it.
+- A possible return path through an opaque external component is incomplete,
+  not a hard loop. A separate known cycle in the same module is still rejected.

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -1,0 +1,96 @@
+# Combinational loop analysis
+
+This document specifies the user-visible acceptance bounds of Veryl's
+combinational loop analysis. It intentionally does not prescribe an analyzer
+IR, a graph representation, or the precision of individual operator models.
+
+## Purpose
+
+Veryl diagnoses combinational feedback before a design is passed to a synthesis
+tool. The analysis is synthesis-oriented. It is not a definition of
+SystemVerilog event scheduling, `always_comb` sensitivity, or four-state
+simulation behavior, and it is not required to reproduce the diagnostics of a
+particular synthesis tool.
+
+The analysis considers value, control, and address dependencies in the
+elaborated design. Procedural statement order, overwrites, branch exits,
+function calls, and module connections are part of that design and are not
+optional sources of analysis precision.
+
+## Acceptance bounds
+
+An implementation may model an evaluated operand conservatively as a dependency
+of the whole result. This whole-dependency interpretation is the conservative
+boundary of the analysis. It applies only to operands, results, and connections
+that exist in the elaborated design; it does not permit dependencies to be
+invented between otherwise disconnected objects or across an opaque boundary.
+
+An implementation may accept additional programs by using more precise
+information. No particular refinement is required. In particular, an
+implementation may, but need not, use bit positions, constant values, value
+ranges, relationships between operands, or facts established by optimization
+and lowering.
+
+Subject to other Veryl errors, the following requirements define the permitted
+acceptance range:
+
+- A program that is acyclic under the whole-dependency interpretation shall be
+  accepted.
+- A program whose known dependencies contain a cycle under every permitted
+  refinement shall be rejected.
+- A program that is cyclic only under a conservative interpretation may be
+  accepted or rejected according to the precision of the implementation.
+
+Equivalently, for the combinational-loop rule alone:
+
+`whole-dependency acyclic programs ⊆ accepted programs ⊆ programs without an unavoidable known-dependency cycle`
+
+The third category is deliberate. Such a program is not guaranteed to be
+accepted by every analyzer version or implementation. Increasing analysis
+precision should normally move programs from this category into the accepted
+set; it need not change the language rule or the conservative boundary.
+
+The latitude above concerns the precision of dependencies inside known
+constructs. It does not make procedural semantics implementation-defined. A
+later complete assignment, for example, removes an earlier reaching definition
+when required by the language's statement ordering. Likewise, an implementation
+that cannot model a function or module connection shall treat that connection
+as incomplete rather than silently omit it from an otherwise complete result.
+
+## State and incomplete boundaries
+
+Retention caused by an incomplete assignment is state, not by itself a
+combinational feedback edge. It is handled by the corresponding assignment or
+latch diagnostic. An explicit read of the previous value is still a dependency
+and can participate in a combinational loop.
+
+If the behavior of a boundary cannot be established, the analysis may report an
+incomplete result. Examples include opaque SystemVerilog components, `inout`
+connections, unresolved hierarchy, recursive boundaries, and effects which
+cannot be represented by the analyzer. An opaque boundary alone shall not be
+replaced by guessed feedthrough and used to produce a hard combinational-loop
+error. Incomplete information does not suppress a loop established entirely by
+known dependencies elsewhere in the design.
+
+## Examples of permitted precision
+
+These examples illustrate implementation choices; they are not additional
+requirements.
+
+- Addition and subtraction may be modeled as whole-result dependencies. An
+  implementation may instead recognize that a result bit is independent of
+  some higher operand bits and thereby accept a bit-disjoint feedback candidate.
+- A constant shift may be treated conservatively, or its shifted positions,
+  vacated positions, and sign fill may be tracked separately.
+- Casts, concatenations, aggregate constructors, and repeated values may use
+  their statically known bit or element placement.
+- A dynamic selector may conservatively cover its enclosing object. An
+  implementation may use a proven value range or a relationship between
+  selector expressions to narrow that set.
+- Algebraic relationships between operands, identical branches, and facts
+  introduced by an optimizer may remove dependencies. An implementation is not
+  required to discover or preserve those facts for this analysis.
+
+These choices affect only programs between the required-acceptance and
+required-rejection bounds. They cannot justify a dependency outside the
+elaborated design or turn an unknown external effect into a proven loop.

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -105,6 +105,12 @@ loop, and a dynamic write which cannot certainly cover the whole destination.
 A complete write before or after such a construct can remove retention when it
 dominates every relevant exit.
 
+For incomplete-assignment diagnostics, `cond_type(unique)`,
+`cond_type(unique0)`, and `cond_type(priority)` suppress retention introduced
+at the annotated conditional, while `cond_type(none)` does not. This policy
+does not erase the retained value or any causal dependency, and retention
+introduced at another unsuppressed control-flow join remains diagnostic.
+
 ### Functions
 
 Dependencies through function inputs, outputs, return values, and

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -182,22 +182,30 @@ This latitude applies independently to expressions, selectors, aggregates,
 functions, and module summaries. It does not make the required causal semantics
 above optional.
 
-## Default portability profile
+## Practical RTL acceptance
 
 The acceptance bounds permit implementations with very different usefulness.
 They are therefore not, by themselves, the policy of the default Veryl
-analyzer. The default analyzer uses a narrower **portability profile** chosen to
-avoid both excessive rejection and dependence on optimizations which downstream
-tools may not reproduce.
+analyzer. The default analyzer chooses a narrower operating point intended for
+ordinary RTL development.
 
-This profile is an engineering interoperability contract, not a consequence of
-the SystemVerilog LRM. Its contents are based on the representations accepted by
-the downstream synthesis ecosystem supported by Veryl and may be revised as
-that ecosystem changes.
+This policy is engineering judgment, not a consequence of the SystemVerilog
+LRM. It accounts for all of the following:
 
-### Minimum precision
+- behavior commonly accepted by downstream synthesis tools;
+- dependencies an RTL author can reasonably recognize from the source; and
+- stable, predictable diagnostics which do not depend on a particular optimizer
+  discovering a nonobvious identity.
 
-The default profile shall preserve statically established placement through:
+The policy may therefore reject a technically loop-free construction when its
+freedom from feedback depends on an unusually subtle value relationship. It
+shall not use that judgment to reject ordinary static wiring which the required
+precision below can distinguish. The policy may be revised as synthesis tools
+and established RTL practice change.
+
+### Baseline precision
+
+The default policy shall preserve statically established placement through:
 
 - direct copies and static packed or unpacked selections;
 - struct fields, array elements, concatenations, aggregate constructors,
@@ -211,22 +219,22 @@ The default profile shall preserve statically established placement through:
 
 The required placement composes through multiple such operations. An
 implementation which collapses all of these cases to whole-object dependency
-does not implement the default profile, even if it remains within the wider
+does not implement the default policy, even if it remains within the wider
 acceptance bounds.
 
-Operators and mappings not covered by the profile may use whole dependency.
-For example, the default profile does not require bit-prefix modeling for
+Operators and mappings not covered by this baseline may use whole dependency.
+For example, the default policy does not require bit-prefix modeling for
 addition or subtraction, or value-range modeling for a dynamic selector.
 
-### Portability ceiling
+### Practical upper bound
 
-The default analyzer may use information beyond the minimum profile without
+The default analyzer may use information beyond the baseline without
 requiring that every analyzer start from the same unoptimized representation.
-However, a refinement beyond the profile shall be the sole reason for accepting
+However, a refinement beyond the baseline shall be the sole reason for accepting
 a program only when at least one of the following is true:
 
-- the refinement has been added to the portability profile based on downstream
-  interoperability results; or
+- the refinement has been adopted by the default policy based on downstream
+  interoperability and ordinary RTL practice; or
 - the transformation which removes the dependency is materialized in the
   representation emitted to downstream tools.
 
@@ -237,23 +245,23 @@ that dependency. It shall not rely on the proof while emitting the original
 expression and requiring every downstream tool to rediscover it.
 
 The same rule applies to value ranges, relationships between selectors,
-algebraic cancellation, and operator-specific precision beyond the profile.
+algebraic cancellation, and operator-specific precision beyond the baseline.
 These facts may always be used for performance, diagnostics, or to construct the
 emitted representation; the restriction concerns using an unmaterialized fact
 as the final reason to suppress a hard error.
 
 Tool-specific or experimental analysis modes may choose a different point
 within the general acceptance bounds, but shall not silently replace the
-default portability profile. Changes to the default profile which can turn a
-previously accepted design into an error are compatibility changes, even when
-both behaviors fall within the wider language bounds.
+default policy. Changes to the default policy which can turn a previously
+accepted design into an error are compatibility changes, even when both
+behaviors fall within the wider language bounds.
 
 ## Permitted precision
 
 Within the wider acceptance bounds, an implementation may use any fact which is
 valid for the representation it analyzes. It may analyze optimized or
-unoptimized input. The default analyzer additionally observes the portability
-profile above. An implementation may, but need not, use:
+unoptimized input. The default analyzer additionally observes the practical RTL
+policy above. An implementation may, but need not, use:
 
 - packed bit positions and unpacked element positions;
 - constant values, unreachable control-flow paths, and short-circuit facts;

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -134,6 +134,14 @@ through the specialization and actual connections being instantiated. A loop
 inside a known child remains a loop whether or not a parent creates a return
 path through that child.
 
+A module definition may recursively instantiate a different concrete
+specialization of itself. When elaboration produces a finite specialization
+graph, every specialization and connection shall be analyzed normally; repeated
+use of the same source-level module name is not an incomplete boundary. A cycle
+which re-enters the same concrete specialization cannot form a finite
+bottom-up summary and is incomplete unless rejected earlier as nonterminating
+elaboration.
+
 No return dependency is implied merely because a path reaches a module port or
 the top of the design. The external environment shall not be modeled as an
 implicit edge from an output back to an input.
@@ -303,9 +311,9 @@ they shall not create guessed edges outside the whole-dependency boundary.
 
 An analysis is **incomplete** when some relevant dependency cannot be placed
 within the acceptance bounds. Causes include opaque boundaries, `inout`,
-unresolved hierarchy, recursive functions or modules, unevaluated generic
-shapes, unanalyzed loops, timed or event effects, and legal constructs not yet
-represented by the analyzer.
+unresolved hierarchy, unresolved recursive calls or cyclic concrete
+specialization graphs, unevaluated generic shapes, unanalyzed loops, timed or
+event effects, and legal constructs not yet represented by the analyzer.
 
 The acceptance equation above applies to the portion for which analysis is
 complete. Incomplete behavior has these rules:

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -317,6 +317,11 @@ incomplete for the affected behavior. Known dependencies found in the loop or
 the surrounding procedure remain usable. Treating an unanalyzed loop as always
 zero-trip or silently dropping all of its effects is not a complete result.
 
+An implementation shall distinguish a dynamic trip count from a statically
+known loop declined because of an expansion or resource limit. Both make the
+affected behavior incomplete, but only the latter can be retried by increasing
+that limit without changing the analysis algorithm.
+
 The same rule applies when an implementation declines to evaluate a bound
 which could in principle be evaluated. Resource limits may reduce completeness;
 they shall not create guessed edges outside the whole-dependency boundary.
@@ -324,10 +329,23 @@ they shall not create guessed edges outside the whole-dependency boundary.
 ## Incomplete analysis
 
 An analysis is **incomplete** when some relevant dependency cannot be placed
-within the acceptance bounds. Causes include opaque boundaries, `inout`,
-unresolved hierarchy, unresolved recursive calls or cyclic concrete
-specialization graphs, unevaluated generic shapes, unanalyzed loops, timed or
-event effects, and legal constructs not yet represented by the analyzer.
+within the acceptance bounds. Completeness remains one predicate: either every
+relevant dependency is represented or the result is incomplete. Incomplete
+reasons additionally carry one of two provenance classes:
+
+- An **opaque boundary** means the analysis input does not expose enough
+  behavior to establish feedthrough. External components, `inout`, timed or
+  event effects, unbounded dynamic regions, unevaluated generic shapes, and
+  source constructs retained without a causal model are opaque.
+- An **analysis gap** means the behavior is defined and available, but this
+  analysis run did not derive its dependency relation. Unresolved hierarchy or
+  region mapping, unresolved recursion, dynamic loop trip counts, and
+  configured loop-expansion limits are analysis gaps.
+
+Both classes prevent an empty diagnostic list from proving acyclicity. The
+classification instead describes remediation: an opaque boundary requires a
+model or more input information, while an analysis gap may be removed by a
+stronger algorithm or a different resource limit.
 
 A dynamic access is not incomplete merely because its exact selected region is
 unknown. If its object or longest static prefix has a known shape, whole
@@ -349,6 +367,12 @@ complete. Incomplete behavior has these rules:
   result is incomplete.
 - Failure to represent otherwise valid analyzer IR is an implementation defect,
   not a new user-language restriction.
+
+An analyzer invariant violation or malformed analyzer IR is an **analysis
+failure**, not a third incomplete class. Failures shall be exposed separately
+from incomplete reasons. A partial result may retain known dependencies and
+incomplete boundaries for debugging, but callers shall not treat a failed run
+as a valid completeness result.
 
 ## Diagnostics
 

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -174,11 +174,78 @@ This latitude applies independently to expressions, selectors, aggregates,
 functions, and module summaries. It does not make the required causal semantics
 above optional.
 
+## Default portability profile
+
+The acceptance bounds permit implementations with very different usefulness.
+They are therefore not, by themselves, the policy of the default Veryl
+analyzer. The default analyzer uses a narrower **portability profile** chosen to
+avoid both excessive rejection and dependence on optimizations which downstream
+tools may not reproduce.
+
+This profile is an engineering interoperability contract, not a consequence of
+the SystemVerilog LRM. Its contents are based on the representations accepted by
+the downstream synthesis ecosystem supported by Veryl and may be revised as
+that ecosystem changes.
+
+### Minimum precision
+
+The default profile shall preserve statically established placement through:
+
+- direct copies and static packed or unpacked selections;
+- struct fields, array elements, concatenations, aggregate constructors,
+  literals, and statically repeated values;
+- truncation, zero extension, sign extension, and width or sign casts whose
+  result placement is statically determined;
+- pointwise unary and bitwise operations, conditional result placement, and
+  constant shifts, including vacated and sign-filled positions; and
+- function arguments, function results and outputs, and known module port
+  mappings when the corresponding placement crosses those boundaries.
+
+The required placement composes through multiple such operations. An
+implementation which collapses all of these cases to whole-object dependency
+does not implement the default profile, even if it remains within the wider
+acceptance bounds.
+
+Operators and mappings not covered by the profile may use whole dependency.
+For example, the default profile does not require bit-prefix modeling for
+addition or subtraction, or value-range modeling for a dynamic selector.
+
+### Portability ceiling
+
+The default analyzer may use information beyond the minimum profile without
+requiring that every analyzer start from the same unoptimized representation.
+However, a refinement beyond the profile shall be the sole reason for accepting
+a program only when at least one of the following is true:
+
+- the refinement has been added to the portability profile based on downstream
+  interoperability results; or
+- the transformation which removes the dependency is materialized in the
+  representation emitted to downstream tools.
+
+For example, an optimizer may prove that correlated operands produce a
+constant. The default analyzer may rely on that fact for acceptance when the
+emitted design contains the resulting constant or an equivalent form without
+that dependency. It shall not rely on the proof while emitting the original
+expression and requiring every downstream tool to rediscover it.
+
+The same rule applies to value ranges, relationships between selectors,
+algebraic cancellation, and operator-specific precision beyond the profile.
+These facts may always be used for performance, diagnostics, or to construct the
+emitted representation; the restriction concerns using an unmaterialized fact
+as the final reason to suppress a hard error.
+
+Tool-specific or experimental analysis modes may choose a different point
+within the general acceptance bounds, but shall not silently replace the
+default portability profile. Changes to the default profile which can turn a
+previously accepted design into an error are compatibility changes, even when
+both behaviors fall within the wider language bounds.
+
 ## Permitted precision
 
-An implementation may use any fact which is valid for the representation it
-analyzes. It may analyze optimized or unoptimized input. It may, but need not,
-use:
+Within the wider acceptance bounds, an implementation may use any fact which is
+valid for the representation it analyzes. It may analyze optimized or
+unoptimized input. The default analyzer additionally observes the portability
+profile above. An implementation may, but need not, use:
 
 - packed bit positions and unpacked element positions;
 - constant values, unreachable control-flow paths, and short-circuit facts;

--- a/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
+++ b/crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md
@@ -323,6 +323,12 @@ unresolved hierarchy, unresolved recursive calls or cyclic concrete
 specialization graphs, unevaluated generic shapes, unanalyzed loops, timed or
 event effects, and legal constructs not yet represented by the analyzer.
 
+A dynamic access is not incomplete merely because its exact selected region is
+unknown. If its object or longest static prefix has a known shape, whole
+dependency over that bounded region is conservative and complete. The access is
+incomplete only when the enclosing region itself cannot be bounded or when its
+mapping is lost across another incomplete boundary.
+
 The acceptance equation above applies to the portion for which analysis is
 complete. Incomplete behavior has these rules:
 

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -34,6 +34,7 @@ toml                = {workspace = true}
 thiserror           = {workspace = true}
 vcd                 = {workspace = true}
 veryl-component-sys = {version = "0.1.1", path = "../component/sys"}
+veryl-causal        = {version = "0.20.3", path = "../causal"}
 veryl-metadata      = {version = "0.20.3", path = "../metadata"}
 veryl-parser        = {version = "0.20.3", path = "../parser"}
 
@@ -41,7 +42,8 @@ veryl-parser        = {version = "0.20.3", path = "../parser"}
 miette          = {workspace = true, features = ["fancy-no-syscall"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-miette          = {workspace = true, features = ["fancy"]}
+miette = {workspace = true, features = ["fancy"]}
+rayon  = {workspace = true}
 
 [dev-dependencies]
 toml = {workspace = true}

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -22,6 +22,7 @@ log                 = {workspace = true}
 num-bigint          = {workspace = true}
 num-traits          = {workspace = true}
 paste               = {workspace = true}
+petgraph            = {workspace = true}
 postcard            = {workspace = true}
 similar             = {workspace = true}
 smallvec            = {workspace = true}

--- a/crates/analyzer/src/analyzer.rs
+++ b/crates/analyzer/src/analyzer.rs
@@ -266,7 +266,7 @@ impl Analyzer {
 
         ret.append(&mut symbol_table::check_unused_variable());
         ret.append(&mut symbol_table::check_wavedrom());
-        ret.append(&mut comb_loop_detect::check(ir));
+        ret.append(&mut comb_loop_detect::check_analyzer(ir));
 
         ret
     }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1880,6 +1880,7 @@ fn add_inst_feedthrough_edges(
             let Some(parent_outputs) =
                 map_child_periodic_output(periodic, child, &output.dst, parent_vars, ctx)
             else {
+                incomplete.insert(IncompleteReason::DynamicRegion);
                 continue;
             };
             for input_region in parent_inputs {
@@ -2222,32 +2223,45 @@ fn map_child_periodic_output(
         .checked_mul(variable.r#type.total_array().unwrap_or(1))?;
     let mapped =
         map_destinations_span_positioned(destinations, Span { start: 0, length }, variables, ctx)?;
-    if mapped.len() != 1 {
-        return None;
-    }
-    let positioned = &mapped[0];
-    let Region::Exact {
-        object,
-        span: destination,
-    } = positioned.region
-    else {
-        return None;
-    };
-    if !positioned.aligned
-        || positioned.expression.start != 0
-        || positioned.expression.length != length
-        || destination.length != length
-    {
-        return None;
-    }
-    Some(vec![PeriodicRegion {
-        object,
-        output: Span {
-            start: destination.start.checked_add(periodic.output.start)?,
+    let transfer = AlignedDependency {
+        read: 0,
+        kind: EdgeKind::Value,
+        source: Span {
+            start: 0,
             length: periodic.output.length,
         },
+        destination: periodic.output,
         axes: periodic.axes.clone(),
-    }])
+    };
+    let mut outputs = Vec::new();
+    for positioned in mapped {
+        let Region::Exact {
+            object,
+            span: destination,
+        } = positioned.region
+        else {
+            return None;
+        };
+        if !positioned.aligned
+            || !positioned.axes.is_empty()
+            || destination.length != positioned.expression.length
+        {
+            return None;
+        }
+        for clipped in
+            crate::comb_memory_ssa::clip_aligned_dependency(&transfer, positioned.expression)?
+        {
+            outputs.push(PeriodicRegion {
+                object,
+                output: Span {
+                    start: destination.start.checked_add(clipped.destination.start)?,
+                    length: clipped.destination.length,
+                },
+                axes: clipped.axes,
+            });
+        }
+    }
+    Some(outputs)
 }
 
 fn expression_has_hierarchical_reference(expression: &Expression) -> bool {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -110,7 +110,7 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
     let mut incomplete = Vec::new();
     let mut summaries: HashMap<StrId, ModuleCombSummary> = HashMap::default();
 
-    let (order, recursive_modules) = topo_order_modules(ir);
+    let (order, recursion_affected_modules) = topo_order_modules(ir);
 
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
@@ -123,7 +123,7 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
                 continue;
             }
             let (graph, mut reasons, bit_part) = build_module_graph(module, &summaries);
-            if recursive_modules {
+            if recursion_affected_modules.contains(&idx) {
                 reasons.insert(IncompleteReason::RecursiveCall);
             }
             check_graph(module, &graph, &mut errors);
@@ -141,9 +141,10 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
     CombAnalysisResult { errors, incomplete }
 }
 
-/// Children before parents. Falls back to input order on cycle
-/// (`infinite_recursion` is reported separately).
-fn topo_order_modules(ir: &Ir) -> (Vec<usize>, bool) {
+/// Children before parents. Modules in, or transitively depending on, an
+/// instantiation cycle are appended in input order because no bottom-up order
+/// exists for them (`infinite_recursion` is reported separately).
+fn topo_order_modules(ir: &Ir) -> (Vec<usize>, HashSet<usize>) {
     let mut name_to_idx: HashMap<StrId, usize> = HashMap::default();
     for (i, c) in ir.components.iter().enumerate() {
         if let Component::Module(m) = c {
@@ -160,7 +161,6 @@ fn topo_order_modules(ir: &Ir) -> (Vec<usize>, bool) {
             for inst in walk_insts(m) {
                 if let Component::Module(child) = inst.component.as_ref()
                     && let Some(&child_idx) = name_to_idx.get(&child.name)
-                    && child_idx != i
                 {
                     deps[i].insert(child_idx);
                     rev_deps[child_idx].insert(i);
@@ -169,10 +169,24 @@ fn topo_order_modules(ir: &Ir) -> (Vec<usize>, bool) {
         }
     }
 
-    let mut indeg: Vec<usize> = deps.iter().map(|s| s.len()).collect();
+    let is_module = ir
+        .components
+        .iter()
+        .map(|component| matches!(component, Component::Module(_)))
+        .collect::<Vec<_>>();
+    order_from_dependencies(&is_module, &deps, &rev_deps)
+}
+
+fn order_from_dependencies(
+    is_module: &[bool],
+    deps: &[HashSet<usize>],
+    rev_deps: &[HashSet<usize>],
+) -> (Vec<usize>, HashSet<usize>) {
+    let n = is_module.len();
+    let mut indeg: Vec<usize> = deps.iter().map(HashSet::len).collect();
     let mut q: VecDeque<usize> = VecDeque::new();
     for (i, _) in indeg.iter().enumerate().take(n) {
-        if matches!(ir.components.get(i), Some(Component::Module(_))) && indeg[i] == 0 {
+        if is_module[i] && indeg[i] == 0 {
             q.push_back(i);
         }
     }
@@ -186,22 +200,14 @@ fn topo_order_modules(ir: &Ir) -> (Vec<usize>, bool) {
             }
         }
     }
-    if order.len()
-        != ir
-            .components
-            .iter()
-            .filter(|c| matches!(c, Component::Module(_)))
-            .count()
-    {
-        // Cycle in module graph -- emit imprecise reports anyway.
-        return (
-            (0..n)
-                .filter(|i| matches!(ir.components.get(*i), Some(Component::Module(_))))
-                .collect(),
-            true,
-        );
-    }
-    (order, false)
+    let ordered = order.iter().copied().collect::<HashSet<_>>();
+    let recursion_affected = (0..n)
+        .filter(|i| is_module[*i] && !ordered.contains(i))
+        .collect::<HashSet<_>>();
+    order.extend(recursion_affected.iter().copied());
+    // HashSet iteration is intentionally not part of summary identity.
+    order[ordered.len()..].sort_unstable();
+    (order, recursion_affected)
 }
 
 fn walk_insts(module: &Module) -> impl Iterator<Item = &InstDeclaration> {
@@ -1532,6 +1538,29 @@ fn mask_spans(mask: &BigUint, width: usize) -> Vec<Span> {
 #[cfg(test)]
 mod memory_ssa_tests {
     use super::*;
+
+    #[test]
+    fn recursive_module_does_not_taint_independent_modules() {
+        // Why this case exists: one recursive hierarchy makes only its SCC and
+        // transitive parents incomplete. Marking an independent hierarchy as
+        // RecursiveCall needlessly discards a valid bottom-up summary.
+        fn set(values: &[usize]) -> HashSet<usize> {
+            values.iter().copied().collect()
+        }
+
+        let is_module = [true, true, true, true];
+        let deps = [set(&[0]), HashSet::default(), set(&[0]), set(&[1])];
+        let rev_deps = [
+            set(&[0, 2]),
+            set(&[3]),
+            HashSet::default(),
+            HashSet::default(),
+        ];
+
+        let (order, affected) = order_from_dependencies(&is_module, &deps, &rev_deps);
+        assert_eq!(order, vec![1, 3, 0, 2]);
+        assert_eq!(affected, set(&[0, 2]));
+    }
 
     #[test]
     fn atomic_ranges_split_at_sparse_mask_transitions() {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -15,9 +15,9 @@ use crate::HashSet;
 use crate::conv::Context;
 use crate::ir::VarId;
 use crate::ir::{
-    AssignDestination, AssignStatement, CaseStatement, Component, Declaration, Expression, Factor,
-    ForBound, ForRange, ForStatement, FunctionCall, IfStatement, InstDeclaration, Ir, Module, Op,
-    Statement, SystemFunctionKind, VarIndex, VarSelect, Variable,
+    ArrayLiteralItem, AssignDestination, AssignStatement, CaseStatement, Component, Declaration,
+    Expression, Factor, ForBound, ForRange, ForStatement, FunctionCall, IfStatement,
+    InstDeclaration, Ir, Module, Op, Statement, SystemFunctionKind, VarIndex, VarSelect, Variable,
 };
 use crate::symbol::{Affiliation, Direction};
 use crate::value::ValueBigUint;
@@ -114,7 +114,7 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
             if module.suppress_unassigned {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
-                    reasons: [IncompleteReason::UnsupportedSyntax].into(),
+                    reasons: [IncompleteReason::UnevaluatedGeneric].into(),
                 });
                 continue;
             }
@@ -203,7 +203,13 @@ fn topo_order_modules(ir: &Ir) -> (Vec<usize>, bool) {
 fn walk_insts(module: &Module) -> impl Iterator<Item = &InstDeclaration> {
     module.declarations.iter().filter_map(|d| match d {
         Declaration::Inst(inst) => Some(inst.as_ref()),
-        _ => None,
+        Declaration::Comb(_)
+        | Declaration::Ff(_)
+        | Declaration::External(_)
+        | Declaration::Initial(_)
+        | Declaration::Final(_)
+        | Declaration::Unsupported(_)
+        | Declaration::Null => None,
     })
 }
 
@@ -490,7 +496,13 @@ fn build_module_graph(
     // summary path until the same region vocabulary crosses module boundaries.
     let analyze_declaration = |declaration: &Declaration| match declaration {
         Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze(module, comb)),
-        _ => None,
+        Declaration::Ff(_)
+        | Declaration::Inst(_)
+        | Declaration::External(_)
+        | Declaration::Initial(_)
+        | Declaration::Final(_)
+        | Declaration::Unsupported(_)
+        | Declaration::Null => None,
     };
     #[cfg(not(target_family = "wasm"))]
     let procedure_summaries = module
@@ -531,9 +543,14 @@ fn build_module_graph(
                 incomplete.insert(IncompleteReason::ExternalComponent);
             }
             Declaration::Unsupported(_) => {
-                incomplete.insert(IncompleteReason::UnsupportedSyntax);
+                incomplete.insert(IncompleteReason::MalformedModel);
             }
-            _ => {}
+            Declaration::Comb(_)
+            | Declaration::Ff(_)
+            | Declaration::Inst(_)
+            | Declaration::Initial(_)
+            | Declaration::Final(_)
+            | Declaration::Null => {}
         }
     }
     #[cfg(target_family = "wasm")]
@@ -549,7 +566,7 @@ fn build_module_graph(
                 add_memory_ssa_edges(module, summary, &bit_part, &mut graph, &mut node_map);
             }
             Err(error) => {
-                incomplete.insert(IncompleteReason::UnsupportedSyntax);
+                incomplete.insert(IncompleteReason::MalformedModel);
                 log::debug!(
                     "failed to build comb MemorySSA for {}: {error}",
                     module.name
@@ -748,17 +765,10 @@ fn add_memory_ssa_edges(
     graph: &mut Graph<NodeKey, ()>,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
 ) {
-    // Unknown control/effects invalidate a whole procedure. Dynamic regions
-    // are narrower: they invalidate only their owning objects, so a dynamic
-    // memory write cannot hide an unrelated scalar loop.
-    if summary.unknown_all
-        || summary
-            .incomplete
-            .iter()
-            .any(|reason| *reason != IncompleteReason::DynamicRegion)
-    {
-        return;
-    }
+    // Incomplete effects are represented by Unknown edges/regions in the
+    // causal model. They must not erase independent, proven dependencies from
+    // the same procedure: doing so lets one opaque read hide an unrelated
+    // scalar loop. Only proven (non-Unknown) edges become hard diagnostics.
     for dependency in &summary.dependencies {
         if dependency.kind == EdgeKind::Unknown {
             continue;
@@ -792,7 +802,22 @@ fn region_node_keys(
     let (object, span) = match region {
         Region::Exact { object, span } => (object, span),
         Region::UnknownObject(object) => {
-            return vec![(object, UNKNOWN_REGION_INDEX, UNKNOWN_REGION_INDEX)];
+            // Alias every region of this object which is otherwise observable
+            // in the sparse partition. This is proportional to touched
+            // regions, not to the declared array size.
+            let mut keys = bit_part
+                .ranges
+                .keys()
+                .filter(|(candidate, _)| *candidate == object)
+                .flat_map(|&(candidate, element)| {
+                    (0..bit_part.ranges_of((candidate, element)).len())
+                        .map(move |range| (candidate, element, range))
+                })
+                .collect::<Vec<_>>();
+            keys.push((object, UNKNOWN_REGION_INDEX, UNKNOWN_REGION_INDEX));
+            keys.sort_unstable();
+            keys.dedup();
+            return keys;
         }
         Region::UnknownAll => return Vec::new(),
     };
@@ -855,16 +880,18 @@ fn collect_instance_summary_regions(
             let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
                 continue;
             };
-            if let Some(mapped) =
+            regions.extend(
                 map_expression_span_to_regions(&input.expr, input_span, &module.variables, ctx)
-            {
-                regions.extend(mapped);
-            }
-            if let Some(mapped) =
+                    .unwrap_or_else(|| {
+                        collect_expression_regions(&input.expr, &module.variables, ctx)
+                    }),
+            );
+            regions.extend(
                 map_destinations_span_to_regions(&output.dst, output_span, &module.variables, ctx)
-            {
-                regions.extend(mapped);
-            }
+                    .unwrap_or_else(|| {
+                        collect_destination_regions(&output.dst, &module.variables, ctx)
+                    }),
+            );
         }
     }
     regions
@@ -908,18 +935,15 @@ fn add_inst_feedthrough_edges(
         let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
             continue;
         };
-        let Some(parent_input_regions) =
+        if expression_has_hierarchical_reference(&input.expr) {
+            incomplete.insert(IncompleteReason::HierarchicalReference);
+        }
+        let parent_input_regions =
             map_expression_span_to_regions(&input.expr, input_span, parent_vars, ctx)
-        else {
-            incomplete.insert(IncompleteReason::UnsupportedSyntax);
-            continue;
-        };
-        let Some(parent_output_regions) =
+                .unwrap_or_else(|| collect_expression_regions(&input.expr, parent_vars, ctx));
+        let parent_output_regions =
             map_destinations_span_to_regions(&output.dst, output_span, parent_vars, ctx)
-        else {
-            incomplete.insert(IncompleteReason::UnsupportedSyntax);
-            continue;
-        };
+                .unwrap_or_else(|| collect_destination_regions(&output.dst, parent_vars, ctx));
         for input_region in parent_input_regions {
             for source in region_node_keys(input_region, parent_vars, bit_part) {
                 for &output_region in &parent_output_regions {
@@ -934,6 +958,81 @@ fn add_inst_feedthrough_edges(
     }
 }
 
+fn expression_has_hierarchical_reference(expression: &Expression) -> bool {
+    match expression {
+        Expression::Term(factor) => match factor.as_ref() {
+            Factor::HierVariable(_) => true,
+            Factor::Variable(_, index, select, _) => {
+                index
+                    .0
+                    .iter()
+                    .chain(select.0.iter())
+                    .any(expression_has_hierarchical_reference)
+                    || select
+                        .1
+                        .as_ref()
+                        .is_some_and(|(_, width)| expression_has_hierarchical_reference(width))
+            }
+            Factor::SystemFunctionCall(call) => match &call.kind {
+                SystemFunctionKind::Bits(input)
+                | SystemFunctionKind::Size(input)
+                | SystemFunctionKind::Clog2(input)
+                | SystemFunctionKind::Onehot(input)
+                | SystemFunctionKind::Signed(input)
+                | SystemFunctionKind::Unsigned(input) => {
+                    expression_has_hierarchical_reference(&input.0)
+                }
+                SystemFunctionKind::Readmemh(input, _) => {
+                    expression_has_hierarchical_reference(&input.0)
+                }
+                SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => inputs
+                    .iter()
+                    .any(|input| expression_has_hierarchical_reference(&input.0)),
+                SystemFunctionKind::Assert { cond, args, .. } => {
+                    expression_has_hierarchical_reference(&cond.0)
+                        || args
+                            .iter()
+                            .any(|input| expression_has_hierarchical_reference(&input.0))
+                }
+                SystemFunctionKind::Finish => false,
+            },
+            Factor::FunctionCall(call) => call
+                .inputs
+                .values()
+                .any(expression_has_hierarchical_reference),
+            Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => false,
+        },
+        Expression::Unary(_, operand, _) => expression_has_hierarchical_reference(operand),
+        Expression::Binary(left, _, right, _) => {
+            expression_has_hierarchical_reference(left)
+                || expression_has_hierarchical_reference(right)
+        }
+        Expression::Ternary(condition, left, right, _) => {
+            expression_has_hierarchical_reference(condition)
+                || expression_has_hierarchical_reference(left)
+                || expression_has_hierarchical_reference(right)
+        }
+        Expression::Concatenation(parts, _) => parts.iter().any(|(part, repeat)| {
+            expression_has_hierarchical_reference(part)
+                || repeat
+                    .as_ref()
+                    .is_some_and(expression_has_hierarchical_reference)
+        }),
+        Expression::ArrayLiteral(items, _) => items.iter().any(|item| match item {
+            ArrayLiteralItem::Value(value, repeat) => {
+                expression_has_hierarchical_reference(value)
+                    || repeat
+                        .as_ref()
+                        .is_some_and(|repeat| expression_has_hierarchical_reference(repeat))
+            }
+            ArrayLiteralItem::Defaul(value) => expression_has_hierarchical_reference(value),
+        }),
+        Expression::StructConstructor(_, fields, _) => fields
+            .iter()
+            .any(|(_, value)| expression_has_hierarchical_reference(value)),
+    }
+}
+
 fn map_expression_span_to_regions(
     expression: &Expression,
     requested: Span,
@@ -942,6 +1041,9 @@ fn map_expression_span_to_regions(
 ) -> Option<Vec<Region<VarId>>> {
     if requested.end()? > expression.comptime().r#type.total_width()? {
         return None;
+    }
+    if let Some(mapped) = crate::comb_memory_ssa::map_expression_span(ctx, expression, requested) {
+        return Some(mapped);
     }
     match expression {
         Expression::Term(factor) => match factor.as_ref() {
@@ -1057,6 +1159,152 @@ fn map_destinations_span_to_regions(
         low = low.checked_add(span.length)?;
     }
     (requested.end()? <= low).then_some(mapped)
+}
+
+/// Conservative fallback for expression forms without a positional bit map.
+///
+/// This is deliberately exhaustive over the analyzer IR. A new expression or
+/// factor variant must choose its causal operands here instead of silently
+/// turning a legal instance connection into an unsupported procedure.
+fn collect_expression_regions(
+    expression: &Expression,
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Vec<Region<VarId>> {
+    fn collect(
+        expression: &Expression,
+        variables: &HashMap<VarId, Variable>,
+        ctx: &mut Context,
+        regions: &mut Vec<Region<VarId>>,
+    ) {
+        match expression {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(id, index, select, _) => {
+                    for address in index.0.iter().chain(select.0.iter()) {
+                        collect(address, variables, ctx, regions);
+                    }
+                    if let Some((_, width)) = &select.1 {
+                        collect(width, variables, ctx, regions);
+                    }
+                    regions.push(variable_access_region(*id, index, select, variables, ctx));
+                }
+                Factor::SystemFunctionCall(call) => match &call.kind {
+                    SystemFunctionKind::Bits(_)
+                    | SystemFunctionKind::Size(_)
+                    | SystemFunctionKind::Clog2(_)
+                    | SystemFunctionKind::Finish => {}
+                    SystemFunctionKind::Onehot(input)
+                    | SystemFunctionKind::Signed(input)
+                    | SystemFunctionKind::Unsigned(input) => {
+                        collect(&input.0, variables, ctx, regions);
+                    }
+                    SystemFunctionKind::Readmemh(input, output) => {
+                        collect(&input.0, variables, ctx, regions);
+                        regions.extend(collect_destination_regions(&output.0, variables, ctx));
+                    }
+                    SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
+                        for input in inputs {
+                            collect(&input.0, variables, ctx, regions);
+                        }
+                    }
+                    SystemFunctionKind::Assert { cond, args, .. } => {
+                        collect(&cond.0, variables, ctx, regions);
+                        for input in args {
+                            collect(&input.0, variables, ctx, regions);
+                        }
+                    }
+                },
+                Factor::FunctionCall(call) => {
+                    // A malformed/recursive function which could not produce
+                    // a positional summary still retains its syntactic input
+                    // dependencies without inventing an unknown object.
+                    for input in call.inputs.values() {
+                        collect(input, variables, ctx, regions);
+                    }
+                }
+                Factor::HierVariable(_)
+                | Factor::Value(_)
+                | Factor::Anonymous(_)
+                | Factor::Unknown(_) => {}
+            },
+            Expression::Unary(_, operand, _) => collect(operand, variables, ctx, regions),
+            Expression::Binary(left, _, right, _) => {
+                collect(left, variables, ctx, regions);
+                collect(right, variables, ctx, regions);
+            }
+            Expression::Ternary(condition, left, right, _) => {
+                collect(condition, variables, ctx, regions);
+                collect(left, variables, ctx, regions);
+                collect(right, variables, ctx, regions);
+            }
+            Expression::Concatenation(parts, _) => {
+                for (part, repeat) in parts {
+                    collect(part, variables, ctx, regions);
+                    if let Some(repeat) = repeat {
+                        collect(repeat, variables, ctx, regions);
+                    }
+                }
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(value, repeat) => {
+                            collect(value, variables, ctx, regions);
+                            if let Some(repeat) = repeat {
+                                collect(repeat, variables, ctx, regions);
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(value) => {
+                            collect(value, variables, ctx, regions);
+                        }
+                    }
+                }
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, value) in fields {
+                    collect(value, variables, ctx, regions);
+                }
+            }
+        }
+    }
+
+    let mut regions = Vec::new();
+    collect(expression, variables, ctx, &mut regions);
+    regions.sort_unstable();
+    regions.dedup();
+    regions
+}
+
+fn collect_destination_regions(
+    destinations: &[AssignDestination],
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Vec<Region<VarId>> {
+    let mut regions = destinations
+        .iter()
+        .map(|destination| {
+            variable_access_region(
+                destination.id,
+                &destination.index,
+                &destination.select,
+                variables,
+                ctx,
+            )
+        })
+        .collect::<Vec<_>>();
+    regions.sort_unstable();
+    regions.dedup();
+    regions
+}
+
+fn variable_access_region(
+    id: VarId,
+    index: &VarIndex,
+    select: &VarSelect,
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Region<VarId> {
+    exact_variable_region(id, index, select, variables, ctx).unwrap_or(Region::UnknownObject(id))
 }
 
 fn exact_variable_region(

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -20,6 +20,7 @@ use crate::ir::{
 };
 use crate::symbol::{Affiliation, Direction};
 use crate::value::ValueBigUint;
+use daggy::petgraph::Direction::Incoming;
 use daggy::petgraph::Graph;
 use daggy::petgraph::algo::tarjan_scc;
 use daggy::petgraph::graph::NodeIndex;
@@ -40,6 +41,144 @@ type IdxKey = (VarId, usize);
 /// `BitPartition`, so bit-disjoint reads/writes form disjoint nodes.
 type NodeKey = (VarId, usize, usize);
 
+#[derive(Clone, Copy)]
+enum SummaryDirection {
+    Forward,
+    Reverse,
+}
+
+struct SummaryWalk {
+    direction: SummaryDirection,
+    endpoints: Vec<(NodeIndex, NodeKey)>,
+    next_endpoint: usize,
+    current_key: Option<NodeKey>,
+    visited: HashSet<(NodeIndex, bool)>,
+    stack: Vec<(NodeIndex, bool)>,
+    dependencies: BTreeMap<(Region<VarId>, Region<VarId>), bool>,
+}
+
+impl SummaryWalk {
+    fn new(direction: SummaryDirection, endpoints: Vec<(NodeIndex, NodeKey)>) -> Self {
+        Self {
+            direction,
+            endpoints,
+            next_endpoint: 0,
+            current_key: None,
+            visited: HashSet::default(),
+            stack: Vec::new(),
+            dependencies: BTreeMap::new(),
+        }
+    }
+
+    /// Advance a bounded amount of graph work. Running forward and reverse
+    /// walks in equal quanta lets the cheaper direction finish without an
+    /// endpoint-count heuristic committing to an adversarially expensive side.
+    fn advance(
+        &mut self,
+        graph: &Graph<NodeKey, bool>,
+        live_nodes: &[bool],
+        module: &Module,
+        bit_part: &BitPartition,
+        input_ids: &HashSet<VarId>,
+        output_ids: &HashSet<VarId>,
+        budget: usize,
+    ) -> bool {
+        let mut work = 0usize;
+        while work < budget {
+            if self.stack.is_empty() {
+                let Some(&(endpoint, key)) = self.endpoints.get(self.next_endpoint) else {
+                    return true;
+                };
+                self.next_endpoint += 1;
+                self.current_key = Some(key);
+                self.visited.clear();
+                self.stack.push((endpoint, true));
+            }
+            let Some((node, path_aligned)) = self.stack.pop() else {
+                continue;
+            };
+            work += 1;
+            if !self.visited.insert((node, path_aligned)) {
+                continue;
+            }
+            let endpoint_key = self.current_key.expect("active summary endpoint");
+            let node_key = graph[node];
+            let pair = match self.direction {
+                SummaryDirection::Forward if output_ids.contains(&node_key.0) => {
+                    Some((endpoint_key, node_key))
+                }
+                SummaryDirection::Reverse if input_ids.contains(&node_key.0) => {
+                    Some((node_key, endpoint_key))
+                }
+                SummaryDirection::Forward | SummaryDirection::Reverse => None,
+            };
+            if let Some((input_key, output_key)) = pair {
+                for input in node_key_regions(input_key, module, bit_part) {
+                    for output in node_key_regions(output_key, module, bit_part) {
+                        self.dependencies
+                            .entry((input, output))
+                            .and_modify(|aligned| *aligned &= path_aligned)
+                            .or_insert(path_aligned);
+                    }
+                }
+            }
+            match self.direction {
+                SummaryDirection::Forward => {
+                    self.stack.extend(
+                        graph
+                            .edges(node)
+                            .filter(|edge| live_nodes[edge.target().index()])
+                            .map(|edge| (edge.target(), path_aligned && *edge.weight())),
+                    );
+                }
+                SummaryDirection::Reverse => {
+                    self.stack.extend(
+                        graph
+                            .edges_directed(node, Incoming)
+                            .filter(|edge| live_nodes[edge.source().index()])
+                            .map(|edge| (edge.source(), path_aligned && *edge.weight())),
+                    );
+                }
+            }
+        }
+        self.stack.is_empty() && self.next_endpoint == self.endpoints.len()
+    }
+}
+
+fn live_summary_nodes(
+    graph: &Graph<NodeKey, bool>,
+    inputs: &[(NodeIndex, NodeKey)],
+    outputs: &[(NodeIndex, NodeKey)],
+) -> Vec<bool> {
+    let mut reachable_from_input = vec![false; graph.node_count()];
+    let mut stack = inputs.iter().map(|&(node, _)| node).collect::<Vec<_>>();
+    while let Some(node) = stack.pop() {
+        if std::mem::replace(&mut reachable_from_input[node.index()], true) {
+            continue;
+        }
+        stack.extend(graph.edges(node).map(|edge| edge.target()));
+    }
+
+    let mut reaches_output = vec![false; graph.node_count()];
+    stack.extend(outputs.iter().map(|&(node, _)| node));
+    while let Some(node) = stack.pop() {
+        if std::mem::replace(&mut reaches_output[node.index()], true) {
+            continue;
+        }
+        stack.extend(
+            graph
+                .edges_directed(node, Incoming)
+                .map(|edge| edge.source()),
+        );
+    }
+
+    reachable_from_input
+        .into_iter()
+        .zip(reaches_output)
+        .map(|(from_input, to_output)| from_input && to_output)
+        .collect()
+}
+
 /// Sparse alias node for a dynamically selected region of one object.  This
 /// deliberately occupies no real array element or bit-partition slot.
 const UNKNOWN_REGION_INDEX: usize = usize::MAX;
@@ -48,7 +187,7 @@ const UNKNOWN_REGION_INDEX: usize = usize::MAX;
 /// iff they appear in the same set of per-decl masks.
 #[derive(Default)]
 struct BitPartition {
-    ranges: HashMap<IdxKey, Vec<BigUint>>,
+    ranges: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
     /// Stable identities for unresolved regions. They are graph nodes, not
     /// array elements, so their count depends on accesses rather than width.
     wildcards: Vec<Region<VarId>>,
@@ -57,7 +196,11 @@ struct BitPartition {
 impl BitPartition {
     /// Empty slice means the variable's bits are untouched.
     fn ranges_of(&self, key: IdxKey) -> &[BigUint] {
-        self.ranges.get(&key).map(|v| v.as_slice()).unwrap_or(&[])
+        self.ranges
+            .get(&key.0)
+            .and_then(|elements| elements.get(&key.1))
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 
     fn wildcard_keys(&self, region: Region<VarId>) -> Vec<NodeKey> {
@@ -346,7 +489,7 @@ fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) ->
         collect_region_mask(region, module, &mut masks);
     }
 
-    let mut ranges: HashMap<(VarId, usize), Vec<BigUint>> = HashMap::default();
+    let mut ranges: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>> = HashMap::default();
     for (key, ms) in masks {
         let width = module
             .variables
@@ -355,7 +498,7 @@ fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) ->
             .unwrap_or(1);
         let parts = atomic_ranges(&ms, width);
         if !parts.is_empty() {
-            ranges.insert(key, parts);
+            ranges.entry(key.0).or_default().insert(key.1, parts);
         }
     }
 
@@ -574,7 +717,72 @@ fn propagate_aligned_regions(
     regions: Vec<Region<VarId>>,
     summaries: &[Result<ProcedureSummary<VarId>, veryl_causal::procedure::ProcedureError>],
 ) -> Vec<Region<VarId>> {
-    let transfers = summaries
+    #[derive(Clone, Copy)]
+    struct Transfer {
+        from: Span,
+        to_object: VarId,
+        to: Span,
+    }
+
+    struct TransferIndex {
+        transfers: Vec<Transfer>,
+        leaf_base: usize,
+        max_end: Vec<usize>,
+    }
+
+    impl TransferIndex {
+        fn new(mut transfers: Vec<Transfer>) -> Self {
+            transfers.sort_unstable_by_key(|transfer| transfer.from.start);
+            let leaf_base = transfers.len().next_power_of_two().max(1);
+            let mut max_end = vec![0; leaf_base * 2];
+            for (index, transfer) in transfers.iter().enumerate() {
+                max_end[leaf_base + index] = transfer.from.end().unwrap_or(usize::MAX);
+            }
+            for index in (1..leaf_base).rev() {
+                max_end[index] = max_end[index * 2].max(max_end[index * 2 + 1]);
+            }
+            Self {
+                transfers,
+                leaf_base,
+                max_end,
+            }
+        }
+
+        fn for_each_overlap(&self, span: Span, mut visit: impl FnMut(Transfer)) {
+            let Some(end) = span.end() else {
+                return;
+            };
+            let high = self
+                .transfers
+                .partition_point(|transfer| transfer.from.start < end);
+            self.visit_overlaps(1, 0, self.leaf_base, high, span.start, &mut visit);
+        }
+
+        fn visit_overlaps(
+            &self,
+            node: usize,
+            low: usize,
+            high: usize,
+            query_high: usize,
+            query_low: usize,
+            visit: &mut impl FnMut(Transfer),
+        ) {
+            if low >= query_high || self.max_end[node] <= query_low {
+                return;
+            }
+            if high - low == 1 {
+                if let Some(&transfer) = self.transfers.get(low) {
+                    visit(transfer);
+                }
+                return;
+            }
+            let middle = low + (high - low) / 2;
+            self.visit_overlaps(node * 2, low, middle, query_high, query_low, visit);
+            self.visit_overlaps(node * 2 + 1, middle, high, query_high, query_low, visit);
+        }
+    }
+
+    let raw_transfers = summaries
         .iter()
         .filter_map(|summary| summary.as_ref().ok())
         .flat_map(|summary| &summary.dependencies)
@@ -594,6 +802,20 @@ fn propagate_aligned_regions(
             _ => None,
         })
         .collect::<Vec<_>>();
+    let mut transfers = HashMap::<VarId, Vec<Transfer>>::default();
+    for (left, right) in raw_transfers {
+        for (from, to) in [(left, right), (right, left)] {
+            transfers.entry(from.0).or_default().push(Transfer {
+                from: from.1,
+                to_object: to.0,
+                to: to.1,
+            });
+        }
+    }
+    let transfers = transfers
+        .into_iter()
+        .map(|(object, transfers)| (object, TransferIndex::new(transfers)))
+        .collect::<HashMap<_, _>>();
     let mut known = regions.into_iter().collect::<BTreeSet<_>>();
     let mut pending = known
         .iter()
@@ -603,32 +825,30 @@ fn propagate_aligned_regions(
         let Region::Exact { object, span } = region else {
             continue;
         };
-        for &(left, right) in &transfers {
-            for (from, to) in [(left, right), (right, left)] {
-                if object != from.0 {
-                    continue;
-                }
-                let Some(overlap) = span.intersection(from.1) else {
-                    continue;
-                };
-                let Some(offset) = overlap.start.checked_sub(from.1.start) else {
-                    continue;
-                };
-                let Some(start) = to.1.start.checked_add(offset) else {
-                    continue;
-                };
-                let mapped = Region::Exact {
-                    object: to.0,
-                    span: Span {
-                        start,
-                        length: overlap.length,
-                    },
-                };
-                if known.insert(mapped) {
-                    pending.push_back(mapped);
-                }
+        let Some(object_transfers) = transfers.get(&object) else {
+            continue;
+        };
+        object_transfers.for_each_overlap(span, |transfer| {
+            let Some(overlap) = span.intersection(transfer.from) else {
+                return;
+            };
+            let Some(offset) = overlap.start.checked_sub(transfer.from.start) else {
+                return;
+            };
+            let Some(start) = transfer.to.start.checked_add(offset) else {
+                return;
+            };
+            let mapped = Region::Exact {
+                object: transfer.to_object,
+                span: Span {
+                    start,
+                    length: overlap.length,
+                },
+            };
+            if known.insert(mapped) {
+                pending.push_back(mapped);
             }
-        }
+        });
     }
     known.into_iter().collect()
 }
@@ -817,14 +1037,25 @@ fn sparse_exact_node_keys(
     let Some(width) = variables.get(&object).and_then(Variable::total_width) else {
         return Vec::new();
     };
+    if width == 0 {
+        return Vec::new();
+    }
     if span.end().is_none() {
         return Vec::new();
     }
+    let Some(elements) = bit_part.ranges.get(&object) else {
+        return Vec::new();
+    };
+    let Some(end) = span.end() else {
+        return Vec::new();
+    };
+    if span.length == 0 {
+        return Vec::new();
+    }
+    let first_element = span.start / width;
+    let last_element = (end - 1) / width;
     let mut keys = Vec::new();
-    for (&(candidate, element), ranges) in &bit_part.ranges {
-        if candidate != object {
-            continue;
-        }
+    for (&element, ranges) in elements.range(first_element..=last_element) {
         let Some(element_start) = element.checked_mul(width) else {
             continue;
         };
@@ -866,10 +1097,11 @@ fn region_node_keys(
         }
         Region::UnknownObject(object) => bit_part
             .ranges
-            .iter()
-            .filter(|((candidate, _), _)| *candidate == object)
-            .flat_map(|(&(candidate, element), ranges)| {
-                (0..ranges.len()).map(move |range| (candidate, element, range))
+            .get(&object)
+            .into_iter()
+            .flat_map(|elements| elements.iter())
+            .flat_map(|(&element, ranges)| {
+                (0..ranges.len()).map(move |range| (object, element, range))
             })
             .collect(),
         Region::UnknownAll => return Vec::new(),
@@ -1804,35 +2036,127 @@ fn compute_module_summary(
         }
     }
 
-    let mut dependencies = BTreeMap::new();
-    let mut visited: HashSet<(NodeIndex, bool)> = HashSet::default();
-    let mut stack: Vec<(NodeIndex, bool)> = Vec::new();
-    for ni in graph.node_indices() {
-        let key = graph[ni];
-        if !input_ids.contains(&key.0) {
-            continue;
+    let input_nodes = graph
+        .node_indices()
+        .filter_map(|node| {
+            let key = graph[node];
+            input_ids.contains(&key.0).then_some((node, key))
+        })
+        .collect::<Vec<_>>();
+    let output_nodes = graph
+        .node_indices()
+        .filter_map(|node| {
+            let key = graph[node];
+            output_ids.contains(&key.0).then_some((node, key))
+        })
+        .collect::<Vec<_>>();
+    if input_nodes.is_empty() || output_nodes.is_empty() {
+        return ModuleCombSummary::default();
+    }
+    let live_nodes = live_summary_nodes(graph, &input_nodes, &output_nodes);
+    let input_nodes = input_nodes
+        .into_iter()
+        .filter(|(node, _)| live_nodes[node.index()])
+        .collect::<Vec<_>>();
+    let output_nodes = output_nodes
+        .into_iter()
+        .filter(|(node, _)| live_nodes[node.index()])
+        .collect::<Vec<_>>();
+    if input_nodes.is_empty() || output_nodes.is_empty() {
+        return ModuleCombSummary::default();
+    }
+
+    const QUANTUM: usize = 512;
+    let winning_walks = if graph.node_count() < QUANTUM {
+        let (direction, endpoints) = if input_nodes.len() <= output_nodes.len() {
+            (SummaryDirection::Forward, input_nodes)
+        } else {
+            (SummaryDirection::Reverse, output_nodes)
+        };
+        let mut walk = SummaryWalk::new(direction, endpoints);
+        while !walk.advance(
+            graph,
+            &live_nodes,
+            module,
+            bit_part,
+            &input_ids,
+            &output_ids,
+            QUANTUM,
+        ) {}
+        vec![walk]
+    } else {
+        #[cfg(not(target_family = "wasm"))]
+        let lane_count = rayon::current_num_threads();
+        #[cfg(target_family = "wasm")]
+        let lane_count = 1usize;
+        let make_walks = |direction, endpoints: Vec<(NodeIndex, NodeKey)>| {
+            let lanes = lane_count.min(endpoints.len()).max(1);
+            let mut partitions = vec![Vec::new(); lanes];
+            for (index, endpoint) in endpoints.into_iter().enumerate() {
+                partitions[index % lanes].push(endpoint);
+            }
+            partitions
+                .into_iter()
+                .map(|endpoints| SummaryWalk::new(direction, endpoints))
+                .collect::<Vec<_>>()
+        };
+        let mut forward = make_walks(SummaryDirection::Forward, input_nodes);
+        let mut reverse = make_walks(SummaryDirection::Reverse, output_nodes);
+        loop {
+            let advance_side = |walks: &mut [SummaryWalk]| {
+                #[cfg(not(target_family = "wasm"))]
+                let complete = walks
+                    .par_iter_mut()
+                    .map(|walk| {
+                        walk.advance(
+                            graph,
+                            &live_nodes,
+                            module,
+                            bit_part,
+                            &input_ids,
+                            &output_ids,
+                            QUANTUM,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                #[cfg(target_family = "wasm")]
+                let complete = walks
+                    .iter_mut()
+                    .map(|walk| {
+                        walk.advance(
+                            graph,
+                            &live_nodes,
+                            module,
+                            bit_part,
+                            &input_ids,
+                            &output_ids,
+                            QUANTUM,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                complete.into_iter().all(|complete| complete)
+            };
+            #[cfg(not(target_family = "wasm"))]
+            let (forward_complete, reverse_complete) =
+                rayon::join(|| advance_side(&mut forward), || advance_side(&mut reverse));
+            #[cfg(target_family = "wasm")]
+            let (forward_complete, reverse_complete) =
+                (advance_side(&mut forward), advance_side(&mut reverse));
+            if forward_complete {
+                break forward;
+            }
+            if reverse_complete {
+                break reverse;
+            }
         }
-        visited.clear();
-        stack.clear();
-        stack.push((ni, true));
-        while let Some((n, path_aligned)) = stack.pop() {
-            if !visited.insert((n, path_aligned)) {
-                continue;
-            }
-            let nk = graph[n];
-            if output_ids.contains(&nk.0) {
-                for input in node_key_regions(key, module, bit_part) {
-                    for output in node_key_regions(nk, module, bit_part) {
-                        dependencies
-                            .entry((input, output))
-                            .and_modify(|aligned| *aligned &= path_aligned)
-                            .or_insert(path_aligned);
-                    }
-                }
-            }
-            for e in graph.edges(n) {
-                stack.push((e.target(), path_aligned && *e.weight()));
-            }
+    };
+    let mut dependencies = BTreeMap::new();
+    for walk in winning_walks {
+        for (pair, aligned) in walk.dependencies {
+            dependencies
+                .entry(pair)
+                .and_modify(|existing| *existing &= aligned)
+                .or_insert(aligned);
         }
     }
     ModuleCombSummary {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -3219,4 +3219,33 @@ mod memory_ssa_tests {
             }
         ));
     }
+
+    #[test]
+    fn diagnostic_witness_uses_one_short_real_cycle_from_a_larger_scc() {
+        // Why this case exists: a maximal SCC can contain both a short cycle
+        // and a longer return path. Once the source-level anchor is selected,
+        // diagnostics should show its shortest real return cycle instead of
+        // dumping every node or edge in the component.
+        let mut graph = CausalGraph::new();
+        let a = graph.add_node((VarId::from_raw(0), 0, 0));
+        let b = graph.add_node((VarId::from_raw(1), 0, 0));
+        let c = graph.add_node((VarId::from_raw(2), 0, 0));
+        let d = graph.add_node((VarId::from_raw(3), 0, 0));
+        graph.add_edge(a, b, CausalEdge::new(false, Some(TokenRange::default())));
+        graph.add_edge(b, a, CausalEdge::new(false, None));
+        graph.add_edge(b, c, CausalEdge::new(false, None));
+        graph.add_edge(c, d, CausalEdge::new(false, None));
+        graph.add_edge(d, a, CausalEdge::new(false, None));
+
+        let scc = strongly_connected_components(&graph)
+            .into_iter()
+            .find(|component| component.len() == 4)
+            .expect("one maximal SCC");
+        let witness = diagnostic_cycle_witness(&graph, &scc).expect("cycle witness");
+        let endpoints = witness
+            .into_iter()
+            .map(|edge| graph.edge_endpoints(edge).expect("live edge"))
+            .collect::<Vec<_>>();
+        assert_eq!(endpoints, vec![(a, b), (b, a)]);
+    }
 }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -26,8 +26,8 @@ use daggy::petgraph::graph::NodeIndex;
 use daggy::petgraph::visit::EdgeRef;
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
-use std::collections::BTreeSet;
 use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet};
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::ProcedureSummary;
 use veryl_causal::region::{Region, Span};
@@ -84,6 +84,7 @@ impl BitPartition {
 struct ModuleCombDependency {
     input: Region<VarId>,
     output: Region<VarId>,
+    aligned: bool,
 }
 
 /// Region-preserving combinational feedthrough across one module boundary.
@@ -360,7 +361,11 @@ fn collect_region_mask(
 fn build_module_graph(
     module: &Module,
     summaries: &HashMap<StrId, ModuleCombSummary>,
-) -> (Graph<NodeKey, ()>, BTreeSet<IncompleteReason>, BitPartition) {
+) -> (
+    Graph<NodeKey, bool>,
+    BTreeSet<IncompleteReason>,
+    BitPartition,
+) {
     // Procedural combinational declarations use statement-ordered region
     // MemorySSA. Keep instance declarations on the existing bottom-up module
     // summary path until the same region vocabulary crosses module boundaries.
@@ -402,7 +407,7 @@ fn build_module_graph(
     ));
     let bit_part = build_bit_partition(module, &partition_regions);
 
-    let mut graph: Graph<NodeKey, ()> = Graph::new();
+    let mut graph: Graph<NodeKey, bool> = Graph::new();
     let mut node_map: HashMap<NodeKey, NodeIndex> = HashMap::default();
     let mut incomplete = BTreeSet::new();
 
@@ -564,7 +569,7 @@ fn add_memory_ssa_edges(
     module: &Module,
     summary: &ProcedureSummary<VarId>,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, ()>,
+    graph: &mut Graph<NodeKey, bool>,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
 ) {
     // Incomplete effects are represented by Unknown edges/regions in the
@@ -577,7 +582,9 @@ fn add_memory_ssa_edges(
         }
         let input = sparse_input_region(summary, dependency.input, dependency.output);
         let output = sparse_output_region(summary, dependency.output);
-        let pairs = if dependency.aligned {
+        let preserve_alignment =
+            dependency.aligned && exact_regions_have_equal_length(input, output);
+        let pairs = if preserve_alignment {
             aligned_region_node_pairs(input, output, &module.variables, bit_part)
         } else {
             let sources = region_node_keys(input, &module.variables, bit_part);
@@ -601,7 +608,7 @@ fn add_memory_ssa_edges(
             }
             let source = ensure_node(graph, node_map, source);
             let destination = ensure_node(graph, node_map, destination);
-            graph.add_edge(source, destination, ());
+            graph.add_edge(source, destination, preserve_alignment);
         }
     }
 }
@@ -865,7 +872,7 @@ fn collect_instance_summary_regions(
 fn add_inst_output_address_edges(
     inst: &InstDeclaration,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, ()>,
+    graph: &mut Graph<NodeKey, bool>,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     parent_vars: &HashMap<VarId, Variable>,
     ctx: &mut Context,
@@ -889,7 +896,7 @@ fn add_inst_output_address_edges(
                     for destination in region_node_keys(destination_region, parent_vars, bit_part) {
                         let source = ensure_node(graph, node_map, source);
                         let destination = ensure_node(graph, node_map, destination);
-                        graph.add_edge(source, destination, ());
+                        graph.add_edge(source, destination, false);
                     }
                 }
             }
@@ -903,7 +910,7 @@ fn add_inst_feedthrough_edges(
     child: &Module,
     summary: &ModuleCombSummary,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, ()>,
+    graph: &mut Graph<NodeKey, bool>,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     parent_vars: &HashMap<VarId, Variable>,
     incomplete: &mut BTreeSet<IncompleteReason>,
@@ -934,18 +941,56 @@ fn add_inst_feedthrough_edges(
             map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
         let parent_output_regions =
             map_child_output_region(dependency.output, child, &output.dst, parent_vars, ctx);
-        for input_region in parent_input_regions {
-            for source in region_node_keys(input_region, parent_vars, bit_part) {
-                for &output_region in &parent_output_regions {
-                    for destination in region_node_keys(output_region, parent_vars, bit_part) {
-                        let source = ensure_node(graph, node_map, source);
-                        let destination = ensure_node(graph, node_map, destination);
-                        graph.add_edge(source, destination, ());
-                    }
-                }
-            }
+        let preserve_alignment = dependency.aligned
+            && parent_input_regions.len() == 1
+            && parent_output_regions.len() == 1
+            && exact_regions_have_equal_length(parent_input_regions[0], parent_output_regions[0]);
+        let pairs = if preserve_alignment {
+            aligned_region_node_pairs(
+                parent_input_regions[0],
+                parent_output_regions[0],
+                parent_vars,
+                bit_part,
+            )
+        } else {
+            parent_input_regions
+                .iter()
+                .copied()
+                .flat_map(|input_region| {
+                    let destinations = parent_output_regions
+                        .iter()
+                        .copied()
+                        .flat_map(|output_region| {
+                            region_node_keys(output_region, parent_vars, bit_part)
+                        })
+                        .collect::<Vec<_>>();
+                    region_node_keys(input_region, parent_vars, bit_part)
+                        .into_iter()
+                        .flat_map(move |source| {
+                            destinations
+                                .clone()
+                                .into_iter()
+                                .map(move |destination| (source, destination))
+                        })
+                })
+                .collect()
+        };
+        for (source, destination) in pairs {
+            let source = ensure_node(graph, node_map, source);
+            let destination = ensure_node(graph, node_map, destination);
+            graph.add_edge(source, destination, preserve_alignment);
         }
     }
+}
+
+fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) -> bool {
+    matches!(
+        (left, right),
+        (
+            Region::Exact { span: left, .. },
+            Region::Exact { span: right, .. }
+        ) if left.length == right.length
+    )
 }
 
 fn region_object(region: Region<VarId>) -> Option<VarId> {
@@ -1423,7 +1468,7 @@ fn is_pure_input_or_output(id: VarId, vars: &HashMap<VarId, Variable>, want: Dir
     actual == want
 }
 
-fn check_graph(module: &Module, graph: &Graph<NodeKey, ()>, errors: &mut Vec<AnalyzerError>) {
+fn check_graph(module: &Module, graph: &Graph<NodeKey, bool>, errors: &mut Vec<AnalyzerError>) {
     let sccs = tarjan_scc(graph);
     let mut reported: HashSet<Vec<NodeKey>> = HashSet::default();
     for scc in sccs {
@@ -1443,14 +1488,14 @@ fn check_graph(module: &Module, graph: &Graph<NodeKey, ()>, errors: &mut Vec<Ana
 }
 
 fn ensure_node(
-    graph: &mut Graph<NodeKey, ()>,
+    graph: &mut Graph<NodeKey, bool>,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     key: NodeKey,
 ) -> NodeIndex {
     *node_map.entry(key).or_insert_with(|| graph.add_node(key))
 }
 
-fn has_self_edge(graph: &Graph<NodeKey, ()>, node: NodeIndex) -> bool {
+fn has_self_edge(graph: &Graph<NodeKey, bool>, node: NodeIndex) -> bool {
     graph
         .edges(node)
         .any(|e| e.source() == node && e.target() == node)
@@ -1504,7 +1549,7 @@ fn is_module_scope_var(id: VarId, variables: &HashMap<VarId, Variable>) -> bool 
 
 fn compute_module_summary(
     module: &Module,
-    graph: &Graph<NodeKey, ()>,
+    graph: &Graph<NodeKey, bool>,
     bit_part: &BitPartition,
 ) -> ModuleCombSummary {
     use crate::ir::VarKind;
@@ -1523,9 +1568,9 @@ fn compute_module_summary(
         }
     }
 
-    let mut dependencies = BTreeSet::new();
-    let mut visited: HashSet<NodeIndex> = HashSet::default();
-    let mut stack: Vec<NodeIndex> = Vec::new();
+    let mut dependencies = BTreeMap::new();
+    let mut visited: HashSet<(NodeIndex, bool)> = HashSet::default();
+    let mut stack: Vec<(NodeIndex, bool)> = Vec::new();
     for ni in graph.node_indices() {
         let key = graph[ni];
         if !input_ids.contains(&key.0) {
@@ -1533,26 +1578,36 @@ fn compute_module_summary(
         }
         visited.clear();
         stack.clear();
-        stack.push(ni);
-        while let Some(n) = stack.pop() {
-            if !visited.insert(n) {
+        stack.push((ni, true));
+        while let Some((n, path_aligned)) = stack.pop() {
+            if !visited.insert((n, path_aligned)) {
                 continue;
             }
             let nk = graph[n];
             if output_ids.contains(&nk.0) {
                 for input in node_key_regions(key, module, bit_part) {
                     for output in node_key_regions(nk, module, bit_part) {
-                        dependencies.insert(ModuleCombDependency { input, output });
+                        dependencies
+                            .entry((input, output))
+                            .and_modify(|aligned| *aligned &= path_aligned)
+                            .or_insert(path_aligned);
                     }
                 }
             }
             for e in graph.edges(n) {
-                stack.push(e.target());
+                stack.push((e.target(), path_aligned && *e.weight()));
             }
         }
     }
     ModuleCombSummary {
-        dependencies: dependencies.into_iter().collect(),
+        dependencies: dependencies
+            .into_iter()
+            .map(|((input, output), aligned)| ModuleCombDependency {
+                input,
+                output,
+                aligned,
+            })
+            .collect(),
     }
 }
 

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -22,7 +22,6 @@ use crate::symbol::{Affiliation, Direction};
 use crate::value::ValueBigUint;
 use daggy::petgraph::Direction::Incoming;
 use daggy::petgraph::Graph;
-use daggy::petgraph::algo::tarjan_scc;
 use daggy::petgraph::graph::NodeIndex;
 use daggy::petgraph::visit::EdgeRef;
 #[cfg(not(target_family = "wasm"))]
@@ -1981,7 +1980,63 @@ fn check_graph(module: &Module, graph: &Graph<NodeKey, bool>, errors: &mut Vec<A
 }
 
 fn strongly_connected_components(graph: &Graph<NodeKey, bool>) -> Vec<Vec<NodeIndex>> {
-    tarjan_scc(graph)
+    let node_bound = graph
+        .node_indices()
+        .map(NodeIndex::index)
+        .max()
+        .map_or(0, |index| index + 1);
+
+    // Kosaraju's two passes are both iterative. Combinational dependency
+    // chains can be tens of thousands of nodes deep, so even a linear-time
+    // recursive SCC implementation can exhaust the compiler's call stack.
+    let mut visited = vec![false; node_bound];
+    let mut finish_order = Vec::with_capacity(graph.node_count());
+    for start in graph.node_indices() {
+        if visited[start.index()] {
+            continue;
+        }
+
+        let mut stack = vec![(start, false)];
+        while let Some((node, exiting)) = stack.pop() {
+            if exiting {
+                finish_order.push(node);
+                continue;
+            }
+            if visited[node.index()] {
+                continue;
+            }
+            visited[node.index()] = true;
+            stack.push((node, true));
+            for successor in graph.neighbors(node) {
+                if !visited[successor.index()] {
+                    stack.push((successor, false));
+                }
+            }
+        }
+    }
+
+    visited.fill(false);
+    let mut components = Vec::new();
+    for start in finish_order.into_iter().rev() {
+        if visited[start.index()] {
+            continue;
+        }
+
+        visited[start.index()] = true;
+        let mut component = Vec::new();
+        let mut stack = vec![start];
+        while let Some(node) = stack.pop() {
+            component.push(node);
+            for predecessor in graph.neighbors_directed(node, Incoming) {
+                if !visited[predecessor.index()] {
+                    visited[predecessor.index()] = true;
+                    stack.push(predecessor);
+                }
+            }
+        }
+        components.push(component);
+    }
+    components
 }
 
 fn ensure_node(

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -140,7 +140,7 @@ use crate::conv::Context;
 use crate::ir::VarId;
 use crate::ir::{
     ArrayLiteralItem, AssignDestination, Component, Declaration, Expression, Factor,
-    InstDeclaration, Ir, Module, Op, SystemFunctionKind, VarIndex, VarSelect, Variable,
+    InstDeclaration, Ir, Module, Op, Signature, SystemFunctionKind, VarIndex, VarSelect, Variable,
 };
 use crate::symbol::{Affiliation, Direction};
 use petgraph::Direction::Incoming;
@@ -435,6 +435,18 @@ struct ModuleCombSummary {
     dependencies: Vec<ModuleCombDependency>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum ComponentSummaryKey {
+    Specialization(Signature),
+    Allocation(usize),
+}
+
+#[derive(Default)]
+struct CombSummaryCache {
+    modules: HashMap<ComponentSummaryKey, ModuleCombSummary>,
+    procedures: crate::comb_memory_ssa::ProcedureSummaryCache,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct LoopDiagnosticKey {
     identifier: String,
@@ -498,11 +510,10 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
     let mut loops = LoopDiagnostics::default();
     let mut coverage = CoverageDiagnostics::default();
     let mut incomplete = Vec::new();
-    let mut summaries: HashMap<usize, ModuleCombSummary> = HashMap::default();
+    let mut summaries = CombSummaryCache::default();
     let mut visiting_specializations = HashSet::default();
 
     let order = module_analysis_order(ir);
-
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
             // Unevaluable generic params do not have a concrete module shape.
@@ -522,8 +533,12 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
                 &mut incomplete,
                 collect_coverage,
             );
-            let (graph, reasons, _bit_part, module_coverage) =
-                build_module_graph(module, &summaries, collect_coverage);
+            let (graph, reasons, bit_part, module_coverage) = build_module_graph(
+                module,
+                &summaries.modules,
+                collect_coverage,
+                &summaries.procedures,
+            );
             extend_unique_errors(&mut coverage, module_coverage);
             check_graph(module, &graph, &mut loops);
             if !reasons.is_empty() {
@@ -531,6 +546,12 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
                     module: module.name.to_string(),
                     reasons,
                 });
+            }
+            if let Some(specialization) = &module.specialization {
+                summaries
+                    .modules
+                    .entry(ComponentSummaryKey::Specialization(specialization.clone()))
+                    .or_insert_with(|| compute_module_summary(module, &graph, &bit_part));
             }
         }
     }
@@ -559,17 +580,26 @@ fn extend_unique_errors(coverage: &mut CoverageDiagnostics, new_errors: Vec<Cove
     }
 }
 
-fn component_summary_key(inst: &InstDeclaration) -> usize {
-    std::sync::Arc::as_ptr(&inst.component) as *const () as usize
+fn component_summary_key(inst: &InstDeclaration) -> ComponentSummaryKey {
+    if let Component::Module(module) = inst.component.as_ref()
+        && let Some(specialization) = &module.specialization
+    {
+        ComponentSummaryKey::Specialization(specialization.clone())
+    } else {
+        ComponentSummaryKey::Allocation(
+            std::sync::Arc::as_ptr(&inst.component) as *const () as usize
+        )
+    }
 }
 
-/// Analyze the concrete module carried by each instance. Generic parameter
-/// overrides are already elaborated in this `Arc<Component>` and therefore
-/// cannot share the declaration-default summary keyed only by module name.
+/// Analyze the concrete module carried by each instance. Normalized
+/// specialization signatures allow exact reuse across separately allocated
+/// components, while the allocation identity remains the fallback for IR
+/// producers which do not attach an elaboration signature.
 fn ensure_instance_summaries(
     module: &Module,
-    summaries: &mut HashMap<usize, ModuleCombSummary>,
-    visiting: &mut HashSet<usize>,
+    summaries: &mut CombSummaryCache,
+    visiting: &mut HashSet<ComponentSummaryKey>,
     loops: &mut LoopDiagnostics,
     coverage: &mut CoverageDiagnostics,
     incomplete: &mut Vec<IncompleteCombAnalysis>,
@@ -580,10 +610,10 @@ fn ensure_instance_summaries(
             continue;
         };
         let key = component_summary_key(inst);
-        if summaries.contains_key(&key) {
+        if summaries.modules.contains_key(&key) {
             continue;
         }
-        if !visiting.insert(key) {
+        if !visiting.insert(key.clone()) {
             incomplete.push(IncompleteCombAnalysis {
                 module: child.name.to_string(),
                 reasons: [IncompleteReason::RecursiveCall].into(),
@@ -599,12 +629,16 @@ fn ensure_instance_summaries(
             incomplete,
             collect_coverage,
         );
-        let (graph, reasons, bit_part, child_coverage) =
-            build_module_graph(child, summaries, collect_coverage);
+        let (graph, reasons, bit_part, child_coverage) = build_module_graph(
+            child,
+            &summaries.modules,
+            collect_coverage,
+            &summaries.procedures,
+        );
         extend_unique_errors(coverage, child_coverage);
         check_graph(child, &graph, loops);
         let summary = compute_module_summary(child, &graph, &bit_part);
-        summaries.insert(key, summary);
+        summaries.modules.insert(key.clone(), summary);
         if !reasons.is_empty() {
             incomplete.push(IncompleteCombAnalysis {
                 module: child.name.to_string(),
@@ -1024,8 +1058,9 @@ fn push_element_mask(
 
 fn build_module_graph(
     module: &Module,
-    summaries: &HashMap<usize, ModuleCombSummary>,
+    summaries: &HashMap<ComponentSummaryKey, ModuleCombSummary>,
     collect_coverage: bool,
+    procedure_summaries: &crate::comb_memory_ssa::ProcedureSummaryCache,
 ) -> (
     CausalGraph,
     BTreeSet<IncompleteReason>,
@@ -1035,7 +1070,8 @@ fn build_module_graph(
     // Procedural combinational declarations use statement-ordered region
     // MemorySSA. Keep instance declarations on the existing bottom-up module
     // summary path until the same region vocabulary crosses module boundaries.
-    let function_cache = crate::comb_memory_ssa::FunctionAnalysisCache::default();
+    let function_cache =
+        crate::comb_memory_ssa::FunctionAnalysisCache::new(procedure_summaries.clone());
     // Build each specialization once before entering Rayon. Procedure tasks
     // then share an immutable summary table instead of racing to initialize
     // the same callee behind a global mutex.
@@ -1910,7 +1946,7 @@ fn region_node_keys(
 
 fn collect_instance_summary_regions(
     module: &Module,
-    summaries: &HashMap<usize, ModuleCombSummary>,
+    summaries: &HashMap<ComponentSummaryKey, ModuleCombSummary>,
     ctx: &mut Context,
     functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
 ) -> (Vec<Region<VarId>>, Vec<PeriodicTransferRegion>) {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -956,50 +956,144 @@ fn add_inst_feedthrough_edges(
         if expression_has_hierarchical_reference(&input.expr) {
             incomplete.insert(IncompleteReason::HierarchicalReference);
         }
+        if dependency.aligned
+            && let (
+                Region::Exact {
+                    span: child_input_span,
+                    ..
+                },
+                Region::Exact {
+                    span: child_output_span,
+                    ..
+                },
+            ) = (dependency.input, dependency.output)
+            && child_input_span.length == child_output_span.length
+            && let Some(parent_inputs) = crate::comb_memory_ssa::map_expression_span_positioned(
+                ctx,
+                &input.expr,
+                child_input_span,
+            )
+            && let Some(parent_outputs) =
+                map_destinations_span_positioned(&output.dst, child_output_span, parent_vars, ctx)
+        {
+            for (source, destination) in aligned_instance_region_pairs(
+                &parent_inputs,
+                &parent_outputs,
+                child_input_span,
+                child_output_span,
+                parent_vars,
+                bit_part,
+            ) {
+                let source = ensure_node(graph, node_map, source);
+                let destination = ensure_node(graph, node_map, destination);
+                graph.add_edge(source, destination, true);
+            }
+            continue;
+        }
         let parent_input_regions =
             map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
         let parent_output_regions =
             map_child_output_region(dependency.output, child, &output.dst, parent_vars, ctx);
-        let preserve_alignment = dependency.aligned
-            && parent_input_regions.len() == 1
-            && parent_output_regions.len() == 1
-            && exact_regions_have_equal_length(parent_input_regions[0], parent_output_regions[0]);
-        let pairs = if preserve_alignment {
-            aligned_region_node_pairs(
-                parent_input_regions[0],
-                parent_output_regions[0],
-                parent_vars,
-                bit_part,
-            )
-        } else {
-            parent_input_regions
-                .iter()
-                .copied()
-                .flat_map(|input_region| {
-                    let destinations = parent_output_regions
-                        .iter()
-                        .copied()
-                        .flat_map(|output_region| {
-                            region_node_keys(output_region, parent_vars, bit_part)
-                        })
-                        .collect::<Vec<_>>();
-                    region_node_keys(input_region, parent_vars, bit_part)
-                        .into_iter()
-                        .flat_map(move |source| {
-                            destinations
-                                .clone()
-                                .into_iter()
-                                .map(move |destination| (source, destination))
-                        })
-                })
-                .collect()
-        };
+        let pairs = parent_input_regions
+            .iter()
+            .copied()
+            .flat_map(|input_region| {
+                let destinations = parent_output_regions
+                    .iter()
+                    .copied()
+                    .flat_map(|output_region| {
+                        region_node_keys(output_region, parent_vars, bit_part)
+                    })
+                    .collect::<Vec<_>>();
+                region_node_keys(input_region, parent_vars, bit_part)
+                    .into_iter()
+                    .flat_map(move |source| {
+                        destinations
+                            .clone()
+                            .into_iter()
+                            .map(move |destination| (source, destination))
+                    })
+            })
+            .collect::<Vec<_>>();
         for (source, destination) in pairs {
             let source = ensure_node(graph, node_map, source);
             let destination = ensure_node(graph, node_map, destination);
-            graph.add_edge(source, destination, preserve_alignment);
+            graph.add_edge(source, destination, false);
         }
     }
+}
+
+fn aligned_instance_region_pairs(
+    inputs: &[crate::comb_memory_ssa::PositionedRegion],
+    outputs: &[crate::comb_memory_ssa::PositionedRegion],
+    child_input: Span,
+    child_output: Span,
+    parent_vars: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<(NodeKey, NodeKey)> {
+    let mut pairs = BTreeSet::new();
+    for input in inputs {
+        let Some(input_start) = input.expression.start.checked_sub(child_input.start) else {
+            continue;
+        };
+        let input_relative = Span {
+            start: input_start,
+            length: input.expression.length,
+        };
+        let Region::Exact {
+            object: input_object,
+            span: input_region,
+        } = input.region
+        else {
+            continue;
+        };
+        for output in outputs {
+            let Some(output_start) = output.expression.start.checked_sub(child_output.start) else {
+                continue;
+            };
+            let output_relative = Span {
+                start: output_start,
+                length: output.expression.length,
+            };
+            let Some(overlap) = input_relative.intersection(output_relative) else {
+                continue;
+            };
+            let Region::Exact {
+                object: output_object,
+                span: output_region,
+            } = output.region
+            else {
+                continue;
+            };
+            let Some(input_offset) = overlap.start.checked_sub(input_relative.start) else {
+                continue;
+            };
+            let Some(output_offset) = overlap.start.checked_sub(output_relative.start) else {
+                continue;
+            };
+            let input_region = Region::Exact {
+                object: input_object,
+                span: Span {
+                    start: input_region.start + input_offset,
+                    length: overlap.length,
+                },
+            };
+            let output_region = Region::Exact {
+                object: output_object,
+                span: Span {
+                    start: output_region.start + output_offset,
+                    length: overlap.length,
+                },
+            };
+            pairs.extend(aligned_region_node_pairs(
+                input_region,
+                output_region,
+                parent_vars,
+                bit_part,
+            ));
+        }
+    }
+    pairs.into_iter().collect()
 }
 
 fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) -> bool {
@@ -1275,6 +1369,46 @@ fn map_destinations_span_to_regions(
                     start: span.start.checked_add(overlap.start.checked_sub(low)?)?,
                     length: overlap.length,
                 },
+            });
+        }
+        low = low.checked_add(span.length)?;
+    }
+    (requested.end()? <= low).then_some(mapped)
+}
+
+fn map_destinations_span_positioned(
+    destinations: &[AssignDestination],
+    requested: Span,
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Option<Vec<crate::comb_memory_ssa::PositionedRegion>> {
+    let mut low = 0usize;
+    let mut mapped = Vec::new();
+    for destination in destinations.iter().rev() {
+        let Region::Exact { object, span } = exact_variable_region(
+            destination.id,
+            &destination.index,
+            &destination.select,
+            variables,
+            ctx,
+        )?
+        else {
+            return None;
+        };
+        let destination_span = Span {
+            start: low,
+            length: span.length,
+        };
+        if let Some(overlap) = requested.intersection(destination_span) {
+            mapped.push(crate::comb_memory_ssa::PositionedRegion {
+                region: Region::Exact {
+                    object,
+                    span: Span {
+                        start: span.start.checked_add(overlap.start.checked_sub(low)?)?,
+                        length: overlap.length,
+                    },
+                },
+                expression: overlap,
             });
         }
         low = low.checked_add(span.length)?;

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -372,6 +372,17 @@ struct PeriodicTransferRegion {
     aligned: bool,
 }
 
+struct MappedUnalignedDependency {
+    inputs: Vec<Region<VarId>>,
+    outputs: Vec<Region<VarId>>,
+}
+
+// The outer order follows module instances in `walk_insts`; each inner order
+// follows that instance summary's dependencies. These are the exact mappings
+// already computed while collecting partition boundaries, not a second
+// approximation of the child-to-parent transfer.
+type MappedInstanceDependencies = Vec<Vec<Option<MappedUnalignedDependency>>>;
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum SummaryOutput {
     Region(Region<VarId>),
@@ -1229,7 +1240,7 @@ fn build_module_graph(
     let mut ctx = Context::default();
     ctx.variables = module.variables.clone();
     ctx.functions = module.functions.clone();
-    let (instance_regions, instance_periodic_transfers) =
+    let (instance_regions, instance_periodic_transfers, mapped_instance_dependencies) =
         collect_instance_summary_regions(module, summaries, &mut ctx, &function_cache);
     partition_regions.extend(instance_regions);
     periodic_transfers.extend(instance_periodic_transfers);
@@ -1296,9 +1307,12 @@ fn build_module_graph(
         }
     }
 
+    let mut module_instance_index = 0;
     for inst in walk_insts(module) {
         match inst.component.as_ref() {
             Component::Module(child) => {
+                let mapped_dependency_index = module_instance_index;
+                module_instance_index += 1;
                 if child
                     .variables
                     .values()
@@ -1328,6 +1342,10 @@ fn build_module_graph(
                     &mut incomplete,
                     &mut ctx,
                     &function_cache,
+                    mapped_instance_dependencies
+                        .get(mapped_dependency_index)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default(),
                 );
             }
             // SV black box: under-detect.
@@ -1949,13 +1967,19 @@ fn collect_instance_summary_regions(
     summaries: &HashMap<ComponentSummaryKey, ModuleCombSummary>,
     ctx: &mut Context,
     functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
-) -> (Vec<Region<VarId>>, Vec<PeriodicTransferRegion>) {
+) -> (
+    Vec<Region<VarId>>,
+    Vec<PeriodicTransferRegion>,
+    MappedInstanceDependencies,
+) {
     let mut regions = Vec::new();
     let mut periodic_transfers = Vec::new();
+    let mut mapped_dependencies = Vec::new();
     for inst in walk_insts(module) {
         let Component::Module(child) = inst.component.as_ref() else {
             continue;
         };
+        let mut mapped_dependencies_for_instance = Vec::new();
         for output in &inst.outputs {
             regions.extend(collect_destination_regions(
                 &output.dst,
@@ -1969,9 +1993,13 @@ fn collect_instance_summary_regions(
             ));
         }
         let Some(summary) = summaries.get(&component_summary_key(inst)) else {
+            mapped_dependencies.push(mapped_dependencies_for_instance);
             continue;
         };
-        for dependency in &summary.dependencies {
+        mapped_dependencies_for_instance.resize_with(summary.dependencies.len(), || None);
+        let mut input_mappings = BTreeMap::<Region<VarId>, Vec<Region<VarId>>>::new();
+        let mut output_mappings = BTreeMap::<Region<VarId>, Vec<Region<VarId>>>::new();
+        for (dependency_index, dependency) in summary.dependencies.iter().enumerate() {
             let Some(child_input) = region_object(dependency.input) else {
                 continue;
             };
@@ -1984,23 +2012,45 @@ fn collect_instance_summary_regions(
             let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
                 continue;
             };
-            let parent_inputs = map_child_input_region(
-                dependency.input,
-                child,
-                &input.expr,
-                &module.variables,
-                ctx,
-                functions,
-            );
-            regions.extend(parent_inputs.iter().copied());
-            match &dependency.output {
-                SummaryOutput::Region(region) => regions.extend(map_child_output_region(
-                    *region,
+            let parent_inputs = if let Some(mapped) = input_mappings.get(&dependency.input) {
+                mapped.clone()
+            } else {
+                let mapped = map_child_input_region(
+                    dependency.input,
                     child,
-                    &output.dst,
+                    &input.expr,
                     &module.variables,
                     ctx,
-                )),
+                    functions,
+                );
+                input_mappings.insert(dependency.input, mapped.clone());
+                mapped
+            };
+            regions.extend(parent_inputs.iter().copied());
+            match &dependency.output {
+                SummaryOutput::Region(region) => {
+                    let parent_outputs = if let Some(mapped) = output_mappings.get(region) {
+                        mapped.clone()
+                    } else {
+                        let mapped = map_child_output_region(
+                            *region,
+                            child,
+                            &output.dst,
+                            &module.variables,
+                            ctx,
+                        );
+                        output_mappings.insert(*region, mapped.clone());
+                        mapped
+                    };
+                    regions.extend(parent_outputs.iter().copied());
+                    if !dependency.aligned {
+                        mapped_dependencies_for_instance[dependency_index] =
+                            Some(MappedUnalignedDependency {
+                                inputs: parent_inputs,
+                                outputs: parent_outputs,
+                            });
+                    }
+                }
                 SummaryOutput::Periodic(periodic) => {
                     let parent_outputs = map_child_periodic_output(
                         periodic,
@@ -2022,8 +2072,9 @@ fn collect_instance_summary_regions(
                 }
             }
         }
+        mapped_dependencies.push(mapped_dependencies_for_instance);
     }
-    (regions, periodic_transfers)
+    (regions, periodic_transfers, mapped_dependencies)
 }
 
 fn add_inst_output_address_edges(
@@ -2074,8 +2125,9 @@ fn add_inst_feedthrough_edges(
     incomplete: &mut BTreeSet<IncompleteReason>,
     ctx: &mut Context,
     functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
+    mapped_dependencies: &[Option<MappedUnalignedDependency>],
 ) {
-    for dependency in &summary.dependencies {
+    for (dependency_index, dependency) in summary.dependencies.iter().enumerate() {
         let Some(child_input) = region_object(dependency.input) else {
             continue;
         };
@@ -2193,16 +2245,25 @@ fn add_inst_feedthrough_edges(
             }
             continue;
         }
-        let parent_input_regions = map_child_input_region(
-            dependency.input,
-            child,
-            &input.expr,
-            parent_vars,
-            ctx,
-            functions,
-        );
-        let parent_output_regions =
-            map_child_output_region(dependency_output, child, &output.dst, parent_vars, ctx);
+        let mapped = mapped_dependencies
+            .get(dependency_index)
+            .and_then(Option::as_ref);
+        let (owned_inputs, owned_outputs);
+        let (parent_input_regions, parent_output_regions) = if let Some(mapped) = mapped {
+            (mapped.inputs.as_slice(), mapped.outputs.as_slice())
+        } else {
+            owned_inputs = map_child_input_region(
+                dependency.input,
+                child,
+                &input.expr,
+                parent_vars,
+                ctx,
+                functions,
+            );
+            owned_outputs =
+                map_child_output_region(dependency_output, child, &output.dst, parent_vars, ctx);
+            (owned_inputs.as_slice(), owned_outputs.as_slice())
+        };
         let pairs = parent_input_regions
             .iter()
             .copied()

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -380,11 +380,36 @@ fn build_module_graph(
         | Declaration::Null => None,
     };
     #[cfg(not(target_family = "wasm"))]
-    let procedure_summaries = module
+    let mut procedure_summaries = module
         .declarations
         .par_iter()
         .filter_map(analyze_declaration)
         .collect::<Vec<_>>();
+    #[cfg(target_family = "wasm")]
+    let mut procedure_summaries = module
+        .declarations
+        .iter()
+        .filter_map(analyze_declaration)
+        .collect::<Vec<_>>();
+
+    let instance_inputs = walk_insts(module)
+        .flat_map(|inst| inst.inputs.iter().map(|input| &input.expr))
+        .collect::<Vec<_>>();
+    #[cfg(not(target_family = "wasm"))]
+    procedure_summaries.extend(
+        instance_inputs
+            .par_iter()
+            .map(|expression| {
+                crate::comb_memory_ssa::analyze_observer_expression(module, expression)
+            })
+            .collect::<Vec<_>>(),
+    );
+    #[cfg(target_family = "wasm")]
+    procedure_summaries.extend(
+        instance_inputs.iter().map(|expression| {
+            crate::comb_memory_ssa::analyze_observer_expression(module, expression)
+        }),
+    );
 
     let mut partition_regions = procedure_summaries
         .iter()
@@ -435,12 +460,6 @@ fn build_module_graph(
             | Declaration::Null => {}
         }
     }
-    #[cfg(target_family = "wasm")]
-    let procedure_summaries = module
-        .declarations
-        .iter()
-        .filter_map(analyze_declaration)
-        .collect::<Vec<_>>();
     for result in &procedure_summaries {
         match result {
             Ok(summary) => {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -45,13 +45,10 @@
 //!    spans and regular repeated copies have symbolic nodes, so graph size is
 //!    normally a function of accesses and boundaries rather than declared bit
 //!    width or unpacked-array length.
-//! 3. Traversal starts at source modules which are not instantiated by another
-//!    source template. Concrete child modules are analyzed before their parent;
-//!    the same child graph emits definition-local diagnostics and produces its
-//!    input-to-output summary, so the standalone template is not rebuilt.
-//!    Uninstantiated modules are roots and remain independently checked.
-//!    Instance actuals project child regions back into the parent, preserving
-//!    bit positions, aggregate layout, and Cartesian repetition axes when that
+//! 3. Child modules are analyzed before parents. A module summary contains only
+//!    input-to-output feedthrough proven in the child graph. Instance actuals
+//!    project the child's regions back into the parent, preserving bit
+//!    positions, aggregate layout, and Cartesian repetition axes when that
 //!    mapping is representable.
 //! 4. Iterative SCC discovery finds cyclic components without using the process
 //!    stack. For each SCC, diagnostics choose a stable source-backed edge and
@@ -459,7 +456,6 @@ enum ComponentSummaryKey {
 struct CombSummaryCache {
     modules: HashMap<ComponentSummaryKey, ModuleCombSummary>,
     procedures: crate::comb_memory_ssa::ProcedureSummaryCache,
-    analyzed_templates: HashSet<StrId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -531,21 +527,12 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
     let order = module_analysis_order(ir);
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
-            // A concrete instance analysis already checked this source
-            // template and produced the summary its parent consumes. Generic
-            // specializations are still all visited by
-            // `ensure_instance_summaries`; this skips only the redundant
-            // standalone template pass.
-            if summaries.analyzed_templates.contains(&module.name) {
-                continue;
-            }
             // Unevaluable generic params do not have a concrete module shape.
             if module.suppress_unassigned {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
                     reasons: [IncompleteReason::UnevaluatedGeneric].into(),
                 });
-                summaries.analyzed_templates.insert(module.name);
                 continue;
             }
             ensure_instance_summaries(
@@ -565,7 +552,6 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
             );
             extend_unique_errors(&mut coverage, module_coverage);
             check_graph(module, &graph, &mut loops);
-            summaries.analyzed_templates.insert(module.name);
             if !reasons.is_empty() {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
@@ -662,7 +648,6 @@ fn ensure_instance_summaries(
         );
         extend_unique_errors(coverage, child_coverage);
         check_graph(child, &graph, loops);
-        summaries.analyzed_templates.insert(child.name);
         let summary = compute_module_summary(child, &graph, &bit_part);
         summaries.modules.insert(key.clone(), summary);
         if !reasons.is_empty() {
@@ -710,24 +695,7 @@ fn module_analysis_order(ir: &Ir) -> Vec<usize> {
         .iter()
         .map(|component| matches!(component, Component::Module(_)))
         .collect::<Vec<_>>();
-    let order = order_from_dependencies(&is_module, &deps, &rev_deps);
-    prioritize_module_roots(order, &rev_deps)
-}
-
-fn prioritize_module_roots(
-    order: Vec<usize>,
-    reverse_dependencies: &[HashSet<usize>],
-) -> Vec<usize> {
-    // Start from modules which are not instantiated by another source
-    // template. Their recursive summary walk checks concrete children before
-    // those children's redundant standalone entries are encountered. Keep
-    // the previous deterministic order within both groups; a name-cycle has
-    // no root and remains in the fallback group.
-    let (mut roots, remaining): (Vec<_>, Vec<_>) = order
-        .into_iter()
-        .partition(|index| reverse_dependencies[*index].is_empty());
-    roots.extend(remaining);
-    roots
+    order_from_dependencies(&is_module, &deps, &rev_deps)
 }
 
 fn order_from_dependencies(
@@ -3533,12 +3501,6 @@ mod memory_ssa_tests {
 
         let order = order_from_dependencies(&is_module, &deps, &rev_deps);
         assert_eq!(order, vec![1, 3, 0, 2]);
-
-        // Why this case exists: concrete instance summaries are discovered
-        // only while visiting a parent. Roots must therefore run before the
-        // child-first fallback order, while a source-name cycle remains in a
-        // deterministic fallback position instead of disappearing.
-        assert_eq!(prioritize_module_roots(order, &rev_deps), vec![3, 2, 1, 0]);
     }
 
     #[test]

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -69,6 +69,15 @@ struct SummaryWalk {
     dependencies: BTreeMap<(Region<VarId>, SummaryOutput), bool>,
 }
 
+struct SummaryWalkContext<'a> {
+    graph: &'a CausalGraph,
+    live_nodes: &'a [bool],
+    module: &'a Module,
+    bit_part: &'a BitPartition,
+    input_ids: &'a HashSet<VarId>,
+    output_ids: &'a HashSet<VarId>,
+}
+
 impl SummaryWalk {
     fn new(direction: SummaryDirection, endpoints: Vec<(NodeIndex, NodeKey)>) -> Self {
         Self {
@@ -85,16 +94,7 @@ impl SummaryWalk {
     /// Advance a bounded amount of graph work. Running forward and reverse
     /// walks in equal quanta lets the cheaper direction finish without an
     /// endpoint-count heuristic committing to an adversarially expensive side.
-    fn advance(
-        &mut self,
-        graph: &CausalGraph,
-        live_nodes: &[bool],
-        module: &Module,
-        bit_part: &BitPartition,
-        input_ids: &HashSet<VarId>,
-        output_ids: &HashSet<VarId>,
-        budget: usize,
-    ) -> bool {
+    fn advance(&mut self, context: &SummaryWalkContext, budget: usize) -> bool {
         let mut work = 0usize;
         while work < budget {
             if self.stack.is_empty() {
@@ -114,19 +114,21 @@ impl SummaryWalk {
                 continue;
             }
             let endpoint_key = self.current_key.expect("active summary endpoint");
-            let node_key = graph[node];
+            let node_key = context.graph[node];
             let pair = match self.direction {
-                SummaryDirection::Forward if output_ids.contains(&node_key.0) => {
+                SummaryDirection::Forward if context.output_ids.contains(&node_key.0) => {
                     Some((endpoint_key, node_key))
                 }
-                SummaryDirection::Reverse if input_ids.contains(&node_key.0) => {
+                SummaryDirection::Reverse if context.input_ids.contains(&node_key.0) => {
                     Some((node_key, endpoint_key))
                 }
                 SummaryDirection::Forward | SummaryDirection::Reverse => None,
             };
             if let Some((input_key, output_key)) = pair {
-                for input in node_key_regions(input_key, module, bit_part) {
-                    for output in node_key_summary_outputs(output_key, module, bit_part) {
+                for input in node_key_regions(input_key, context.module, context.bit_part) {
+                    for output in
+                        node_key_summary_outputs(output_key, context.module, context.bit_part)
+                    {
                         self.dependencies
                             .entry((input, output))
                             .and_modify(|aligned| *aligned &= path_aligned)
@@ -137,17 +139,19 @@ impl SummaryWalk {
             match self.direction {
                 SummaryDirection::Forward => {
                     self.stack.extend(
-                        graph
+                        context
+                            .graph
                             .edges(node)
-                            .filter(|edge| live_nodes[edge.target().index()])
+                            .filter(|edge| context.live_nodes[edge.target().index()])
                             .map(|edge| (edge.target(), path_aligned && edge.weight().aligned)),
                     );
                 }
                 SummaryDirection::Reverse => {
                     self.stack.extend(
-                        graph
+                        context
+                            .graph
                             .edges_directed(node, Incoming)
-                            .filter(|edge| live_nodes[edge.source().index()])
+                            .filter(|edge| context.live_nodes[edge.source().index()])
                             .map(|edge| (edge.source(), path_aligned && edge.weight().aligned)),
                     );
                 }
@@ -293,10 +297,31 @@ struct ModuleCombSummary {
     dependencies: Vec<ModuleCombDependency>,
 }
 
-/// Compatibility entry point: emit only proven loop diagnostics. Tools which
-/// need to surface analysis coverage must call [`check_detailed`].
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CoverageDiagnosticKey {
+    identifier: String,
+    locations: Vec<TokenRange>,
+}
+
+type CoverageDiagnostic = (CoverageDiagnosticKey, AnalyzerError);
+
+#[derive(Default)]
+struct CoverageDiagnostics {
+    errors: Vec<AnalyzerError>,
+    keys: BTreeSet<CoverageDiagnosticKey>,
+}
+
+/// Compatibility entry point: emit only proven loop diagnostics.
 pub fn check(ir: &Ir) -> Vec<AnalyzerError> {
     check_detailed(ir).errors
+}
+
+/// Ordinary analyzer entry point. Coverage and loop diagnostics consume the
+/// same internal MemorySSA run, while the public loop-only API stays stable.
+pub(crate) fn check_analyzer(ir: &Ir) -> Vec<AnalyzerError> {
+    let (mut result, mut coverage_errors) = analyze(ir, true);
+    result.errors.append(&mut coverage_errors);
+    result.errors
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -314,7 +339,12 @@ pub struct CombAnalysisResult {
 /// Run loop detection while retaining uncertainty which must not be promoted
 /// to a hard combinational-loop diagnostic.
 pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
+    analyze(ir, false).0
+}
+
+fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<AnalyzerError>) {
     let mut errors = Vec::new();
+    let mut coverage = CoverageDiagnostics::default();
     let mut incomplete = Vec::new();
     let mut summaries: HashMap<usize, ModuleCombSummary> = HashMap::default();
     let mut visiting_specializations = HashSet::default();
@@ -336,9 +366,13 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
                 &mut summaries,
                 &mut visiting_specializations,
                 &mut errors,
+                &mut coverage,
                 &mut incomplete,
+                collect_coverage,
             );
-            let (graph, mut reasons, _bit_part) = build_module_graph(module, &summaries);
+            let (graph, mut reasons, _bit_part, module_coverage) =
+                build_module_graph(module, &summaries, collect_coverage);
+            extend_unique_errors(&mut coverage, module_coverage);
             if recursion_affected_modules.contains(&idx) {
                 reasons.insert(IncompleteReason::RecursiveCall);
             }
@@ -352,7 +386,15 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
         }
     }
 
-    CombAnalysisResult { errors, incomplete }
+    (CombAnalysisResult { errors, incomplete }, coverage.errors)
+}
+
+fn extend_unique_errors(coverage: &mut CoverageDiagnostics, new_errors: Vec<CoverageDiagnostic>) {
+    for (key, error) in new_errors {
+        if coverage.keys.insert(key) {
+            coverage.errors.push(error);
+        }
+    }
 }
 
 fn component_summary_key(inst: &InstDeclaration) -> usize {
@@ -367,7 +409,9 @@ fn ensure_instance_summaries(
     summaries: &mut HashMap<usize, ModuleCombSummary>,
     visiting: &mut HashSet<usize>,
     errors: &mut Vec<AnalyzerError>,
+    coverage: &mut CoverageDiagnostics,
     incomplete: &mut Vec<IncompleteCombAnalysis>,
+    collect_coverage: bool,
 ) {
     for inst in walk_insts(module) {
         let Component::Module(child) = inst.component.as_ref() else {
@@ -384,8 +428,18 @@ fn ensure_instance_summaries(
             });
             continue;
         }
-        ensure_instance_summaries(child, summaries, visiting, errors, incomplete);
-        let (graph, reasons, bit_part) = build_module_graph(child, summaries);
+        ensure_instance_summaries(
+            child,
+            summaries,
+            visiting,
+            errors,
+            coverage,
+            incomplete,
+            collect_coverage,
+        );
+        let (graph, reasons, bit_part, child_coverage) =
+            build_module_graph(child, summaries, collect_coverage);
+        extend_unique_errors(coverage, child_coverage);
         check_graph(child, &graph, errors);
         let summary = compute_module_summary(child, &graph, &bit_part);
         summaries.insert(key, summary);
@@ -801,12 +855,28 @@ fn push_element_mask(
 fn build_module_graph(
     module: &Module,
     summaries: &HashMap<usize, ModuleCombSummary>,
-) -> (CausalGraph, BTreeSet<IncompleteReason>, BitPartition) {
+    collect_coverage: bool,
+) -> (
+    CausalGraph,
+    BTreeSet<IncompleteReason>,
+    BitPartition,
+    Vec<CoverageDiagnostic>,
+) {
     // Procedural combinational declarations use statement-ordered region
     // MemorySSA. Keep instance declarations on the existing bottom-up module
     // summary path until the same region vocabulary crosses module boundaries.
+    let function_cache = crate::comb_memory_ssa::FunctionAnalysisCache::default();
+    // Build each specialization once before entering Rayon. Procedure tasks
+    // then share an immutable summary table instead of racing to initialize
+    // the same callee behind a global mutex.
+    let all_function_analyses = crate::comb_memory_ssa::analyze_functions(module, &function_cache);
+    function_cache.freeze();
     let analyze_declaration = |declaration: &Declaration| match declaration {
-        Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze(module, comb)),
+        Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze(
+            module,
+            comb,
+            &function_cache,
+        )),
         Declaration::Ff(_)
         | Declaration::Inst(_)
         | Declaration::External(_)
@@ -828,24 +898,68 @@ fn build_module_graph(
         .filter_map(analyze_declaration)
         .collect::<Vec<_>>();
 
-    let instance_inputs = walk_insts(module)
-        .flat_map(|inst| inst.inputs.iter().map(|input| &input.expr))
-        .collect::<Vec<_>>();
+    let mut instance_observers = Vec::new();
+    for inst in walk_insts(module) {
+        instance_observers.extend(inst.inputs.iter().map(|input| &input.expr));
+        for destination in inst.outputs.iter().flat_map(|output| output.dst.iter()) {
+            instance_observers.extend(destination.index.0.iter());
+            instance_observers.extend(destination.select.0.iter());
+            instance_observers.extend(
+                destination
+                    .select
+                    .1
+                    .iter()
+                    .map(|(_, expression)| expression),
+            );
+        }
+    }
+    instance_observers
+        .retain(|expression| crate::comb_memory_ssa::expression_needs_observer(expression));
     #[cfg(not(target_family = "wasm"))]
     procedure_summaries.extend(
-        instance_inputs
+        instance_observers
             .par_iter()
             .map(|expression| {
-                crate::comb_memory_ssa::analyze_observer_expression(module, expression)
+                crate::comb_memory_ssa::analyze_observer_expression(
+                    module,
+                    expression,
+                    &function_cache,
+                )
             })
             .collect::<Vec<_>>(),
     );
+
     #[cfg(target_family = "wasm")]
-    procedure_summaries.extend(
-        instance_inputs.iter().map(|expression| {
-            crate::comb_memory_ssa::analyze_observer_expression(module, expression)
-        }),
-    );
+    procedure_summaries.extend(instance_observers.iter().map(|expression| {
+        crate::comb_memory_ssa::analyze_observer_expression(module, expression, &function_cache)
+    }));
+    let function_analyses = if collect_coverage {
+        all_function_analyses
+    } else {
+        Vec::new()
+    };
+    let coverage_sites = procedure_summaries
+        .iter()
+        .filter_map(|result| result.as_ref().ok())
+        .flat_map(|analysis| analysis.coverage_sites.iter().copied())
+        .chain(function_analyses.iter().flat_map(|analysis| {
+            analysis
+                .coverage_sites
+                .iter()
+                .copied()
+                .filter(|(region, _)| {
+                    region_object(*region).is_none_or(|object| {
+                        module.variables.get(&object).is_none_or(|variable| {
+                            variable.affiliation != crate::symbol::Affiliation::Module
+                        })
+                    })
+                })
+        }));
+    let coverage_errors = if collect_coverage {
+        retention_diagnostics(module, coverage_sites)
+    } else {
+        Vec::new()
+    };
 
     let mut partition_regions = procedure_summaries
         .iter()
@@ -885,7 +999,7 @@ fn build_module_graph(
     ctx.variables = module.variables.clone();
     ctx.functions = module.functions.clone();
     let (instance_regions, instance_periodic_transfers) =
-        collect_instance_summary_regions(module, summaries, &mut ctx);
+        collect_instance_summary_regions(module, summaries, &mut ctx, &function_cache);
     partition_regions.extend(instance_regions);
     periodic_transfers.extend(instance_periodic_transfers);
     let mut periodic_regions = periodic_transfers
@@ -983,6 +1097,7 @@ fn build_module_graph(
                     &module.variables,
                     &mut incomplete,
                     &mut ctx,
+                    &function_cache,
                 );
             }
             // SV black box: under-detect.
@@ -994,7 +1109,36 @@ fn build_module_graph(
         }
     }
 
-    (graph, incomplete, bit_part)
+    (graph, incomplete, bit_part, coverage_errors)
+}
+
+fn retention_diagnostics(
+    module: &Module,
+    coverage_sites: impl IntoIterator<Item = (Region<VarId>, TokenRange)>,
+) -> Vec<CoverageDiagnostic> {
+    let mut sites: BTreeMap<VarId, BTreeSet<TokenRange>> = BTreeMap::new();
+    for (region, token) in coverage_sites {
+        if let Some(object) = region_object(region) {
+            sites.entry(object).or_default().insert(token);
+        }
+    }
+    sites
+        .into_iter()
+        .filter_map(|(object, tokens)| {
+            let variable = module.variables.get(&object)?;
+            let tokens = tokens.into_iter().collect::<Vec<_>>();
+            let first = tokens.first()?;
+            let identifier = variable.path.to_string();
+            let key = CoverageDiagnosticKey {
+                identifier: identifier.clone(),
+                locations: tokens.clone(),
+            };
+            Some((
+                key,
+                AnalyzerError::uncovered_branch(&identifier, first, &tokens),
+            ))
+        })
+        .collect()
 }
 
 fn propagate_aligned_regions(
@@ -1574,6 +1718,7 @@ fn collect_instance_summary_regions(
     module: &Module,
     summaries: &HashMap<usize, ModuleCombSummary>,
     ctx: &mut Context,
+    functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
 ) -> (Vec<Region<VarId>>, Vec<PeriodicTransferRegion>) {
     let mut regions = Vec::new();
     let mut periodic_transfers = Vec::new();
@@ -1615,6 +1760,7 @@ fn collect_instance_summary_regions(
                 &input.expr,
                 &module.variables,
                 ctx,
+                functions,
             );
             regions.extend(parent_inputs.iter().copied());
             match &dependency.output {
@@ -1697,6 +1843,7 @@ fn add_inst_feedthrough_edges(
     parent_vars: &HashMap<VarId, Variable>,
     incomplete: &mut BTreeSet<IncompleteReason>,
     ctx: &mut Context,
+    functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
 ) {
     for dependency in &summary.dependencies {
         let Some(child_input) = region_object(dependency.input) else {
@@ -1720,8 +1867,14 @@ fn add_inst_feedthrough_edges(
             incomplete.insert(IncompleteReason::HierarchicalReference);
         }
         if let SummaryOutput::Periodic(periodic) = &dependency.output {
-            let parent_inputs =
-                map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
+            let parent_inputs = map_child_input_region(
+                dependency.input,
+                child,
+                &input.expr,
+                parent_vars,
+                ctx,
+                functions,
+            );
             let Some(parent_outputs) =
                 map_child_periodic_output(periodic, child, &output.dst, parent_vars, ctx)
             else {
@@ -1786,6 +1939,7 @@ fn add_inst_feedthrough_edges(
                 &input.expr,
                 input_type,
                 child_input_span,
+                functions,
             )
             && let Some(parent_outputs) =
                 map_destinations_span_positioned(&output.dst, child_output_span, parent_vars, ctx)
@@ -1808,8 +1962,14 @@ fn add_inst_feedthrough_edges(
             }
             continue;
         }
-        let parent_input_regions =
-            map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
+        let parent_input_regions = map_child_input_region(
+            dependency.input,
+            child,
+            &input.expr,
+            parent_vars,
+            ctx,
+            functions,
+        );
         let parent_output_regions =
             map_child_output_region(dependency_output, child, &output.dst, parent_vars, ctx);
         let pairs = parent_input_regions
@@ -1985,6 +2145,7 @@ fn map_child_input_region(
     actual: &Expression,
     parent_vars: &HashMap<VarId, Variable>,
     ctx: &mut Context,
+    functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
 ) -> Vec<Region<VarId>> {
     let Some((span, uncertain)) = child_region_span(region, child) else {
         return Vec::new();
@@ -1997,6 +2158,7 @@ fn map_child_input_region(
                 actual,
                 &variable.r#type,
                 span,
+                functions,
             )
         })
         .map(|positioned| {
@@ -2005,7 +2167,7 @@ fn map_child_input_region(
                 .map(|positioned| positioned.region)
                 .collect()
         })
-        .or_else(|| map_expression_span_to_regions(actual, span, parent_vars, ctx))
+        .or_else(|| map_expression_span_to_regions(actual, span, parent_vars, ctx, functions))
         .unwrap_or_else(|| collect_expression_regions(actual, parent_vars, ctx));
     retain_uncertainty(mapped, uncertain)
 }
@@ -2146,6 +2308,7 @@ fn map_expression_span_to_regions(
     requested: Span,
     variables: &HashMap<VarId, Variable>,
     ctx: &mut Context,
+    functions: &crate::comb_memory_ssa::FunctionAnalysisCache,
 ) -> Option<Vec<Region<VarId>>> {
     let expression_type = &expression.comptime().r#type;
     let expression_length = expression_type
@@ -2154,7 +2317,9 @@ fn map_expression_span_to_regions(
     if requested.end()? > expression_length {
         return None;
     }
-    if let Some(mapped) = crate::comb_memory_ssa::map_expression_span(ctx, expression, requested) {
+    if let Some(mapped) =
+        crate::comb_memory_ssa::map_expression_span(ctx, expression, requested, functions)
+    {
         return Some(mapped);
     }
     match expression {
@@ -2179,7 +2344,7 @@ fn map_expression_span_to_regions(
             Factor::Value(_) => Some(Vec::new()),
             Factor::SystemFunctionCall(call) => match &call.kind {
                 SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
-                    map_expression_span_to_regions(&input.0, requested, variables, ctx)
+                    map_expression_span_to_regions(&input.0, requested, variables, ctx, functions)
                 }
                 _ => None,
             },
@@ -2206,6 +2371,7 @@ fn map_expression_span_to_regions(
                         },
                         variables,
                         ctx,
+                        functions,
                     )?);
                 }
                 low = low.checked_add(width)?;
@@ -2217,7 +2383,7 @@ fn map_expression_span_to_regions(
                 && operand.comptime().r#type.total_width()?
                     == expression.comptime().r#type.total_width()? =>
         {
-            map_expression_span_to_regions(operand, requested, variables, ctx)
+            map_expression_span_to_regions(operand, requested, variables, ctx, functions)
         }
         Expression::Binary(left, op, right, _)
             if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
@@ -2226,9 +2392,10 @@ fn map_expression_span_to_regions(
                 && right.comptime().r#type.total_width()?
                     == expression.comptime().r#type.total_width()? =>
         {
-            let mut mapped = map_expression_span_to_regions(left, requested, variables, ctx)?;
+            let mut mapped =
+                map_expression_span_to_regions(left, requested, variables, ctx, functions)?;
             mapped.extend(map_expression_span_to_regions(
-                right, requested, variables, ctx,
+                right, requested, variables, ctx, functions,
             )?);
             Some(mapped)
         }
@@ -2830,6 +2997,14 @@ fn compute_module_summary(
     if input_nodes.is_empty() || output_nodes.is_empty() {
         return ModuleCombSummary::default();
     }
+    let walk_context = SummaryWalkContext {
+        graph,
+        live_nodes: &live_nodes,
+        module,
+        bit_part,
+        input_ids: &input_ids,
+        output_ids: &output_ids,
+    };
 
     const QUANTUM: usize = 512;
     let winning_walks = if graph.node_count() < QUANTUM {
@@ -2839,15 +3014,7 @@ fn compute_module_summary(
             (SummaryDirection::Reverse, output_nodes)
         };
         let mut walk = SummaryWalk::new(direction, endpoints);
-        while !walk.advance(
-            graph,
-            &live_nodes,
-            module,
-            bit_part,
-            &input_ids,
-            &output_ids,
-            QUANTUM,
-        ) {}
+        while !walk.advance(&walk_context, QUANTUM) {}
         vec![walk]
     } else {
         #[cfg(not(target_family = "wasm"))]
@@ -2872,32 +3039,12 @@ fn compute_module_summary(
                 #[cfg(not(target_family = "wasm"))]
                 let complete = walks
                     .par_iter_mut()
-                    .map(|walk| {
-                        walk.advance(
-                            graph,
-                            &live_nodes,
-                            module,
-                            bit_part,
-                            &input_ids,
-                            &output_ids,
-                            QUANTUM,
-                        )
-                    })
+                    .map(|walk| walk.advance(&walk_context, QUANTUM))
                     .collect::<Vec<_>>();
                 #[cfg(target_family = "wasm")]
                 let complete = walks
                     .iter_mut()
-                    .map(|walk| {
-                        walk.advance(
-                            graph,
-                            &live_nodes,
-                            module,
-                            bit_part,
-                            &input_ids,
-                            &output_ids,
-                            QUANTUM,
-                        )
-                    })
+                    .map(|walk| walk.advance(&walk_context, QUANTUM))
                     .collect::<Vec<_>>();
                 complete.into_iter().all(|complete| complete)
             };

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -27,7 +27,7 @@ use rayon::prelude::*;
 use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet};
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
-use veryl_causal::procedure::{PeriodicAxis, ProcedureSummary};
+use veryl_causal::procedure::{AlignedDependency, PeriodicAxis, ProcedureSummary};
 use veryl_causal::region::{Region, Span};
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
@@ -2031,16 +2031,30 @@ fn aligned_instance_region_pairs(
         else {
             continue;
         };
+        let transfer = AlignedDependency {
+            read: 0,
+            kind: input.kind,
+            source: if input.aligned {
+                input_region
+            } else {
+                Span {
+                    start: 0,
+                    length: input.expression.length,
+                }
+            },
+            destination: input_relative,
+            axes: input.axes.clone(),
+        };
         for output in outputs {
+            if !output.axes.is_empty() {
+                continue;
+            }
             let Some(output_start) = output.expression.start.checked_sub(child_output.start) else {
                 continue;
             };
             let output_relative = Span {
                 start: output_start,
                 length: output.expression.length,
-            };
-            let Some(overlap) = input_relative.intersection(output_relative) else {
-                continue;
             };
             let Region::Exact {
                 object: output_object,
@@ -2049,36 +2063,42 @@ fn aligned_instance_region_pairs(
             else {
                 continue;
             };
-            let Some(output_offset) = overlap.start.checked_sub(output_relative.start) else {
+            let Some(clipped) =
+                crate::comb_memory_ssa::clip_aligned_dependency(&transfer, output_relative)
+            else {
                 continue;
             };
-            let output_region = Region::Exact {
-                object: output_object,
-                span: Span {
-                    start: output_region.start + output_offset,
-                    length: overlap.length,
-                },
-            };
-            if input.aligned {
-                let Some(input_offset) = overlap.start.checked_sub(input_relative.start) else {
+            for clipped in clipped {
+                let Some(destination_start) =
+                    output_region.start.checked_add(clipped.destination.start)
+                else {
                     continue;
                 };
-                let input_region = Region::Exact {
-                    object: input_object,
-                    span: Span {
-                        start: input_region.start + input_offset,
-                        length: overlap.length,
+                let periodic = PeriodicRegion {
+                    object: output_object,
+                    output: Span {
+                        start: destination_start,
+                        length: clipped.destination.length,
                     },
+                    axes: clipped.axes,
                 };
-                pairs.extend(
-                    aligned_region_node_pairs(input_region, output_region, parent_vars, bit_part)
-                        .into_iter()
-                        .map(|(source, destination)| (source, destination, true)),
-                );
-            } else {
-                for source in region_node_keys(input.region, parent_vars, bit_part) {
-                    for destination in region_node_keys(output_region, parent_vars, bit_part) {
-                        pairs.insert((source, destination, false));
+                if input.aligned && output.aligned {
+                    let input_region = Region::Exact {
+                        object: input_object,
+                        span: clipped.source,
+                    };
+                    pairs.extend(
+                        aligned_periodic_node_pairs(input_region, periodic, parent_vars, bit_part)
+                            .into_iter()
+                            .map(|(source, destination)| (source, destination, true)),
+                    );
+                } else {
+                    for source in region_node_keys(input.region, parent_vars, bit_part) {
+                        for destination in
+                            periodic_region_node_keys(periodic.clone(), parent_vars, bit_part)
+                        {
+                            pairs.insert((source, destination, false));
+                        }
                     }
                 }
             }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -20,7 +20,7 @@ use crate::ir::{
 use crate::symbol::{Affiliation, Direction};
 use petgraph::Direction::Incoming;
 use petgraph::Graph;
-use petgraph::graph::NodeIndex;
+use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
@@ -30,6 +30,7 @@ use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{PeriodicAxis, ProcedureSummary};
 use veryl_causal::region::{Region, Span};
 use veryl_parser::resource_table::StrId;
+use veryl_parser::token_range::TokenRange;
 
 /// One concrete unpacked-array element. Bit-precision lives in masks.
 type IdxKey = (VarId, usize);
@@ -37,6 +38,20 @@ type IdxKey = (VarId, usize);
 /// `(VarId, array_idx, range_idx)`. `range_idx` indexes the variable's
 /// `BitPartition`, so bit-disjoint reads/writes form disjoint nodes.
 type NodeKey = (VarId, usize, usize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CausalEdge {
+    aligned: bool,
+    origin: Option<TokenRange>,
+}
+
+impl CausalEdge {
+    fn new(aligned: bool, origin: Option<TokenRange>) -> Self {
+        Self { aligned, origin }
+    }
+}
+
+type CausalGraph = Graph<NodeKey, CausalEdge>;
 
 #[derive(Clone, Copy)]
 enum SummaryDirection {
@@ -72,7 +87,7 @@ impl SummaryWalk {
     /// endpoint-count heuristic committing to an adversarially expensive side.
     fn advance(
         &mut self,
-        graph: &Graph<NodeKey, bool>,
+        graph: &CausalGraph,
         live_nodes: &[bool],
         module: &Module,
         bit_part: &BitPartition,
@@ -125,7 +140,7 @@ impl SummaryWalk {
                         graph
                             .edges(node)
                             .filter(|edge| live_nodes[edge.target().index()])
-                            .map(|edge| (edge.target(), path_aligned && *edge.weight())),
+                            .map(|edge| (edge.target(), path_aligned && edge.weight().aligned)),
                     );
                 }
                 SummaryDirection::Reverse => {
@@ -133,7 +148,7 @@ impl SummaryWalk {
                         graph
                             .edges_directed(node, Incoming)
                             .filter(|edge| live_nodes[edge.source().index()])
-                            .map(|edge| (edge.source(), path_aligned && *edge.weight())),
+                            .map(|edge| (edge.source(), path_aligned && edge.weight().aligned)),
                     );
                 }
             }
@@ -143,7 +158,7 @@ impl SummaryWalk {
 }
 
 fn live_summary_nodes(
-    graph: &Graph<NodeKey, bool>,
+    graph: &CausalGraph,
     inputs: &[(NodeIndex, NodeKey)],
     outputs: &[(NodeIndex, NodeKey)],
 ) -> Vec<bool> {
@@ -786,11 +801,7 @@ fn push_element_mask(
 fn build_module_graph(
     module: &Module,
     summaries: &HashMap<usize, ModuleCombSummary>,
-) -> (
-    Graph<NodeKey, bool>,
-    BTreeSet<IncompleteReason>,
-    BitPartition,
-) {
+) -> (CausalGraph, BTreeSet<IncompleteReason>, BitPartition) {
     // Procedural combinational declarations use statement-ordered region
     // MemorySSA. Keep instance declarations on the existing bottom-up module
     // summary path until the same region vocabulary crosses module boundaries.
@@ -890,7 +901,7 @@ fn build_module_graph(
     periodic_regions.dedup();
     let bit_part = build_bit_partition(module, &partition_regions, &periodic_regions);
 
-    let mut graph: Graph<NodeKey, bool> = Graph::new();
+    let mut graph = CausalGraph::new();
     let mut node_map: HashMap<NodeKey, NodeIndex> = HashMap::default();
     let mut incomplete = BTreeSet::new();
 
@@ -988,7 +999,10 @@ fn build_module_graph(
 
 fn propagate_aligned_regions(
     regions: Vec<Region<VarId>>,
-    summaries: &[Result<ProcedureSummary<VarId>, veryl_causal::procedure::ProcedureError>],
+    summaries: &[Result<
+        crate::comb_memory_ssa::ProcedureAnalysis,
+        veryl_causal::procedure::ProcedureError,
+    >],
 ) -> Vec<Region<VarId>> {
     #[derive(Clone, Copy)]
     struct Transfer {
@@ -1128,9 +1142,9 @@ fn propagate_aligned_regions(
 
 fn add_memory_ssa_edges(
     module: &Module,
-    summary: &ProcedureSummary<VarId>,
+    summary: &crate::comb_memory_ssa::ProcedureAnalysis,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, bool>,
+    graph: &mut CausalGraph,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
 ) {
     // Incomplete effects are represented by Unknown edges/regions in the
@@ -1145,6 +1159,10 @@ fn add_memory_ssa_edges(
         let output = sparse_output_region(summary, dependency.output);
         let preserve_alignment =
             dependency.aligned && exact_regions_have_equal_length(input, output);
+        let origin = dependency
+            .origin
+            .and_then(|write| summary.write_tokens.get(&write))
+            .copied();
         let pairs = if preserve_alignment {
             aligned_region_node_pairs(input, output, &module.variables, bit_part)
         } else {
@@ -1169,16 +1187,20 @@ fn add_memory_ssa_edges(
             }
             let source = ensure_node(graph, node_map, source);
             let destination = ensure_node(graph, node_map, destination);
-            graph.add_edge(source, destination, preserve_alignment);
+            graph.add_edge(
+                source,
+                destination,
+                CausalEdge::new(preserve_alignment, origin),
+            );
         }
     }
 }
 
 fn add_periodic_memory_ssa_edges(
     module: &Module,
-    summary: &ProcedureSummary<VarId>,
+    summary: &crate::comb_memory_ssa::ProcedureAnalysis,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, bool>,
+    graph: &mut CausalGraph,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
 ) {
     for dependency in &summary.periodic_dependencies {
@@ -1191,6 +1213,10 @@ fn add_periodic_memory_ssa_edges(
             output: dependency.output,
             axes: dependency.axes.clone(),
         };
+        let origin = dependency
+            .origin
+            .and_then(|write| summary.write_tokens.get(&write))
+            .copied();
         let pairs = if dependency.aligned {
             aligned_periodic_node_pairs(input, periodic, &module.variables, bit_part)
         } else {
@@ -1214,7 +1240,11 @@ fn add_periodic_memory_ssa_edges(
             }
             let source = ensure_node(graph, node_map, source);
             let destination = ensure_node(graph, node_map, destination);
-            graph.add_edge(source, destination, dependency.aligned);
+            graph.add_edge(
+                source,
+                destination,
+                CausalEdge::new(dependency.aligned, origin),
+            );
         }
     }
 }
@@ -1623,13 +1653,14 @@ fn collect_instance_summary_regions(
 fn add_inst_output_address_edges(
     inst: &InstDeclaration,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, bool>,
+    graph: &mut CausalGraph,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     parent_vars: &HashMap<VarId, Variable>,
     ctx: &mut Context,
 ) {
     for output in &inst.outputs {
         for destination in &output.dst {
+            let origin = destination.token;
             let destination_region = variable_access_region(
                 destination.id,
                 &destination.index,
@@ -1647,7 +1678,7 @@ fn add_inst_output_address_edges(
                     for destination in region_node_keys(destination_region, parent_vars, bit_part) {
                         let source = ensure_node(graph, node_map, source);
                         let destination = ensure_node(graph, node_map, destination);
-                        graph.add_edge(source, destination, false);
+                        graph.add_edge(source, destination, CausalEdge::new(false, Some(origin)));
                     }
                 }
             }
@@ -1661,7 +1692,7 @@ fn add_inst_feedthrough_edges(
     child: &Module,
     summary: &ModuleCombSummary,
     bit_part: &BitPartition,
-    graph: &mut Graph<NodeKey, bool>,
+    graph: &mut CausalGraph,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     parent_vars: &HashMap<VarId, Variable>,
     incomplete: &mut BTreeSet<IncompleteReason>,
@@ -1721,7 +1752,11 @@ fn add_inst_feedthrough_edges(
                     for (source, destination) in pairs {
                         let source = ensure_node(graph, node_map, source);
                         let destination = ensure_node(graph, node_map, destination);
-                        graph.add_edge(source, destination, dependency.aligned);
+                        graph.add_edge(
+                            source,
+                            destination,
+                            CausalEdge::new(dependency.aligned, Some(inst.token)),
+                        );
                     }
                 }
             }
@@ -1765,7 +1800,11 @@ fn add_inst_feedthrough_edges(
             ) {
                 let source = ensure_node(graph, node_map, source);
                 let destination = ensure_node(graph, node_map, destination);
-                graph.add_edge(source, destination, aligned);
+                graph.add_edge(
+                    source,
+                    destination,
+                    CausalEdge::new(aligned, Some(inst.token)),
+                );
             }
             continue;
         }
@@ -1797,7 +1836,11 @@ fn add_inst_feedthrough_edges(
         for (source, destination) in pairs {
             let source = ensure_node(graph, node_map, source);
             let destination = ensure_node(graph, node_map, destination);
-            graph.add_edge(source, destination, false);
+            graph.add_edge(
+                source,
+                destination,
+                CausalEdge::new(false, Some(inst.token)),
+            );
         }
     }
 }
@@ -2512,26 +2555,122 @@ fn is_pure_input_or_output(id: VarId, vars: &HashMap<VarId, Variable>, want: Dir
     actual == want
 }
 
-fn check_graph(module: &Module, graph: &Graph<NodeKey, bool>, errors: &mut Vec<AnalyzerError>) {
+fn check_graph(module: &Module, graph: &CausalGraph, errors: &mut Vec<AnalyzerError>) {
     let sccs = strongly_connected_components(graph);
     let mut reported: HashSet<Vec<NodeKey>> = HashSet::default();
     for scc in sccs {
-        let is_loop = scc.len() > 1 || (scc.len() == 1 && has_self_edge(graph, scc[0]));
-        if !is_loop {
+        let Some(witness) = diagnostic_cycle_witness(graph, &scc) else {
             continue;
-        }
+        };
         let mut keys: Vec<NodeKey> = scc.iter().map(|n| graph[*n]).collect();
         keys.sort();
         if !reported.insert(keys.clone()) {
             continue;
         }
-        if let Some(error) = build_error(module, &keys) {
+        if let Some(error) = build_error(module, graph, &witness) {
             errors.push(error);
         }
     }
 }
 
-fn strongly_connected_components(graph: &Graph<NodeKey, bool>) -> Vec<Vec<NodeIndex>> {
+fn diagnostic_edge_key(
+    graph: &CausalGraph,
+    edge: EdgeIndex,
+) -> (bool, TokenRange, NodeKey, NodeKey, usize) {
+    let (source, target) = graph.edge_endpoints(edge).expect("live causal edge");
+    let weight = graph.edge_weight(edge).expect("live causal edge");
+    (
+        weight.origin.is_none(),
+        weight.origin.unwrap_or_default(),
+        graph[source],
+        graph[target],
+        edge.index(),
+    )
+}
+
+/// Select a stable source-level anchor, then find the shortest directed return
+/// path to it inside the SCC. The result is one real simple cycle rather than
+/// every node in the maximal SCC, while avoiding an all-sources shortest-cycle
+/// search whose worst-case cost is quadratic in a malicious component.
+fn diagnostic_cycle_witness(graph: &CausalGraph, scc: &[NodeIndex]) -> Option<Vec<EdgeIndex>> {
+    if scc.is_empty() {
+        return None;
+    }
+    let node_bound = graph
+        .node_indices()
+        .map(NodeIndex::index)
+        .max()
+        .map_or(0, |index| index + 1);
+    let mut inside = vec![false; node_bound];
+    for &node in scc {
+        inside[node.index()] = true;
+    }
+
+    let mut internal_edges = scc
+        .iter()
+        .flat_map(|&node| graph.edges(node).map(|edge| edge.id()))
+        .filter(|&edge| {
+            graph
+                .edge_endpoints(edge)
+                .is_some_and(|(_, target)| inside[target.index()])
+        })
+        .collect::<Vec<_>>();
+    internal_edges.sort_unstable_by_key(|&edge| diagnostic_edge_key(graph, edge));
+    internal_edges.dedup();
+
+    if let Some(&edge) = internal_edges.iter().find(|&&edge| {
+        graph
+            .edge_endpoints(edge)
+            .is_some_and(|(source, target)| source == target)
+    }) {
+        return Some(vec![edge]);
+    }
+
+    let anchor = *internal_edges.first()?;
+    let (anchor_source, anchor_target) = graph.edge_endpoints(anchor)?;
+    let mut predecessor = vec![None::<(NodeIndex, EdgeIndex)>; node_bound];
+    let mut discovered = vec![false; node_bound];
+    let mut pending = VecDeque::from([anchor_target]);
+    discovered[anchor_target.index()] = true;
+
+    while let Some(node) = pending.pop_front() {
+        if node == anchor_source {
+            break;
+        }
+        let mut outgoing = graph
+            .edges(node)
+            .filter(|edge| inside[edge.target().index()])
+            .map(|edge| edge.id())
+            .collect::<Vec<_>>();
+        outgoing.sort_unstable_by_key(|&edge| diagnostic_edge_key(graph, edge));
+        for edge in outgoing {
+            let (_, target) = graph.edge_endpoints(edge)?;
+            if std::mem::replace(&mut discovered[target.index()], true) {
+                continue;
+            }
+            predecessor[target.index()] = Some((node, edge));
+            pending.push_back(target);
+        }
+    }
+    if !discovered[anchor_source.index()] {
+        return None;
+    }
+
+    let mut return_path = Vec::new();
+    let mut current = anchor_source;
+    while current != anchor_target {
+        let (previous, edge) = predecessor[current.index()]?;
+        return_path.push(edge);
+        current = previous;
+    }
+    return_path.reverse();
+    let mut witness = Vec::with_capacity(return_path.len() + 1);
+    witness.push(anchor);
+    witness.extend(return_path);
+    Some(witness)
+}
+
+fn strongly_connected_components(graph: &CausalGraph) -> Vec<Vec<NodeIndex>> {
     let node_bound = graph
         .node_indices()
         .map(NodeIndex::index)
@@ -2592,45 +2731,35 @@ fn strongly_connected_components(graph: &Graph<NodeKey, bool>) -> Vec<Vec<NodeIn
 }
 
 fn ensure_node(
-    graph: &mut Graph<NodeKey, bool>,
+    graph: &mut CausalGraph,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     key: NodeKey,
 ) -> NodeIndex {
     *node_map.entry(key).or_insert_with(|| graph.add_node(key))
 }
 
-fn has_self_edge(graph: &Graph<NodeKey, bool>, node: NodeIndex) -> bool {
-    graph
-        .edges(node)
-        .any(|e| e.source() == node && e.target() == node)
-}
-
-fn build_error(module: &Module, keys: &[NodeKey]) -> Option<AnalyzerError> {
-    let mut tokens: Vec<veryl_parser::token_range::TokenRange> = Vec::new();
-    let mut identifier: Option<String> = None;
-    let mut seen_var: HashSet<VarId> = HashSet::default();
-    for (id, _idx, _range) in keys {
-        if !seen_var.insert(*id) {
-            continue;
-        }
-        let variable = module.variables.get(id);
-        if let Some(var) = variable
-            && identifier.is_none()
-        {
-            identifier = Some(var.path.to_string());
-        }
-        if let Some(toks) = module.assign_tokens.get(id)
-            && !toks.is_empty()
-        {
-            tokens.extend(toks.iter().copied());
-        } else if let Some(var) = variable {
-            // Large dynamic assignments intentionally do not allocate the
-            // legacy per-element AssignTable, so no assignment-token vector
-            // exists. The declaration still provides a stable diagnostic
-            // anchor for a loop proven by the sparse causal graph.
-            tokens.push(var.token);
-        }
-    }
+fn build_error(
+    module: &Module,
+    graph: &CausalGraph,
+    witness: &[EdgeIndex],
+) -> Option<AnalyzerError> {
+    let anchor = *witness.first()?;
+    let (_, anchor_target) = graph.edge_endpoints(anchor)?;
+    let identifier = module
+        .variables
+        .get(&graph[anchor_target].0)
+        .map(|variable| variable.path.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    let mut tokens = witness
+        .iter()
+        .filter_map(|&edge| {
+            let (_, target) = graph.edge_endpoints(edge)?;
+            graph
+                .edge_weight(edge)?
+                .origin
+                .or_else(|| module.variables.get(&graph[target].0).map(|var| var.token))
+        })
+        .collect::<Vec<_>>();
     {
         let mut seen: HashSet<_> = HashSet::default();
         tokens.retain(|t| seen.insert(*t));
@@ -2638,7 +2767,7 @@ fn build_error(module: &Module, keys: &[NodeKey]) -> Option<AnalyzerError> {
     let primary = *tokens.first()?;
     let participants: Vec<_> = tokens.iter().skip(1).copied().collect();
     Some(AnalyzerError::combinational_loop(
-        identifier.as_deref().unwrap_or("?"),
+        &identifier,
         &primary,
         &participants,
     ))
@@ -2653,7 +2782,7 @@ fn is_module_scope_var(id: VarId, variables: &HashMap<VarId, Variable>) -> bool 
 
 fn compute_module_summary(
     module: &Module,
-    graph: &Graph<NodeKey, bool>,
+    graph: &CausalGraph,
     bit_part: &BitPartition,
 ) -> ModuleCombSummary {
     use crate::ir::VarKind;
@@ -2906,12 +3035,12 @@ mod memory_ssa_tests {
         // SCC discovery must use heap-backed worklists regardless of graph
         // depth; every node in this chain is its own component.
         let count = 25_600usize;
-        let mut graph = Graph::<NodeKey, bool>::new();
+        let mut graph = CausalGraph::new();
         let nodes = (0..count)
             .map(|index| graph.add_node((VarId::from_raw(index as u32), 0, 0)))
             .collect::<Vec<_>>();
         for pair in nodes.windows(2) {
-            graph.add_edge(pair[0], pair[1], false);
+            graph.add_edge(pair[0], pair[1], CausalEdge::new(false, None));
         }
 
         let components = strongly_connected_components(&graph);

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -49,6 +49,9 @@ const UNKNOWN_REGION_INDEX: usize = usize::MAX;
 #[derive(Default)]
 struct BitPartition {
     ranges: HashMap<IdxKey, Vec<BigUint>>,
+    /// Stable identities for unresolved regions. They are graph nodes, not
+    /// array elements, so their count depends on accesses rather than width.
+    wildcards: Vec<Region<VarId>>,
 }
 
 impl BitPartition {
@@ -57,14 +60,16 @@ impl BitPartition {
         self.ranges.get(&key).map(|v| v.as_slice()).unwrap_or(&[])
     }
 
-    fn overlapping(&self, key: IdxKey, mask: &BigUint) -> Vec<usize> {
-        let zero = BigUint::default();
-        self.ranges_of(key)
-            .iter()
-            .enumerate()
-            .filter(|(_, m)| (*m & mask) != zero)
-            .map(|(i, _)| i)
-            .collect()
+    fn wildcard_key(&self, region: Region<VarId>) -> Option<NodeKey> {
+        self.wildcards
+            .binary_search(&region)
+            .ok()
+            .and_then(|index| match region {
+                Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
+                    Some((object, UNKNOWN_REGION_INDEX, index))
+                }
+                Region::Exact { .. } | Region::UnknownAll => None,
+            })
     }
 }
 
@@ -291,7 +296,20 @@ fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) ->
         }
     }
 
-    BitPartition { ranges }
+    let wildcards = memory_ssa_regions
+        .iter()
+        .copied()
+        .filter(|region| {
+            matches!(
+                region,
+                Region::UnknownRegion { .. } | Region::UnknownObject(_)
+            )
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    BitPartition { ranges, wildcards }
 }
 
 fn collect_region_mask(
@@ -356,7 +374,7 @@ fn build_module_graph(
         .flat_map(|summary| {
             summary.dependencies.iter().flat_map(|dependency| {
                 [
-                    dependency.input,
+                    sparse_input_region(summary, dependency.input, dependency.output),
                     sparse_output_region(summary, dependency.output),
                 ]
             })
@@ -536,11 +554,12 @@ fn add_memory_ssa_edges(
         if dependency.kind == EdgeKind::Unknown {
             continue;
         }
+        let input = sparse_input_region(summary, dependency.input, dependency.output);
         let output = sparse_output_region(summary, dependency.output);
         let pairs = if dependency.aligned {
-            aligned_region_node_pairs(dependency.input, output, &module.variables, bit_part)
+            aligned_region_node_pairs(input, output, &module.variables, bit_part)
         } else {
-            let sources = region_node_keys(dependency.input, &module.variables, bit_part);
+            let sources = region_node_keys(input, &module.variables, bit_part);
             let destinations = region_node_keys(output, &module.variables, bit_part);
             sources
                 .into_iter()
@@ -644,17 +663,94 @@ fn aligned_region_node_pairs(
     pairs.into_iter().collect()
 }
 
-/// Memory SSA expands an unknown-object write over its sparse atom endpoints
-/// so kill/phi semantics stay exact. Do not turn the resulting large exact
-/// output spans back into per-element graph nodes: the object-local alias node
-/// carries the same uncertainty and aliases only regions touched elsewhere.
-fn sparse_output_region(summary: &ProcedureSummary<VarId>, output: Region<VarId>) -> Region<VarId> {
-    match output {
-        Region::Exact { object, .. } if summary.uncertain_write_objects.contains(&object) => {
-            Region::UnknownObject(object)
-        }
-        output => output,
+fn sparse_input_region(
+    summary: &ProcedureSummary<VarId>,
+    input: Region<VarId>,
+    output: Region<VarId>,
+) -> Region<VarId> {
+    if summary
+        .uncertain_input_dependencies
+        .contains(&(input, output))
+    {
+        restore_uncertain_region(&summary.uncertain_read_regions, input)
+    } else {
+        input
     }
+}
+
+/// Memory SSA expands an unresolved write over its sparse atom endpoints
+/// so kill/phi semantics stay exact. Do not turn the resulting large exact
+/// spans back into per-element graph nodes. Restore the narrowest original
+/// uncertain region, retaining any statically known prefix.
+fn sparse_output_region(summary: &ProcedureSummary<VarId>, output: Region<VarId>) -> Region<VarId> {
+    restore_uncertain_region(&summary.uncertain_write_regions, output)
+}
+
+fn restore_uncertain_region(
+    uncertain: &BTreeSet<Region<VarId>>,
+    exact: Region<VarId>,
+) -> Region<VarId> {
+    let Region::Exact { object, span } = exact else {
+        return exact;
+    };
+    uncertain
+        .iter()
+        .copied()
+        .filter(|region| match region {
+            Region::UnknownRegion {
+                object: candidate,
+                span: candidate_span,
+            } => *candidate == object && candidate_span.intersection(span) == Some(span),
+            Region::UnknownObject(candidate) => *candidate == object,
+            Region::Exact { .. } | Region::UnknownAll => false,
+        })
+        .min_by_key(|region| match region {
+            Region::UnknownRegion { span, .. } => span.length,
+            Region::UnknownObject(_) => usize::MAX,
+            Region::Exact { .. } | Region::UnknownAll => 0,
+        })
+        .unwrap_or(exact)
+}
+
+fn sparse_exact_node_keys(
+    object: VarId,
+    span: Span,
+    variables: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<NodeKey> {
+    let Some(width) = variables.get(&object).and_then(Variable::total_width) else {
+        return Vec::new();
+    };
+    if span.end().is_none() {
+        return Vec::new();
+    }
+    let mut keys = Vec::new();
+    for (&(candidate, element), ranges) in &bit_part.ranges {
+        if candidate != object {
+            continue;
+        }
+        let Some(element_start) = element.checked_mul(width) else {
+            continue;
+        };
+        let Some(overlap) = (Span {
+            start: element_start,
+            length: width,
+        })
+        .intersection(span) else {
+            continue;
+        };
+        let local_start = overlap.start - element_start;
+        let local_end = local_start + overlap.length;
+        let mask = ValueBigUint::gen_mask_range(local_end - 1, local_start);
+        keys.extend(
+            ranges
+                .iter()
+                .enumerate()
+                .filter(|(_, range)| (*range & &mask) != BigUint::default())
+                .map(|(range, _)| (object, element, range)),
+        );
+    }
+    keys
 }
 
 /// Convert the MemorySSA engine's flattened, half-open bit region back to the
@@ -665,50 +761,28 @@ fn region_node_keys(
     variables: &HashMap<VarId, Variable>,
     bit_part: &BitPartition,
 ) -> Vec<NodeKey> {
-    let (object, span) = match region {
-        Region::Exact { object, span } => (object, span),
-        Region::UnknownObject(object) => {
-            // Alias every region of this object which is otherwise observable
-            // in the sparse partition. This is proportional to touched
-            // regions, not to the declared array size.
-            let mut keys = bit_part
-                .ranges
-                .keys()
-                .filter(|(candidate, _)| *candidate == object)
-                .flat_map(|&(candidate, element)| {
-                    (0..bit_part.ranges_of((candidate, element)).len())
-                        .map(move |range| (candidate, element, range))
-                })
-                .collect::<Vec<_>>();
-            keys.push((object, UNKNOWN_REGION_INDEX, UNKNOWN_REGION_INDEX));
-            keys.sort_unstable();
-            keys.dedup();
-            return keys;
+    let mut keys = match region {
+        Region::Exact { object, span } => {
+            return sparse_exact_node_keys(object, span, variables, bit_part);
         }
+        Region::UnknownRegion { object, span } => {
+            sparse_exact_node_keys(object, span, variables, bit_part)
+        }
+        Region::UnknownObject(object) => bit_part
+            .ranges
+            .iter()
+            .filter(|((candidate, _), _)| *candidate == object)
+            .flat_map(|(&(candidate, element), ranges)| {
+                (0..ranges.len()).map(move |range| (candidate, element, range))
+            })
+            .collect(),
         Region::UnknownAll => return Vec::new(),
     };
-    let Some(width) = variables.get(&object).and_then(Variable::total_width) else {
-        return Vec::new();
-    };
-    let Some(end) = span.end() else {
-        return Vec::new();
-    };
-    let mut keys = Vec::new();
-    let mut cursor = span.start;
-    while cursor < end {
-        let element = cursor / width;
-        let bit_start = cursor % width;
-        let element_end = end.min((element + 1).saturating_mul(width));
-        let bit_end = element_end - element * width;
-        let mask = ValueBigUint::gen_mask_range(bit_end - 1, bit_start);
-        keys.extend(
-            bit_part
-                .overlapping((object, element), &mask)
-                .into_iter()
-                .map(|range| (object, element, range)),
-        );
-        cursor = element_end;
+    if let Some(wildcard) = bit_part.wildcard_key(region) {
+        keys.push(wildcard);
     }
+    keys.sort_unstable();
+    keys.dedup();
     keys
 }
 
@@ -726,18 +800,10 @@ fn collect_instance_summary_regions(
             continue;
         };
         for dependency in &summary.dependencies {
-            let Region::Exact {
-                object: child_input,
-                span: input_span,
-            } = dependency.input
-            else {
+            let Some(child_input) = region_object(dependency.input) else {
                 continue;
             };
-            let Region::Exact {
-                object: child_output,
-                span: output_span,
-            } = dependency.output
-            else {
+            let Some(child_output) = region_object(dependency.output) else {
                 continue;
             };
             let Some(input) = inst.inputs.iter().find(|input| input.id == child_input) else {
@@ -746,18 +812,20 @@ fn collect_instance_summary_regions(
             let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
                 continue;
             };
-            regions.extend(
-                map_expression_span_to_regions(&input.expr, input_span, &module.variables, ctx)
-                    .unwrap_or_else(|| {
-                        collect_expression_regions(&input.expr, &module.variables, ctx)
-                    }),
-            );
-            regions.extend(
-                map_destinations_span_to_regions(&output.dst, output_span, &module.variables, ctx)
-                    .unwrap_or_else(|| {
-                        collect_destination_regions(&output.dst, &module.variables, ctx)
-                    }),
-            );
+            regions.extend(map_child_input_region(
+                dependency.input,
+                child,
+                &input.expr,
+                &module.variables,
+                ctx,
+            ));
+            regions.extend(map_child_output_region(
+                dependency.output,
+                child,
+                &output.dst,
+                &module.variables,
+                ctx,
+            ));
         }
     }
     regions
@@ -776,18 +844,10 @@ fn add_inst_feedthrough_edges(
     ctx: &mut Context,
 ) {
     for dependency in &summary.dependencies {
-        let Region::Exact {
-            object: child_input,
-            span: input_span,
-        } = dependency.input
-        else {
+        let Some(child_input) = region_object(dependency.input) else {
             continue;
         };
-        let Region::Exact {
-            object: child_output,
-            span: output_span,
-        } = dependency.output
-        else {
+        let Some(child_output) = region_object(dependency.output) else {
             continue;
         };
         if !is_pure_input_or_output(child_input, &child.variables, Direction::Input)
@@ -805,11 +865,9 @@ fn add_inst_feedthrough_edges(
             incomplete.insert(IncompleteReason::HierarchicalReference);
         }
         let parent_input_regions =
-            map_expression_span_to_regions(&input.expr, input_span, parent_vars, ctx)
-                .unwrap_or_else(|| collect_expression_regions(&input.expr, parent_vars, ctx));
+            map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
         let parent_output_regions =
-            map_destinations_span_to_regions(&output.dst, output_span, parent_vars, ctx)
-                .unwrap_or_else(|| collect_destination_regions(&output.dst, parent_vars, ctx));
+            map_child_output_region(dependency.output, child, &output.dst, parent_vars, ctx);
         for input_region in parent_input_regions {
             for source in region_node_keys(input_region, parent_vars, bit_part) {
                 for &output_region in &parent_output_regions {
@@ -822,6 +880,73 @@ fn add_inst_feedthrough_edges(
             }
         }
     }
+}
+
+fn region_object(region: Region<VarId>) -> Option<VarId> {
+    match region {
+        Region::Exact { object, .. }
+        | Region::UnknownRegion { object, .. }
+        | Region::UnknownObject(object) => Some(object),
+        Region::UnknownAll => None,
+    }
+}
+
+fn child_region_span(region: Region<VarId>, child: &Module) -> Option<(Span, bool)> {
+    match region {
+        Region::Exact { span, .. } => Some((span, false)),
+        Region::UnknownRegion { span, .. } => Some((span, true)),
+        Region::UnknownObject(object) => {
+            let variable = child.variables.get(&object)?;
+            let length = variable
+                .total_width()?
+                .checked_mul(variable.r#type.total_array().unwrap_or(1))?;
+            Some((Span { start: 0, length }, true))
+        }
+        Region::UnknownAll => None,
+    }
+}
+
+fn retain_uncertainty(regions: Vec<Region<VarId>>, uncertain: bool) -> Vec<Region<VarId>> {
+    if !uncertain {
+        return regions;
+    }
+    regions
+        .into_iter()
+        .map(|region| match region {
+            Region::Exact { object, span } => Region::UnknownRegion { object, span },
+            region => region,
+        })
+        .collect()
+}
+
+fn map_child_input_region(
+    region: Region<VarId>,
+    child: &Module,
+    actual: &Expression,
+    parent_vars: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Vec<Region<VarId>> {
+    let Some((span, uncertain)) = child_region_span(region, child) else {
+        return Vec::new();
+    };
+    let mapped = map_expression_span_to_regions(actual, span, parent_vars, ctx)
+        .unwrap_or_else(|| collect_expression_regions(actual, parent_vars, ctx));
+    retain_uncertainty(mapped, uncertain)
+}
+
+fn map_child_output_region(
+    region: Region<VarId>,
+    child: &Module,
+    actual: &[AssignDestination],
+    parent_vars: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Vec<Region<VarId>> {
+    let Some((span, uncertain)) = child_region_span(region, child) else {
+        return Vec::new();
+    };
+    let mapped = map_destinations_span_to_regions(actual, span, parent_vars, ctx)
+        .unwrap_or_else(|| collect_destination_regions(actual, parent_vars, ctx));
+    retain_uncertainty(mapped, uncertain)
 }
 
 fn expression_has_hierarchical_reference(expression: &Expression) -> bool {
@@ -1342,8 +1467,8 @@ fn compute_module_summary(
 }
 
 fn node_key_regions(key: NodeKey, module: &Module, bit_part: &BitPartition) -> Vec<Region<VarId>> {
-    if key.1 == UNKNOWN_REGION_INDEX || key.2 == UNKNOWN_REGION_INDEX {
-        return Vec::new();
+    if key.1 == UNKNOWN_REGION_INDEX {
+        return bit_part.wildcards.get(key.2).copied().into_iter().collect();
     }
     let Some(width) = module.variables.get(&key.0).and_then(Variable::total_width) else {
         return Vec::new();

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -95,23 +95,27 @@
 //! the same procedure or module.
 //!
 //! [`check`] returns only hard loop errors for compatibility.
-//! [`check_detailed`] additionally exposes per-module incomplete reasons. The
-//! important incomplete boundaries are:
+//! [`check_detailed`] additionally exposes per-module incomplete reasons,
+//! classified by provenance:
 //!
-//! - SystemVerilog/external components and `inout` ports;
-//! - hierarchical references and instance actual/destination mappings which
-//!   cannot preserve a region;
-//! - recursive functions or cyclic concrete module-specialization graphs;
-//! - runtime-bound loops and constant loops deliberately left above the
-//!   evaluation-size limit;
-//! - timed/event effects, unsupported or malformed analyzer IR, and generic
-//!   modules whose concrete shape was not elaborated.
+//! - opaque boundaries include SystemVerilog/external components, `inout`,
+//!   timed/event effects, unbounded regions, and unsupported source retained
+//!   without a causal model;
+//! - analysis gaps include unresolved hierarchy or region mapping, recursive
+//!   summaries, dynamic loop trip counts, and constant loops deliberately left
+//!   above the evaluation-size limit. Unevaluated generic shapes are opaque
+//!   because no concrete behavior exists in the analysis input.
 //!
 //! These cases may still contain a real loop that this pass cannot prove. No
 //! guessed feedthrough is added across an opaque boundary. Callers that require
 //! a completeness guarantee must inspect `CombAnalysisResult::incomplete`
 //! rather than interpreting an empty `errors` list as proof that the design is
 //! acyclic.
+//!
+//! Malformed analyzer IR is reported separately in
+//! `CombAnalysisResult::failures`. It is an analyzer failure rather than an
+//! incomplete user design, and invalidates a completeness conclusion even when
+//! the partial result also contains useful known dependencies.
 //!
 //! # Complexity and limits
 //!
@@ -151,7 +155,9 @@ use petgraph::visit::EdgeRef;
 use rayon::prelude::*;
 use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet};
-use veryl_causal::graph::{EdgeKind, IncompleteReason};
+use veryl_causal::graph::{
+    AnalysisFailure, AnalysisGap, EdgeKind, IncompleteReason, OpaqueBoundary,
+};
 use veryl_causal::procedure::{AlignedDependency, PeriodicAxis, ProcedureSummary};
 use veryl_causal::region::{Region, Span};
 use veryl_parser::resource_table::StrId;
@@ -505,10 +511,39 @@ pub struct IncompleteCombAnalysis {
     pub reasons: BTreeSet<IncompleteReason>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FailedCombAnalysis {
+    pub module: String,
+    pub reasons: BTreeSet<AnalysisFailure>,
+}
+
+#[derive(Default)]
+struct CombAnalysisProvenance {
+    incomplete: Vec<IncompleteCombAnalysis>,
+    failures: Vec<FailedCombAnalysis>,
+}
+
 #[derive(Debug, Default)]
 pub struct CombAnalysisResult {
     pub errors: Vec<AnalyzerError>,
     pub incomplete: Vec<IncompleteCombAnalysis>,
+    pub failures: Vec<FailedCombAnalysis>,
+}
+
+impl CombAnalysisResult {
+    /// Whether the analyzer completed without violating its own IR/model
+    /// invariants. This is independent of whether the design contains a loop.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.failures.is_empty()
+    }
+
+    /// Whether every relevant dependency was represented. Proven loop errors
+    /// do not make an otherwise complete analysis incomplete.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.is_valid() && self.incomplete.is_empty()
+    }
 }
 
 /// Run loop detection while retaining uncertainty which must not be promoted
@@ -520,7 +555,7 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
 fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<AnalyzerError>) {
     let mut loops = LoopDiagnostics::default();
     let mut coverage = CoverageDiagnostics::default();
-    let mut incomplete = Vec::new();
+    let mut provenance = CombAnalysisProvenance::default();
     let mut summaries = CombSummaryCache::default();
     let mut visiting_specializations = HashSet::default();
 
@@ -529,9 +564,9 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
         if let Component::Module(module) = &ir.components[idx] {
             // Unevaluable generic params do not have a concrete module shape.
             if module.suppress_unassigned {
-                incomplete.push(IncompleteCombAnalysis {
+                provenance.incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
-                    reasons: [IncompleteReason::UnevaluatedGeneric].into(),
+                    reasons: [IncompleteReason::Opaque(OpaqueBoundary::UnevaluatedGeneric)].into(),
                 });
                 continue;
             }
@@ -541,10 +576,10 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
                 &mut visiting_specializations,
                 &mut loops,
                 &mut coverage,
-                &mut incomplete,
+                &mut provenance,
                 collect_coverage,
             );
-            let (graph, reasons, bit_part, module_coverage) = build_module_graph(
+            let (graph, reasons, module_failures, bit_part, module_coverage) = build_module_graph(
                 module,
                 &summaries.modules,
                 collect_coverage,
@@ -553,9 +588,15 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
             extend_unique_errors(&mut coverage, module_coverage);
             check_graph(module, &graph, &mut loops);
             if !reasons.is_empty() {
-                incomplete.push(IncompleteCombAnalysis {
+                provenance.incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
                     reasons,
+                });
+            }
+            if !module_failures.is_empty() {
+                provenance.failures.push(FailedCombAnalysis {
+                    module: module.name.to_string(),
+                    reasons: module_failures,
                 });
             }
             if let Some(specialization) = &module.specialization {
@@ -570,7 +611,8 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
     (
         CombAnalysisResult {
             errors: loops.errors,
-            incomplete,
+            incomplete: provenance.incomplete,
+            failures: provenance.failures,
         },
         coverage.errors,
     )
@@ -613,7 +655,7 @@ fn ensure_instance_summaries(
     visiting: &mut HashSet<ComponentSummaryKey>,
     loops: &mut LoopDiagnostics,
     coverage: &mut CoverageDiagnostics,
-    incomplete: &mut Vec<IncompleteCombAnalysis>,
+    provenance: &mut CombAnalysisProvenance,
     collect_coverage: bool,
 ) {
     for inst in walk_insts(module) {
@@ -625,9 +667,9 @@ fn ensure_instance_summaries(
             continue;
         }
         if !visiting.insert(key.clone()) {
-            incomplete.push(IncompleteCombAnalysis {
+            provenance.incomplete.push(IncompleteCombAnalysis {
                 module: child.name.to_string(),
-                reasons: [IncompleteReason::RecursiveCall].into(),
+                reasons: [IncompleteReason::Analysis(AnalysisGap::RecursiveCall)].into(),
             });
             continue;
         }
@@ -637,10 +679,10 @@ fn ensure_instance_summaries(
             visiting,
             loops,
             coverage,
-            incomplete,
+            provenance,
             collect_coverage,
         );
-        let (graph, reasons, bit_part, child_coverage) = build_module_graph(
+        let (graph, reasons, child_failures, bit_part, child_coverage) = build_module_graph(
             child,
             &summaries.modules,
             collect_coverage,
@@ -651,9 +693,15 @@ fn ensure_instance_summaries(
         let summary = compute_module_summary(child, &graph, &bit_part);
         summaries.modules.insert(key.clone(), summary);
         if !reasons.is_empty() {
-            incomplete.push(IncompleteCombAnalysis {
+            provenance.incomplete.push(IncompleteCombAnalysis {
                 module: child.name.to_string(),
                 reasons,
+            });
+        }
+        if !child_failures.is_empty() {
+            provenance.failures.push(FailedCombAnalysis {
+                module: child.name.to_string(),
+                reasons: child_failures,
             });
         }
         visiting.remove(&key);
@@ -1075,6 +1123,7 @@ fn build_module_graph(
 ) -> (
     CausalGraph,
     BTreeSet<IncompleteReason>,
+    BTreeSet<AnalysisFailure>,
     BitPartition,
     Vec<CoverageDiagnostic>,
 ) {
@@ -1088,6 +1137,10 @@ fn build_module_graph(
     // the same callee behind a global mutex.
     let (all_function_analyses, mut analysis_context) =
         crate::comb_memory_ssa::analyze_functions(module, &function_cache);
+    let function_failures = all_function_analyses
+        .iter()
+        .flat_map(|analysis| analysis.failures.iter().copied())
+        .collect::<BTreeSet<_>>();
     function_cache.freeze();
     let analyze_declaration = |declaration: &Declaration| match declaration {
         Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze(
@@ -1277,22 +1330,26 @@ fn build_module_graph(
     let mut graph = CausalGraph::new();
     let mut node_map: HashMap<NodeKey, NodeIndex> = HashMap::default();
     let mut incomplete = BTreeSet::new();
+    let mut failures = function_cache.failures();
+    failures.extend(function_failures);
 
     if module
         .variables
         .values()
         .any(|variable| matches!(variable.kind, crate::ir::VarKind::Inout))
     {
-        incomplete.insert(IncompleteReason::InoutPort);
+        incomplete.insert(IncompleteReason::Opaque(OpaqueBoundary::InoutPort));
     }
 
     for declaration in &module.declarations {
         match declaration {
             Declaration::External(_) => {
-                incomplete.insert(IncompleteReason::ExternalComponent);
+                incomplete.insert(IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent));
             }
             Declaration::Unsupported(_) => {
-                incomplete.insert(IncompleteReason::MalformedModel);
+                incomplete.insert(IncompleteReason::Opaque(
+                    OpaqueBoundary::UnsupportedConstruct,
+                ));
             }
             Declaration::Comb(_)
             | Declaration::Ff(_)
@@ -1306,6 +1363,7 @@ fn build_module_graph(
         match result {
             Ok(summary) => {
                 incomplete.extend(summary.incomplete.iter().copied());
+                failures.extend(summary.failures.iter().copied());
                 add_memory_ssa_edges(module, summary, &bit_part, &mut graph, &mut node_map);
                 add_periodic_memory_ssa_edges(
                     module,
@@ -1316,7 +1374,7 @@ fn build_module_graph(
                 );
             }
             Err(error) => {
-                incomplete.insert(IncompleteReason::MalformedModel);
+                failures.insert(AnalysisFailure::MalformedModel);
                 log::debug!(
                     "failed to build comb MemorySSA for {}: {error}",
                     module.name
@@ -1336,7 +1394,7 @@ fn build_module_graph(
                     .values()
                     .any(|variable| matches!(variable.kind, crate::ir::VarKind::Inout))
                 {
-                    incomplete.insert(IncompleteReason::InoutPort);
+                    incomplete.insert(IncompleteReason::Opaque(OpaqueBoundary::InoutPort));
                 }
                 add_inst_output_address_edges(
                     inst,
@@ -1368,14 +1426,14 @@ fn build_module_graph(
             }
             // SV black box: under-detect.
             Component::SystemVerilog(_) => {
-                incomplete.insert(IncompleteReason::ExternalComponent);
+                incomplete.insert(IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent));
             }
             // Interface signals are already lifted into the parent.
             Component::Interface(_) => {}
         }
     }
 
-    (graph, incomplete, bit_part, coverage_errors)
+    (graph, incomplete, failures, bit_part, coverage_errors)
 }
 
 fn retention_diagnostics(
@@ -2164,7 +2222,7 @@ fn add_inst_feedthrough_edges(
             continue;
         };
         if expression_has_hierarchical_reference(&input.expr) {
-            incomplete.insert(IncompleteReason::HierarchicalReference);
+            incomplete.insert(IncompleteReason::Analysis(AnalysisGap::UnresolvedHierarchy));
         }
         if let SummaryOutput::Periodic(periodic) = &dependency.output {
             let parent_inputs = map_child_input_region(
@@ -2178,7 +2236,7 @@ fn add_inst_feedthrough_edges(
             let Some(parent_outputs) =
                 map_child_periodic_output(periodic, child, &output.dst, parent_vars, ctx)
             else {
-                incomplete.insert(IncompleteReason::DynamicRegion);
+                incomplete.insert(IncompleteReason::Analysis(AnalysisGap::RegionMapping));
                 continue;
             };
             for input_region in parent_inputs {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -678,7 +678,7 @@ fn sparse_input_region(
         .uncertain_input_dependencies
         .contains(&(input, output))
     {
-        restore_uncertain_region(&summary.uncertain_read_regions, input)
+        restore_uncertain_region(&summary.uncertain_input_regions, input)
     } else {
         input
     }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -9,7 +9,6 @@
 //! simulator's `analyze_dependency` is the backup safety net.
 
 use crate::AnalyzerError;
-use crate::BigUint;
 use crate::HashMap;
 use crate::HashSet;
 use crate::conv::Context;
@@ -19,7 +18,6 @@ use crate::ir::{
     InstDeclaration, Ir, Module, Op, SystemFunctionKind, VarIndex, VarSelect, Variable,
 };
 use crate::symbol::{Affiliation, Direction};
-use crate::value::ValueBigUint;
 use daggy::petgraph::Direction::Incoming;
 use daggy::petgraph::Graph;
 use daggy::petgraph::graph::NodeIndex;
@@ -187,7 +185,7 @@ const DENSE_REGION_INDEX: usize = usize::MAX - 1;
 /// iff they appear in the same set of per-decl masks.
 #[derive(Default)]
 struct BitPartition {
-    ranges: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
+    ranges: HashMap<VarId, BTreeMap<usize, Vec<Span>>>,
     /// Symbolic full-element interiors of large exact spans. Their graph-node
     /// count depends on observed spans, not on unpacked array length.
     dense_regions: Vec<Region<VarId>>,
@@ -198,7 +196,7 @@ struct BitPartition {
 
 impl BitPartition {
     /// Empty slice means the variable's bits are untouched.
-    fn ranges_of(&self, key: IdxKey) -> &[BigUint] {
+    fn ranges_of(&self, key: IdxKey) -> &[Span] {
         self.ranges
             .get(&key.0)
             .and_then(|elements| elements.get(&key.1))
@@ -428,69 +426,49 @@ fn walk_insts(module: &Module) -> impl Iterator<Item = &InstDeclaration> {
 
 /// Group bits into atomic ranges by signature: bits with the same set
 /// of containing masks form one range. Bits in zero masks are dropped.
-fn atomic_ranges(masks: &[BigUint], width: usize) -> Vec<BigUint> {
-    // Split only at mask transitions. The previous implementation visited
-    // every declared bit and built a signature BigUint for it, making a sparse
-    // access to a million-bit object take O(width * accesses). Here the work is
-    // O(mask limbs + transitions * accesses), independent of untouched spans.
-    let mut endpoints = BTreeSet::new();
-    endpoints.insert(0usize);
-    endpoints.insert(width);
+fn atomic_ranges(masks: &[Span], width: usize) -> Vec<Span> {
+    // Every mask is already a compact interval. Sweep its endpoints instead
+    // of constructing width-sized BigUints or comparing every interval with
+    // every mask. A finer split at each transition is causally equivalent to
+    // merging non-contiguous intervals with the same signature.
+    let mut events = BTreeMap::<usize, isize>::new();
     for mask in masks {
-        let digits = mask.iter_u64_digits().collect::<Vec<_>>();
-        let mut previous_bit = false;
-        for word_index in 0..=digits.len() {
-            let word = digits.get(word_index).copied().unwrap_or(0);
-            let shifted = word.wrapping_shl(1) | u64::from(previous_bit);
-            let mut transitions = word ^ shifted;
-            while transitions != 0 {
-                let bit = transitions.trailing_zeros() as usize;
-                let endpoint = word_index.saturating_mul(64).saturating_add(bit);
-                if endpoint <= width {
-                    endpoints.insert(endpoint);
-                }
-                transitions &= transitions - 1;
-            }
-            previous_bit = word >> 63 != 0;
-        }
-    }
-
-    let mut by_sig: HashMap<BigUint, BigUint> = HashMap::default();
-    let one = BigUint::from(1u32);
-    let endpoints = endpoints.into_iter().collect::<Vec<_>>();
-    for window in endpoints.windows(2) {
-        let start = window[0];
-        let end = window[1];
+        let Some(end) = mask.end().map(|end| end.min(width)) else {
+            continue;
+        };
+        let start = mask.start.min(width);
         if start >= end {
             continue;
         }
-        let mut sig = BigUint::default();
-        for (i, m) in masks.iter().enumerate() {
-            if m.bit(start as u64) {
-                sig |= &one << i;
-            }
-        }
-        if sig == BigUint::default() {
-            continue;
-        }
-        let entry = by_sig.entry(sig).or_default();
-        *entry |= ValueBigUint::gen_mask_range(end - 1, start);
+        *events.entry(start).or_default() += 1;
+        *events.entry(end).or_default() -= 1;
     }
-    let mut ret: Vec<BigUint> = by_sig.into_values().collect();
-    // Stable order by lowest set bit so NodeKey range_idx is deterministic.
-    ret.sort_by_key(|m| m.trailing_zeros().unwrap_or(0));
-    ret
+
+    let mut active = 0isize;
+    let mut previous = 0usize;
+    let mut ranges = Vec::new();
+    for (endpoint, delta) in events {
+        if active > 0 && previous < endpoint {
+            ranges.push(Span {
+                start: previous,
+                length: endpoint - previous,
+            });
+        }
+        active += delta;
+        previous = endpoint;
+    }
+    ranges
 }
 
 fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) -> BitPartition {
-    let mut masks: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>> = HashMap::default();
+    let mut masks: HashMap<VarId, BTreeMap<usize, Vec<Span>>> = HashMap::default();
 
     // A shifted copy can propagate every observed endpoint through the copy
     // relation. Feed those sparse spans into the shared partition so distinct
     // causal atoms do not collapse into a spurious self-edge.
     let dense_regions = collect_region_masks(memory_ssa_regions, module, &mut masks);
 
-    let mut ranges: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>> = HashMap::default();
+    let mut ranges: HashMap<VarId, BTreeMap<usize, Vec<Span>>> = HashMap::default();
     for (object, elements) in masks {
         let width = module
             .variables
@@ -530,7 +508,7 @@ fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) ->
 fn collect_region_masks(
     regions: &[Region<VarId>],
     module: &Module,
-    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
+    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<Span>>>,
 ) -> Vec<Region<VarId>> {
     // Full-element interiors are homogeneous. Materialize only their boundary
     // representatives and any sparse element already observed by another
@@ -562,14 +540,20 @@ fn collect_region_masks(
             masks,
             object,
             first,
-            ValueBigUint::gen_mask_range(first_end - first * width - 1, span.start % width),
+            Span {
+                start: span.start % width,
+                length: first_end - span.start,
+            },
         );
         if last != first {
             push_element_mask(
                 masks,
                 object,
                 last,
-                ValueBigUint::gen_mask_range(end - last * width - 1, 0),
+                Span {
+                    start: 0,
+                    length: end - last * width,
+                },
             );
         }
 
@@ -594,7 +578,10 @@ fn collect_region_masks(
         else {
             continue;
         };
-        let full_mask = ValueBigUint::gen_mask_range(width - 1, 0);
+        let full_mask = Span {
+            start: 0,
+            length: width,
+        };
         let elements = masks.entry(object).or_default();
         for (start, end) in intervals {
             dense_regions.push(Region::Exact {
@@ -616,7 +603,7 @@ fn collect_region_masks(
                 elements
                     .get_mut(&element)
                     .expect("materialized element")
-                    .push(full_mask.clone());
+                    .push(full_mask);
             }
         }
     }
@@ -626,10 +613,10 @@ fn collect_region_masks(
 }
 
 fn push_element_mask(
-    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
+    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<Span>>>,
     object: VarId,
     element: usize,
-    mask: BigUint,
+    mask: Span,
 ) {
     masks
         .entry(object)
@@ -1146,12 +1133,15 @@ fn sparse_exact_node_keys(
         };
         let local_start = overlap.start - element_start;
         let local_end = local_start + overlap.length;
-        let mask = ValueBigUint::gen_mask_range(local_end - 1, local_start);
+        let selected = Span {
+            start: local_start,
+            length: local_end - local_start,
+        };
         keys.extend(
             ranges
                 .iter()
                 .enumerate()
-                .filter(|(_, range)| (*range & &mask) != BigUint::default())
+                .filter(|(_, range)| range.intersection(selected).is_some())
                 .map(|(range, _)| (object, element, range)),
         );
     }
@@ -1902,10 +1892,18 @@ fn collect_expression_regions(
             Expression::Unary(_, operand, _) => collect(operand, variables, ctx, regions),
             Expression::Binary(left, op, right, _) => {
                 collect(left, variables, ctx, regions);
-                let left_value = left.clone().eval_value(ctx);
-                let rhs_reachable = match (op, left_value.as_ref()) {
-                    (Op::LogicAnd, Some(value)) if !value.is_xz() && !value.is_positive() => false,
-                    (Op::LogicOr, Some(value)) if !value.is_xz() && value.is_positive() => false,
+                let rhs_reachable = match op {
+                    Op::LogicAnd | Op::LogicOr => {
+                        let left_value = left.clone().eval_value(ctx);
+                        !matches!(
+                            (op, left_value.as_ref()),
+                            (Op::LogicAnd, Some(value))
+                                if !value.is_xz() && !value.is_positive()
+                        ) && !matches!(
+                            (op, left_value.as_ref()),
+                            (Op::LogicOr, Some(value)) if !value.is_xz() && value.is_positive()
+                        )
+                    }
                     _ => true,
                 };
                 if rhs_reachable {
@@ -2381,60 +2379,23 @@ fn node_key_regions_for_variables(
     let Some(width) = variables.get(&key.0).and_then(Variable::total_width) else {
         return Vec::new();
     };
-    let Some(mask) = bit_part.ranges_of((key.0, key.1)).get(key.2) else {
+    let Some(span) = bit_part.ranges_of((key.0, key.1)).get(key.2) else {
         return Vec::new();
     };
-    mask_spans(mask, width)
-        .into_iter()
-        .filter_map(|span| {
-            let start = key.1.checked_mul(width)?.checked_add(span.start)?;
-            Some(Region::Exact {
-                object: key.0,
-                span: Span {
-                    start,
-                    length: span.length,
-                },
-            })
-        })
-        .collect()
-}
-
-fn mask_spans(mask: &BigUint, width: usize) -> Vec<Span> {
-    let digits = mask.iter_u64_digits().collect::<Vec<_>>();
-    let mut spans = Vec::new();
-    let mut start = None;
-    for word_index in 0..=digits.len() {
-        let word = digits.get(word_index).copied().unwrap_or(0);
-        let previous_bit = word_index
-            .checked_sub(1)
-            .and_then(|index| digits.get(index))
-            .is_some_and(|word| word >> 63 != 0);
-        let mut transitions = word ^ (word.wrapping_shl(1) | u64::from(previous_bit));
-        while transitions != 0 {
-            let bit = transitions.trailing_zeros() as usize;
-            let point = word_index.saturating_mul(64).saturating_add(bit).min(width);
-            if mask.bit(point as u64) {
-                start = Some(point);
-            } else if let Some(span_start) = start.take()
-                && span_start < point
-            {
-                spans.push(Span {
-                    start: span_start,
-                    length: point - span_start,
-                });
-            }
-            transitions &= transitions - 1;
-        }
-    }
-    if let Some(span_start) = start
-        && span_start < width
-    {
-        spans.push(Span {
-            start: span_start,
-            length: width - span_start,
-        });
-    }
-    spans
+    let Some(start) = key
+        .1
+        .checked_mul(width)
+        .and_then(|base| base.checked_add(span.start))
+    else {
+        return Vec::new();
+    };
+    vec![Region::Exact {
+        object: key.0,
+        span: Span {
+            start,
+            length: span.length,
+        },
+    }]
 }
 
 #[cfg(test)]
@@ -2486,48 +2447,80 @@ mod memory_ssa_tests {
 
     #[test]
     fn atomic_ranges_split_at_sparse_mask_transitions() {
+        // Why this case exists: sparse endpoints on a huge packed object must
+        // cost O(accesses), not O(declared width).
         let width = 1_000_000;
-        let low = ValueBigUint::gen_mask_range(15, 8);
-        let high = ValueBigUint::gen_mask_range(width - 9, width - 16);
-        let ranges = atomic_ranges(&[low.clone(), high.clone()], width);
-        assert_eq!(ranges.len(), 2);
-        assert!(ranges.contains(&low));
-        assert!(ranges.contains(&high));
+        let low = Span {
+            start: 8,
+            length: 8,
+        };
+        let high = Span {
+            start: width - 16,
+            length: 8,
+        };
+        assert_eq!(atomic_ranges(&[low, high], width), vec![low, high]);
     }
 
     #[test]
     fn atomic_ranges_preserve_shared_and_disjoint_signatures() {
-        let first = ValueBigUint::gen_mask_range(127, 0);
-        let second = ValueBigUint::gen_mask_range(191, 64);
+        // Why this case exists: an event sweep may use a finer partition than
+        // signature merging, but it must split at both overlap boundaries.
+        let first = Span {
+            start: 0,
+            length: 128,
+        };
+        let second = Span {
+            start: 64,
+            length: 128,
+        };
         let ranges = atomic_ranges(&[first, second], 192);
-        assert_eq!(ranges.len(), 3);
-        assert_eq!(ranges[0], ValueBigUint::gen_mask_range(63, 0));
-        assert_eq!(ranges[1], ValueBigUint::gen_mask_range(127, 64));
-        assert_eq!(ranges[2], ValueBigUint::gen_mask_range(191, 128));
-    }
-
-    #[test]
-    fn module_summary_masks_split_across_word_boundaries() {
-        let mask = ValueBigUint::gen_mask_range(1, 0)
-            | ValueBigUint::gen_mask_range(65, 63)
-            | ValueBigUint::gen_mask_range(127, 127);
         assert_eq!(
-            mask_spans(&mask, 192),
+            ranges,
             vec![
                 Span {
                     start: 0,
-                    length: 2,
+                    length: 64,
                 },
                 Span {
-                    start: 63,
-                    length: 3,
+                    start: 64,
+                    length: 64,
                 },
                 Span {
-                    start: 127,
-                    length: 1,
+                    start: 128,
+                    length: 64,
                 },
             ]
         );
-        assert!(mask_spans(&BigUint::default(), 192).is_empty());
+    }
+
+    #[test]
+    fn atomic_ranges_keep_adjacent_signature_transitions() {
+        // Why this case exists: two masks ending and starting at the same bit
+        // leave coverage nonzero, but still require distinct causal atoms.
+        assert_eq!(
+            atomic_ranges(
+                &[
+                    Span {
+                        start: 0,
+                        length: 64,
+                    },
+                    Span {
+                        start: 64,
+                        length: 64,
+                    },
+                ],
+                128,
+            ),
+            vec![
+                Span {
+                    start: 0,
+                    length: 64,
+                },
+                Span {
+                    start: 64,
+                    length: 64,
+                },
+            ]
+        );
     }
 }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1540,14 +1540,30 @@ fn collect_expression_regions(
                 | Factor::Unknown(_) => {}
             },
             Expression::Unary(_, operand, _) => collect(operand, variables, ctx, regions),
-            Expression::Binary(left, _, right, _) => {
+            Expression::Binary(left, op, right, _) => {
                 collect(left, variables, ctx, regions);
-                collect(right, variables, ctx, regions);
+                let left_value = left.clone().eval_value(ctx);
+                let rhs_reachable = match (op, left_value.as_ref()) {
+                    (Op::LogicAnd, Some(value)) if !value.is_xz() && !value.is_positive() => false,
+                    (Op::LogicOr, Some(value)) if !value.is_xz() && value.is_positive() => false,
+                    _ => true,
+                };
+                if rhs_reachable {
+                    collect(right, variables, ctx, regions);
+                }
             }
             Expression::Ternary(condition, left, right, _) => {
                 collect(condition, variables, ctx, regions);
-                collect(left, variables, ctx, regions);
-                collect(right, variables, ctx, regions);
+                match condition.clone().eval_value(ctx) {
+                    Some(value) if !value.is_xz() && value.is_positive() => {
+                        collect(left, variables, ctx, regions);
+                    }
+                    Some(value) if !value.is_xz() => collect(right, variables, ctx, regions),
+                    _ => {
+                        collect(left, variables, ctx, regions);
+                        collect(right, variables, ctx, regions);
+                    }
+                }
             }
             Expression::Concatenation(parts, _) => {
                 for (part, repeat) in parts {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -178,6 +178,19 @@ impl CausalEdge {
 
 type CausalGraph = Graph<NodeKey, CausalEdge>;
 
+#[cfg(not(target_family = "wasm"))]
+fn benefits_from_parallelism(work_items: usize) -> bool {
+    // A procedure/observer task is normally too small to amortize waking the
+    // global pool. Its idle workers also outlive this pass and can contend with
+    // later serial compiler work, so retain parallelism for genuinely broad
+    // modules rather than initializing Rayon for ordinary RTL.
+    const MIN_PARALLEL_WORK_ITEMS: usize = 64;
+    if work_items < MIN_PARALLEL_WORK_ITEMS {
+        return false;
+    }
+    work_items >= rayon::current_num_threads().saturating_mul(2)
+}
+
 #[derive(Clone, Copy)]
 enum SummaryDirection {
     Forward,
@@ -1043,11 +1056,25 @@ fn build_module_graph(
         | Declaration::Null => None,
     };
     #[cfg(not(target_family = "wasm"))]
-    let mut procedure_summaries = module
+    let procedure_count = module
         .declarations
-        .par_iter()
-        .filter_map(analyze_declaration)
-        .collect::<Vec<_>>();
+        .iter()
+        .filter(|declaration| matches!(declaration, Declaration::Comb(_)))
+        .count();
+    #[cfg(not(target_family = "wasm"))]
+    let mut procedure_summaries = if benefits_from_parallelism(procedure_count) {
+        module
+            .declarations
+            .par_iter()
+            .filter_map(analyze_declaration)
+            .collect::<Vec<_>>()
+    } else {
+        module
+            .declarations
+            .iter()
+            .filter_map(analyze_declaration)
+            .collect::<Vec<_>>()
+    };
     #[cfg(target_family = "wasm")]
     let mut procedure_summaries = module
         .declarations
@@ -1073,7 +1100,7 @@ fn build_module_graph(
     instance_observers
         .retain(|expression| crate::comb_memory_ssa::expression_needs_observer(expression));
     #[cfg(not(target_family = "wasm"))]
-    procedure_summaries.extend(
+    procedure_summaries.extend(if benefits_from_parallelism(instance_observers.len()) {
         instance_observers
             .par_iter()
             .map(|expression| {
@@ -1083,8 +1110,19 @@ fn build_module_graph(
                     &function_cache,
                 )
             })
-            .collect::<Vec<_>>(),
-    );
+            .collect::<Vec<_>>()
+    } else {
+        instance_observers
+            .iter()
+            .map(|expression| {
+                crate::comb_memory_ssa::analyze_observer_expression(
+                    module,
+                    expression,
+                    &function_cache,
+                )
+            })
+            .collect::<Vec<_>>()
+    });
 
     #[cfg(target_family = "wasm")]
     procedure_summaries.extend(instance_observers.iter().map(|expression| {
@@ -3197,7 +3235,11 @@ fn compute_module_summary(
     };
 
     const QUANTUM: usize = 512;
-    let winning_walks = if graph.node_count() < QUANTUM {
+    // Below this grain, starting the global Rayon pool and racing both walk
+    // directions costs more than completing the smaller side serially. This
+    // changes scheduling only; both paths compute the same summary.
+    const MIN_PARALLEL_SUMMARY_NODES: usize = QUANTUM * 8;
+    let winning_walks = if graph.node_count() < MIN_PARALLEL_SUMMARY_NODES {
         let (direction, endpoints) = if input_nodes.len() <= output_nodes.len() {
             (SummaryDirection::Forward, input_nodes)
         } else {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -27,7 +27,7 @@ use rayon::prelude::*;
 use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet};
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
-use veryl_causal::procedure::ProcedureSummary;
+use veryl_causal::procedure::{PeriodicAxis, ProcedureSummary};
 use veryl_causal::region::{Region, Span};
 use veryl_parser::resource_table::StrId;
 
@@ -182,22 +182,40 @@ const UNKNOWN_REGION_INDEX: usize = usize::MAX;
 const DENSE_REGION_INDEX: usize = usize::MAX - 1;
 const PERIODIC_REGION_INDEX: usize = usize::MAX - 2;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct PeriodicRegion {
     object: VarId,
     output: Span,
-    repetitions: usize,
-    stride: usize,
+    axes: Vec<PeriodicAxis>,
 }
 
-#[derive(Clone, Copy, Debug)]
+impl PeriodicRegion {
+    fn extent(&self) -> Option<usize> {
+        self.axes
+            .iter()
+            .try_fold(self.output.length, |extent, axis| {
+                if axis.repetitions == 0 || axis.destination_stride < extent {
+                    return None;
+                }
+                axis.destination_stride
+                    .checked_mul(axis.repetitions - 1)
+                    .and_then(|offset| extent.checked_add(offset))
+            })
+    }
+
+    fn end(&self) -> Option<usize> {
+        self.output.start.checked_add(self.extent()?)
+    }
+}
+
+#[derive(Clone, Debug)]
 struct PeriodicTransferRegion {
     input: Region<VarId>,
     output: PeriodicRegion,
     aligned: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum SummaryOutput {
     Region(Region<VarId>),
     Periodic(PeriodicRegion),
@@ -247,7 +265,7 @@ impl BitPartition {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct ModuleCombDependency {
     input: Region<VarId>,
     output: SummaryOutput,
@@ -491,11 +509,10 @@ fn build_bit_partition(
 ) -> BitPartition {
     let mut masks: HashMap<VarId, BTreeMap<usize, Vec<Span>>> = HashMap::default();
 
-    // A shifted copy can propagate every observed endpoint through the copy
-    // relation. Feed those sparse spans into the shared partition so distinct
-    // causal atoms do not collapse into a spurious self-edge.
+    // Exact accesses define the materialized partition. Periodic transfers
+    // remain symbolic and are connected to those atoms by arithmetic overlap
+    // tests, so neither packed width nor repetition count expands this table.
     let dense_regions = collect_region_masks(memory_ssa_regions, module, &mut masks);
-    collect_periodic_masks(periodic_regions, module, &mut masks);
 
     let mut ranges: HashMap<VarId, BTreeMap<usize, Vec<Span>>> = HashMap::default();
     for (object, elements) in masks {
@@ -532,67 +549,6 @@ fn build_bit_partition(
         dense_regions,
         periodic_regions: periodic_regions.to_vec(),
         wildcards,
-    }
-}
-
-fn collect_periodic_masks(
-    periodic_regions: &[PeriodicRegion],
-    module: &Module,
-    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<Span>>>,
-) {
-    for &periodic in periodic_regions {
-        if periodic.repetitions == 0 || periodic.output.length == 0 {
-            continue;
-        }
-        let Some(width) = module
-            .variables
-            .get(&periodic.object)
-            .and_then(Variable::total_width)
-        else {
-            continue;
-        };
-        if width == 0 {
-            continue;
-        }
-        let Some(last_start) = periodic
-            .stride
-            .checked_mul(periodic.repetitions - 1)
-            .and_then(|offset| periodic.output.start.checked_add(offset))
-        else {
-            continue;
-        };
-        let Some(pattern_end) = last_start.checked_add(periodic.output.length) else {
-            continue;
-        };
-        let first_element = periodic.output.start / width;
-        masks
-            .entry(periodic.object)
-            .or_default()
-            .entry(first_element)
-            .or_default();
-        let elements = masks.entry(periodic.object).or_default();
-        let materialized = elements
-            .range(first_element..=((pattern_end - 1) / width))
-            .map(|(&element, _)| element)
-            .collect::<Vec<_>>();
-        for element in materialized {
-            let Some(element_start) = element.checked_mul(width) else {
-                continue;
-            };
-            let query = Span {
-                start: element_start,
-                length: width,
-            };
-            for overlap in periodic_span_intersections(periodic, query) {
-                elements
-                    .get_mut(&element)
-                    .expect("materialized periodic element")
-                    .push(Span {
-                        start: overlap.start - element_start,
-                        length: overlap.length,
-                    });
-            }
-        }
     }
 }
 
@@ -635,62 +591,75 @@ fn propagate_periodic_partition_regions(
                     start,
                     length: overlap.length,
                 },
-                repetitions: transfer.output.repetitions,
-                stride: transfer.output.stride,
+                axes: transfer.output.axes.clone(),
             });
         }
     }
 }
 
-fn periodic_span_intersections(periodic: PeriodicRegion, query: Span) -> Vec<Span> {
+fn periodic_overlaps_span(periodic: &PeriodicRegion, query: Span) -> bool {
     let Some(query_end) = query.end() else {
-        return Vec::new();
+        return false;
     };
-    let Some(phase_end) = periodic.output.end() else {
-        return Vec::new();
-    };
-    if periodic.repetitions == 0 || periodic.stride == 0 {
-        return periodic.output.intersection(query).into_iter().collect();
-    }
-    if periodic.output.length == periodic.stride {
-        let Some(length) = periodic.stride.checked_mul(periodic.repetitions) else {
-            return Vec::new();
+    let mut inner_extents = Vec::with_capacity(periodic.axes.len() + 1);
+    inner_extents.push(periodic.output.length);
+    for axis in &periodic.axes {
+        let inner_extent = inner_extents[inner_extents.len() - 1];
+        if axis.repetitions == 0 || axis.destination_stride < inner_extent {
+            return false;
+        }
+        let Some(extent) = axis
+            .destination_stride
+            .checked_mul(axis.repetitions.saturating_sub(1))
+            .and_then(|offset| inner_extent.checked_add(offset))
+        else {
+            return false;
         };
-        return (Span {
-            start: periodic.output.start,
-            length,
-        })
-        .intersection(query)
-        .into_iter()
-        .collect();
+        inner_extents.push(extent);
     }
-    let first = if query.start < phase_end {
-        0
-    } else {
-        (query.start - phase_end) / periodic.stride + 1
-    };
-    let end = if query_end <= periodic.output.start {
-        0
-    } else {
-        query_end
-            .saturating_sub(periodic.output.start)
-            .saturating_add(periodic.stride - 1)
-            / periodic.stride
-    }
-    .min(periodic.repetitions);
-    (first..end)
-        .filter_map(|copy| {
-            let start = periodic
-                .output
-                .start
-                .checked_add(copy.checked_mul(periodic.stride)?)?;
-            (Span {
-                start,
+    let mut stack = vec![(periodic.output.start, periodic.axes.len())];
+    while let Some((base_start, depth)) = stack.pop() {
+        if depth == 0 {
+            if (Span {
+                start: base_start,
                 length: periodic.output.length,
             })
             .intersection(query)
-        })
-        .collect()
+            .is_some()
+            {
+                return true;
+            }
+            continue;
+        }
+        let axis = periodic.axes[depth - 1];
+        let Some(inner_end) = base_start.checked_add(inner_extents[depth - 1]) else {
+            continue;
+        };
+        let first = if query.start < inner_end {
+            0
+        } else {
+            (query.start - inner_end) / axis.destination_stride + 1
+        };
+        let end = if query_end <= base_start {
+            0
+        } else {
+            query_end
+                .saturating_sub(base_start)
+                .saturating_add(axis.destination_stride - 1)
+                / axis.destination_stride
+        }
+        .min(axis.repetitions);
+        for copy in first..end {
+            let Some(start) = copy
+                .checked_mul(axis.destination_stride)
+                .and_then(|offset| base_start.checked_add(offset))
+            else {
+                continue;
+            };
+            stack.push((start, depth - 1));
+        }
+    }
+    false
 }
 
 fn collect_region_masks(
@@ -896,8 +865,7 @@ fn build_module_graph(
             output: PeriodicRegion {
                 object: dependency.output_object,
                 output: dependency.output,
-                repetitions: dependency.repetitions,
-                stride: dependency.destination_stride,
+                axes: dependency.axes.clone(),
             },
             aligned: dependency.aligned,
         })
@@ -911,7 +879,7 @@ fn build_module_graph(
     periodic_transfers.extend(instance_periodic_transfers);
     let mut periodic_regions = periodic_transfers
         .iter()
-        .map(|transfer| transfer.output)
+        .map(|transfer| transfer.output.clone())
         .collect::<Vec<_>>();
     propagate_periodic_partition_regions(
         &partition_regions,
@@ -1221,8 +1189,7 @@ fn add_periodic_memory_ssa_edges(
         let periodic = PeriodicRegion {
             object: dependency.output_object,
             output: dependency.output,
-            repetitions: dependency.repetitions,
-            stride: dependency.destination_stride,
+            axes: dependency.axes.clone(),
         };
         let pairs = if dependency.aligned {
             aligned_periodic_node_pairs(input, periodic, &module.variables, bit_part)
@@ -1288,8 +1255,7 @@ fn aligned_periodic_node_pairs(
                     start: output_start,
                     length: overlap.length,
                 },
-                repetitions: periodic.repetitions,
-                stride: periodic.stride,
+                axes: periodic.axes.clone(),
             };
             pairs.extend(
                 periodic_region_node_keys(mapped, variables, bit_part)
@@ -1511,14 +1477,7 @@ fn periodic_region_node_keys(
     else {
         return keys;
     };
-    let Some(last_start) = periodic
-        .stride
-        .checked_mul(periodic.repetitions.saturating_sub(1))
-        .and_then(|offset| periodic.output.start.checked_add(offset))
-    else {
-        return keys;
-    };
-    let Some(end) = last_start.checked_add(periodic.output.length) else {
+    let Some(end) = periodic.end() else {
         return keys;
     };
     let Some(elements) = bit_part.ranges.get(&periodic.object) else {
@@ -1537,7 +1496,7 @@ fn periodic_region_node_keys(
                 start,
                 length: range.length,
             };
-            if !periodic_span_intersections(periodic, query).is_empty() {
+            if periodic_overlaps_span(&periodic, query) {
                 keys.push((periodic.object, element, range_index));
             }
         }
@@ -1611,7 +1570,7 @@ fn collect_instance_summary_regions(
             let Some(child_input) = region_object(dependency.input) else {
                 continue;
             };
-            let Some(child_output) = summary_output_object(dependency.output) else {
+            let Some(child_output) = summary_output_object(&dependency.output) else {
                 continue;
             };
             let Some(input) = inst.inputs.iter().find(|input| input.id == child_input) else {
@@ -1628,9 +1587,9 @@ fn collect_instance_summary_regions(
                 ctx,
             );
             regions.extend(parent_inputs.iter().copied());
-            match dependency.output {
+            match &dependency.output {
                 SummaryOutput::Region(region) => regions.extend(map_child_output_region(
-                    region,
+                    *region,
                     child,
                     &output.dst,
                     &module.variables,
@@ -1646,10 +1605,10 @@ fn collect_instance_summary_regions(
                     )
                     .unwrap_or_default();
                     for &input in &parent_inputs {
-                        for &output in &parent_outputs {
+                        for output in &parent_outputs {
                             periodic_transfers.push(PeriodicTransferRegion {
                                 input,
-                                output,
+                                output: output.clone(),
                                 aligned: dependency.aligned,
                             });
                         }
@@ -1712,7 +1671,7 @@ fn add_inst_feedthrough_edges(
         let Some(child_input) = region_object(dependency.input) else {
             continue;
         };
-        let Some(child_output) = summary_output_object(dependency.output) else {
+        let Some(child_output) = summary_output_object(&dependency.output) else {
             continue;
         };
         if !is_pure_input_or_output(child_input, &child.variables, Direction::Input)
@@ -1729,7 +1688,7 @@ fn add_inst_feedthrough_edges(
         if expression_has_hierarchical_reference(&input.expr) {
             incomplete.insert(IncompleteReason::HierarchicalReference);
         }
-        if let SummaryOutput::Periodic(periodic) = dependency.output {
+        if let SummaryOutput::Periodic(periodic) = &dependency.output {
             let parent_inputs =
                 map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
             let Some(parent_outputs) =
@@ -1738,17 +1697,17 @@ fn add_inst_feedthrough_edges(
                 continue;
             };
             for input_region in parent_inputs {
-                for &parent_output in &parent_outputs {
+                for parent_output in &parent_outputs {
                     let pairs = if dependency.aligned {
                         aligned_periodic_node_pairs(
                             input_region,
-                            parent_output,
+                            parent_output.clone(),
                             parent_vars,
                             bit_part,
                         )
                     } else {
                         let destinations =
-                            periodic_region_node_keys(parent_output, parent_vars, bit_part);
+                            periodic_region_node_keys(parent_output.clone(), parent_vars, bit_part);
                         region_node_keys(input_region, parent_vars, bit_part)
                             .into_iter()
                             .flat_map(|source| {
@@ -1942,9 +1901,9 @@ fn region_object(region: Region<VarId>) -> Option<VarId> {
     }
 }
 
-fn summary_output_object(output: SummaryOutput) -> Option<VarId> {
+fn summary_output_object(output: &SummaryOutput) -> Option<VarId> {
     match output {
-        SummaryOutput::Region(region) => region_object(region),
+        SummaryOutput::Region(region) => region_object(*region),
         SummaryOutput::Periodic(periodic) => Some(periodic.object),
     }
 }
@@ -2024,7 +1983,7 @@ fn map_child_output_region(
 }
 
 fn map_child_periodic_output(
-    periodic: PeriodicRegion,
+    periodic: &PeriodicRegion,
     child: &Module,
     destinations: &[AssignDestination],
     variables: &HashMap<VarId, Variable>,
@@ -2060,8 +2019,7 @@ fn map_child_periodic_output(
             start: destination.start.checked_add(periodic.output.start)?,
             length: periodic.output.length,
         },
-        repetitions: periodic.repetitions,
-        stride: periodic.stride,
+        axes: periodic.axes.clone(),
     }])
 }
 
@@ -2903,7 +2861,7 @@ fn node_key_summary_outputs(
         return bit_part
             .periodic_regions
             .get(key.2)
-            .copied()
+            .cloned()
             .map(SummaryOutput::Periodic)
             .into_iter()
             .collect();

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -99,7 +99,7 @@
 //! - SystemVerilog/external components and `inout` ports;
 //! - hierarchical references and instance actual/destination mappings which
 //!   cannot preserve a region;
-//! - recursive functions or module-instantiation cycles;
+//! - recursive functions or cyclic concrete module-specialization graphs;
 //! - runtime-bound loops and constant loops deliberately left above the
 //!   evaluation-size limit;
 //! - timed/event effects, unsupported or malformed analyzer IR, and generic
@@ -472,7 +472,7 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
     let mut summaries: HashMap<usize, ModuleCombSummary> = HashMap::default();
     let mut visiting_specializations = HashSet::default();
 
-    let (order, recursion_affected_modules) = topo_order_modules(ir);
+    let order = module_analysis_order(ir);
 
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
@@ -493,12 +493,9 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
                 &mut incomplete,
                 collect_coverage,
             );
-            let (graph, mut reasons, _bit_part, module_coverage) =
+            let (graph, reasons, _bit_part, module_coverage) =
                 build_module_graph(module, &summaries, collect_coverage);
             extend_unique_errors(&mut coverage, module_coverage);
-            if recursion_affected_modules.contains(&idx) {
-                reasons.insert(IncompleteReason::RecursiveCall);
-            }
             check_graph(module, &graph, &mut errors);
             if !reasons.is_empty() {
                 incomplete.push(IncompleteCombAnalysis {
@@ -576,10 +573,12 @@ fn ensure_instance_summaries(
     }
 }
 
-/// Children before parents. Modules in, or transitively depending on, an
-/// instantiation cycle are appended in input order because no bottom-up order
-/// exists for them (`infinite_recursion` is reported separately).
-fn topo_order_modules(ir: &Ir) -> (Vec<usize>, HashSet<usize>) {
+/// Put declaration-level children before parents when module names happen to
+/// form a DAG. Name cycles affect scheduling only: recursive generic modules
+/// can elaborate to a finite graph of distinct concrete specializations, and
+/// only [`ensure_instance_summaries`] has the specialization identity required
+/// to classify recursion. Remaining declarations are appended in input order.
+fn module_analysis_order(ir: &Ir) -> Vec<usize> {
     let mut name_to_idx: HashMap<StrId, usize> = HashMap::default();
     for (i, c) in ir.components.iter().enumerate() {
         if let Component::Module(m) = c {
@@ -616,7 +615,7 @@ fn order_from_dependencies(
     is_module: &[bool],
     deps: &[HashSet<usize>],
     rev_deps: &[HashSet<usize>],
-) -> (Vec<usize>, HashSet<usize>) {
+) -> Vec<usize> {
     let n = is_module.len();
     let mut indeg: Vec<usize> = deps.iter().map(HashSet::len).collect();
     let mut q: VecDeque<usize> = VecDeque::new();
@@ -636,13 +635,13 @@ fn order_from_dependencies(
         }
     }
     let ordered = order.iter().copied().collect::<HashSet<_>>();
-    let recursion_affected = (0..n)
+    let remaining = (0..n)
         .filter(|i| is_module[*i] && !ordered.contains(i))
         .collect::<HashSet<_>>();
-    order.extend(recursion_affected.iter().copied());
+    order.extend(remaining.iter().copied());
     // HashSet iteration is intentionally not part of summary identity.
     order[ordered.len()..].sort_unstable();
-    (order, recursion_affected)
+    order
 }
 
 fn walk_insts(module: &Module) -> impl Iterator<Item = &InstDeclaration> {
@@ -3314,10 +3313,10 @@ mod memory_ssa_tests {
     use super::*;
 
     #[test]
-    fn recursive_module_does_not_taint_independent_modules() {
-        // Why this case exists: one recursive hierarchy makes only its SCC and
-        // transitive parents incomplete. Marking an independent hierarchy as
-        // RecursiveCall needlessly discards a valid bottom-up summary.
+    fn module_name_cycles_only_affect_analysis_order() {
+        // Why this case exists: a source-level module-name cycle can be a
+        // finite chain of distinct generic specializations. This ordering
+        // helper lacks concrete identity and must not classify recursion.
         fn set(values: &[usize]) -> HashSet<usize> {
             values.iter().copied().collect()
         }
@@ -3331,9 +3330,8 @@ mod memory_ssa_tests {
             HashSet::default(),
         ];
 
-        let (order, affected) = order_from_dependencies(&is_module, &deps, &rev_deps);
+        let order = order_from_dependencies(&is_module, &deps, &rev_deps);
         assert_eq!(order, vec![1, 3, 0, 2]);
-        assert_eq!(affected, set(&[0, 2]));
     }
 
     #[test]

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -181,12 +181,16 @@ fn live_summary_nodes(
 /// Sparse alias node for a dynamically selected region of one object.  This
 /// deliberately occupies no real array element or bit-partition slot.
 const UNKNOWN_REGION_INDEX: usize = usize::MAX;
+const DENSE_REGION_INDEX: usize = usize::MAX - 1;
 
 /// Per `IdxKey`, atomic bit-range masks. Two bits are in the same range
 /// iff they appear in the same set of per-decl masks.
 #[derive(Default)]
 struct BitPartition {
     ranges: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
+    /// Symbolic full-element interiors of large exact spans. Their graph-node
+    /// count depends on observed spans, not on unpacked array length.
+    dense_regions: Vec<Region<VarId>>,
     /// Stable identities for unresolved regions. They are graph nodes, not
     /// array elements, so their count depends on accesses rather than width.
     wildcards: Vec<Region<VarId>>,
@@ -479,25 +483,27 @@ fn atomic_ranges(masks: &[BigUint], width: usize) -> Vec<BigUint> {
 }
 
 fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) -> BitPartition {
-    let mut masks: HashMap<(VarId, usize), Vec<BigUint>> = HashMap::default();
+    let mut masks: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>> = HashMap::default();
 
     // A shifted copy can propagate every observed endpoint through the copy
     // relation. Feed those sparse spans into the shared partition so distinct
     // causal atoms do not collapse into a spurious self-edge.
-    for &region in memory_ssa_regions {
-        collect_region_mask(region, module, &mut masks);
-    }
+    let dense_regions = collect_region_masks(memory_ssa_regions, module, &mut masks);
 
     let mut ranges: HashMap<VarId, BTreeMap<usize, Vec<BigUint>>> = HashMap::default();
-    for (key, ms) in masks {
+    for (object, elements) in masks {
         let width = module
             .variables
-            .get(&key.0)
-            .and_then(|v| v.total_width())
+            .get(&object)
+            .and_then(|variable| variable.total_width())
             .unwrap_or(1);
-        let parts = atomic_ranges(&ms, width);
-        if !parts.is_empty() {
-            ranges.entry(key.0).or_default().insert(key.1, parts);
+        for (element, mut element_masks) in elements {
+            element_masks.sort_unstable();
+            element_masks.dedup();
+            let parts = atomic_ranges(&element_masks, width);
+            if !parts.is_empty() {
+                ranges.entry(object).or_default().insert(element, parts);
+            }
         }
     }
 
@@ -514,39 +520,123 @@ fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) ->
         .into_iter()
         .collect();
 
-    BitPartition { ranges, wildcards }
+    BitPartition {
+        ranges,
+        dense_regions,
+        wildcards,
+    }
 }
 
-fn collect_region_mask(
-    region: Region<VarId>,
+fn collect_region_masks(
+    regions: &[Region<VarId>],
     module: &Module,
-    masks: &mut HashMap<(VarId, usize), Vec<BigUint>>,
-) {
-    let Region::Exact { object, span } = region else {
-        return;
-    };
-    let Some(width) = module
-        .variables
-        .get(&object)
-        .and_then(Variable::total_width)
-    else {
-        return;
-    };
-    let Some(end) = span.end() else {
-        return;
-    };
-    let mut cursor = span.start;
-    while cursor < end {
-        let element = cursor / width;
-        let bit_start = cursor % width;
-        let element_end = end.min((element + 1).saturating_mul(width));
-        let bit_end = element_end - element * width;
-        masks
-            .entry((object, element))
-            .or_default()
-            .push(ValueBigUint::gen_mask_range(bit_end - 1, bit_start));
-        cursor = element_end;
+    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
+) -> Vec<Region<VarId>> {
+    // Full-element interiors are homogeneous. Materialize only their boundary
+    // representatives and any sparse element already observed by another
+    // region. This keeps whole-array work independent of the declared number
+    // of unpacked elements while preserving every relevant intersection.
+    let mut full_interiors: HashMap<VarId, Vec<(usize, usize)>> = HashMap::default();
+    for &region in regions {
+        let Region::Exact { object, span } = region else {
+            continue;
+        };
+        let Some(width) = module
+            .variables
+            .get(&object)
+            .and_then(Variable::total_width)
+        else {
+            continue;
+        };
+        let Some(end) = span.end() else {
+            continue;
+        };
+        if width == 0 || span.start >= end {
+            continue;
+        }
+
+        let first = span.start / width;
+        let last = (end - 1) / width;
+        let first_end = end.min((first + 1).saturating_mul(width));
+        push_element_mask(
+            masks,
+            object,
+            first,
+            ValueBigUint::gen_mask_range(first_end - first * width - 1, span.start % width),
+        );
+        if last != first {
+            push_element_mask(
+                masks,
+                object,
+                last,
+                ValueBigUint::gen_mask_range(end - last * width - 1, 0),
+            );
+        }
+
+        let interior_start = first.saturating_add(1);
+        if interior_start < last {
+            full_interiors
+                .entry(object)
+                .or_default()
+                .push((interior_start, last));
+        }
     }
+
+    let mut dense_regions = Vec::new();
+    for (object, mut intervals) in full_interiors {
+        intervals.sort_unstable();
+        intervals.dedup();
+
+        let Some(width) = module
+            .variables
+            .get(&object)
+            .and_then(Variable::total_width)
+        else {
+            continue;
+        };
+        let full_mask = ValueBigUint::gen_mask_range(width - 1, 0);
+        let elements = masks.entry(object).or_default();
+        for (start, end) in intervals {
+            dense_regions.push(Region::Exact {
+                object,
+                span: Span {
+                    start: start.saturating_mul(width),
+                    length: end.saturating_sub(start).saturating_mul(width),
+                },
+            });
+            // One representative retains dependencies which touch only the
+            // whole interval. Other exact accesses have already inserted
+            // their own element keys and are filled by the range query.
+            elements.entry(start).or_default();
+            let materialized = elements
+                .range(start..end)
+                .map(|(&element, _)| element)
+                .collect::<Vec<_>>();
+            for element in materialized {
+                elements
+                    .get_mut(&element)
+                    .expect("materialized element")
+                    .push(full_mask.clone());
+            }
+        }
+    }
+    dense_regions.sort_unstable();
+    dense_regions.dedup();
+    dense_regions
+}
+
+fn push_element_mask(
+    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<BigUint>>>,
+    object: VarId,
+    element: usize,
+    mask: BigUint,
+) {
+    masks
+        .entry(object)
+        .or_default()
+        .entry(element)
+        .or_default()
+        .push(mask);
 }
 
 fn build_module_graph(
@@ -908,7 +998,7 @@ fn aligned_region_node_pairs(
 ) -> Vec<(NodeKey, NodeKey)> {
     let (
         Region::Exact {
-            object: input_object,
+            object: _,
             span: input_span,
         },
         Region::Exact {
@@ -932,27 +1022,16 @@ fn aligned_region_node_pairs(
     if input_span.length != output_span.length {
         return Vec::new();
     }
-    let Some(input_width) = variables.get(&input_object).and_then(Variable::total_width) else {
-        return Vec::new();
-    };
     let mut pairs = BTreeSet::new();
     for source in region_node_keys(input, variables, bit_part) {
-        let Some(mask) = bit_part.ranges_of((source.0, source.1)).get(source.2) else {
-            continue;
-        };
-        for local in mask_spans(mask, input_width) {
-            let Some(global_start) = source
-                .1
-                .checked_mul(input_width)
-                .and_then(|base| base.checked_add(local.start))
+        for source_region in node_key_regions_for_variables(source, variables, bit_part) {
+            let Region::Exact {
+                span: source_span, ..
+            } = source_region
             else {
                 continue;
             };
-            let Some(overlap) = (Span {
-                start: global_start,
-                length: local.length,
-            })
-            .intersection(input_span) else {
+            let Some(overlap) = source_span.intersection(input_span) else {
                 continue;
             };
             let Some(offset) = overlap.start.checked_sub(input_span.start) else {
@@ -1079,6 +1158,28 @@ fn sparse_exact_node_keys(
     keys
 }
 
+fn dense_region_node_keys(object: VarId, span: Span, bit_part: &BitPartition) -> Vec<NodeKey> {
+    bit_part
+        .dense_regions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, region)| match region {
+            Region::Exact {
+                object: candidate,
+                span: candidate_span,
+            } if *candidate == object
+                && span.intersection(*candidate_span) == Some(*candidate_span) =>
+            {
+                Some((object, DENSE_REGION_INDEX, index))
+            }
+            Region::Exact { .. }
+            | Region::UnknownRegion { .. }
+            | Region::UnknownObject(_)
+            | Region::UnknownAll => None,
+        })
+        .collect()
+}
+
 /// Convert the MemorySSA engine's flattened, half-open bit region back to the
 /// graph `(array element, bit partition)` coordinates. The loop is
 /// proportional to touched elements, never to the declared array size.
@@ -1089,7 +1190,9 @@ fn region_node_keys(
 ) -> Vec<NodeKey> {
     let mut keys = match region {
         Region::Exact { object, span } => {
-            return sparse_exact_node_keys(object, span, variables, bit_part);
+            let mut keys = sparse_exact_node_keys(object, span, variables, bit_part);
+            keys.extend(dense_region_node_keys(object, span, bit_part));
+            keys
         }
         Region::UnknownRegion { object, span } => {
             sparse_exact_node_keys(object, span, variables, bit_part)
@@ -2256,10 +2359,26 @@ fn compute_module_summary(
 }
 
 fn node_key_regions(key: NodeKey, module: &Module, bit_part: &BitPartition) -> Vec<Region<VarId>> {
+    node_key_regions_for_variables(key, &module.variables, bit_part)
+}
+
+fn node_key_regions_for_variables(
+    key: NodeKey,
+    variables: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<Region<VarId>> {
     if key.1 == UNKNOWN_REGION_INDEX {
         return bit_part.wildcards.get(key.2).copied().into_iter().collect();
     }
-    let Some(width) = module.variables.get(&key.0).and_then(Variable::total_width) else {
+    if key.1 == DENSE_REGION_INDEX {
+        return bit_part
+            .dense_regions
+            .get(key.2)
+            .copied()
+            .into_iter()
+            .collect();
+    }
+    let Some(width) = variables.get(&key.0).and_then(Variable::total_width) else {
         return Vec::new();
     };
     let Some(mask) = bit_part.ranges_of((key.0, key.1)).get(key.2) else {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -462,6 +462,14 @@ fn build_module_graph(
                 {
                     incomplete.insert(IncompleteReason::InoutPort);
                 }
+                add_inst_output_address_edges(
+                    inst,
+                    &bit_part,
+                    &mut graph,
+                    &mut node_map,
+                    &module.variables,
+                    &mut ctx,
+                );
                 let Some(summary) = summaries.get(&child.name) else {
                     continue;
                 };
@@ -807,6 +815,18 @@ fn collect_instance_summary_regions(
         let Component::Module(child) = inst.component.as_ref() else {
             continue;
         };
+        for output in &inst.outputs {
+            regions.extend(collect_destination_regions(
+                &output.dst,
+                &module.variables,
+                ctx,
+            ));
+            regions.extend(collect_destination_address_regions(
+                &output.dst,
+                &module.variables,
+                ctx,
+            ));
+        }
         let Some(summary) = summaries.get(&child.name) else {
             continue;
         };
@@ -840,6 +860,41 @@ fn collect_instance_summary_regions(
         }
     }
     regions
+}
+
+fn add_inst_output_address_edges(
+    inst: &InstDeclaration,
+    bit_part: &BitPartition,
+    graph: &mut Graph<NodeKey, ()>,
+    node_map: &mut HashMap<NodeKey, NodeIndex>,
+    parent_vars: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) {
+    for output in &inst.outputs {
+        for destination in &output.dst {
+            let destination_region = variable_access_region(
+                destination.id,
+                &destination.index,
+                &destination.select,
+                parent_vars,
+                ctx,
+            );
+            let address_regions = collect_destination_address_regions(
+                std::slice::from_ref(destination),
+                parent_vars,
+                ctx,
+            );
+            for address_region in address_regions {
+                for source in region_node_keys(address_region, parent_vars, bit_part) {
+                    for destination in region_node_keys(destination_region, parent_vars, bit_part) {
+                        let source = ensure_node(graph, node_map, source);
+                        let destination = ensure_node(graph, node_map, destination);
+                        graph.add_edge(source, destination, ());
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1294,6 +1349,30 @@ fn collect_destination_regions(
             )
         })
         .collect::<Vec<_>>();
+    regions.sort_unstable();
+    regions.dedup();
+    regions
+}
+
+fn collect_destination_address_regions(
+    destinations: &[AssignDestination],
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Vec<Region<VarId>> {
+    let mut regions = Vec::new();
+    for destination in destinations {
+        for expression in destination
+            .index
+            .0
+            .iter()
+            .chain(destination.select.0.iter())
+        {
+            regions.extend(collect_expression_regions(expression, variables, ctx));
+        }
+        if let Some((_, expression)) = &destination.select.1 {
+            regions.extend(collect_expression_regions(expression, variables, ctx));
+        }
+    }
     regions.sort_unstable();
     regions.dedup();
     regions

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -362,6 +362,7 @@ fn build_module_graph(
             })
         })
         .collect::<Vec<_>>();
+    partition_regions = propagate_aligned_regions(partition_regions, &procedure_summaries);
     let mut ctx = Context::default();
     ctx.variables = module.variables.clone();
     ctx.functions = module.functions.clone();
@@ -457,6 +458,69 @@ fn build_module_graph(
     (graph, incomplete, bit_part)
 }
 
+fn propagate_aligned_regions(
+    regions: Vec<Region<VarId>>,
+    summaries: &[Result<ProcedureSummary<VarId>, veryl_causal::procedure::ProcedureError>],
+) -> Vec<Region<VarId>> {
+    let transfers = summaries
+        .iter()
+        .filter_map(|summary| summary.as_ref().ok())
+        .flat_map(|summary| &summary.dependencies)
+        .filter_map(|dependency| match (dependency.input, dependency.output) {
+            (
+                Region::Exact {
+                    object: input_object,
+                    span: input_span,
+                },
+                Region::Exact {
+                    object: output_object,
+                    span: output_span,
+                },
+            ) if dependency.aligned && input_span.length == output_span.length => {
+                Some(((input_object, input_span), (output_object, output_span)))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut known = regions.into_iter().collect::<BTreeSet<_>>();
+    let mut pending = known
+        .iter()
+        .copied()
+        .collect::<std::collections::VecDeque<_>>();
+    while let Some(region) = pending.pop_front() {
+        let Region::Exact { object, span } = region else {
+            continue;
+        };
+        for &(left, right) in &transfers {
+            for (from, to) in [(left, right), (right, left)] {
+                if object != from.0 {
+                    continue;
+                }
+                let Some(overlap) = span.intersection(from.1) else {
+                    continue;
+                };
+                let Some(offset) = overlap.start.checked_sub(from.1.start) else {
+                    continue;
+                };
+                let Some(start) = to.1.start.checked_add(offset) else {
+                    continue;
+                };
+                let mapped = Region::Exact {
+                    object: to.0,
+                    span: Span {
+                        start,
+                        length: overlap.length,
+                    },
+                };
+                if known.insert(mapped) {
+                    pending.push_back(mapped);
+                }
+            }
+        }
+    }
+    known.into_iter().collect()
+}
+
 fn add_memory_ssa_edges(
     module: &Module,
     summary: &ProcedureSummary<VarId>,
@@ -472,26 +536,112 @@ fn add_memory_ssa_edges(
         if dependency.kind == EdgeKind::Unknown {
             continue;
         }
-        let sources = region_node_keys(dependency.input, &module.variables, bit_part);
-        let destinations = region_node_keys(
-            sparse_output_region(summary, dependency.output),
-            &module.variables,
-            bit_part,
-        );
-        for source in &sources {
+        let output = sparse_output_region(summary, dependency.output);
+        let pairs = if dependency.aligned {
+            aligned_region_node_pairs(dependency.input, output, &module.variables, bit_part)
+        } else {
+            let sources = region_node_keys(dependency.input, &module.variables, bit_part);
+            let destinations = region_node_keys(output, &module.variables, bit_part);
+            sources
+                .into_iter()
+                .flat_map(|source| {
+                    destinations
+                        .iter()
+                        .copied()
+                        .map(move |destination| (source, destination))
+                })
+                .collect()
+        };
+        for (source, destination) in pairs {
             if !is_module_scope_var(source.0, &module.variables) {
                 continue;
             }
-            for destination in &destinations {
-                if !is_module_scope_var(destination.0, &module.variables) {
-                    continue;
-                }
-                let source = ensure_node(graph, node_map, *source);
-                let destination = ensure_node(graph, node_map, *destination);
-                graph.add_edge(source, destination, ());
+            if !is_module_scope_var(destination.0, &module.variables) {
+                continue;
             }
+            let source = ensure_node(graph, node_map, source);
+            let destination = ensure_node(graph, node_map, destination);
+            graph.add_edge(source, destination, ());
         }
     }
+}
+
+fn aligned_region_node_pairs(
+    input: Region<VarId>,
+    output: Region<VarId>,
+    variables: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<(NodeKey, NodeKey)> {
+    let (
+        Region::Exact {
+            object: input_object,
+            span: input_span,
+        },
+        Region::Exact {
+            object: output_object,
+            span: output_span,
+        },
+    ) = (input, output)
+    else {
+        let sources = region_node_keys(input, variables, bit_part);
+        let destinations = region_node_keys(output, variables, bit_part);
+        return sources
+            .into_iter()
+            .flat_map(|source| {
+                destinations
+                    .iter()
+                    .copied()
+                    .map(move |destination| (source, destination))
+            })
+            .collect();
+    };
+    if input_span.length != output_span.length {
+        return Vec::new();
+    }
+    let Some(input_width) = variables.get(&input_object).and_then(Variable::total_width) else {
+        return Vec::new();
+    };
+    let mut pairs = BTreeSet::new();
+    for source in region_node_keys(input, variables, bit_part) {
+        let Some(mask) = bit_part.ranges_of((source.0, source.1)).get(source.2) else {
+            continue;
+        };
+        for local in mask_spans(mask, input_width) {
+            let Some(global_start) = source
+                .1
+                .checked_mul(input_width)
+                .and_then(|base| base.checked_add(local.start))
+            else {
+                continue;
+            };
+            let Some(overlap) = (Span {
+                start: global_start,
+                length: local.length,
+            })
+            .intersection(input_span) else {
+                continue;
+            };
+            let Some(offset) = overlap.start.checked_sub(input_span.start) else {
+                continue;
+            };
+            let Some(mapped_start) = output_span.start.checked_add(offset) else {
+                continue;
+            };
+            let mapped = Region::Exact {
+                object: output_object,
+                span: Span {
+                    start: mapped_start,
+                    length: overlap.length,
+                },
+            };
+            pairs.extend(
+                region_node_keys(mapped, variables, bit_part)
+                    .into_iter()
+                    .map(|destination| (source, destination)),
+            );
+        }
+    }
+    pairs.into_iter().collect()
 }
 
 /// Memory SSA expands an unknown-object write over its sparse atom endpoints

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1,12 +1,130 @@
-//! Combinational loop detection on the analyzer IR (issue #931).
+//! Region-sensitive combinational loop detection on the analyzer IR (issue
+//! #931).
 //!
-//! Builds a sparse per-module region dependency graph from independently
-//! analyzable Memory SSA procedure summaries, then reports SCCs. Module
-//! instance feedthrough is summarized bottom-up in topo order.
+//! # Problem model
 //!
-//! Under-detect by design: opaque constructs (SystemVerilog black
-//! boxes, `inout` ports, recursive functions) add no edges; the
-//! simulator's `analyze_dependency` is the backup safety net.
+//! This analysis decides whether the elaborated design contains a cycle of
+//! **structural combinational dependencies**. It does not compute Boolean
+//! functions, prove algebraic cancellation, or reproduce the implicit
+//! sensitivity list of `always_comb`.
+//!
+//! A graph node is an `(object, sparse region)` pair rather than a whole
+//! variable or one node per bit. A directed edge `A -> B` means that a proven
+//! value, control, or address dependency can make a write to region `B`
+//! structurally depend on region `A`. A self-edge or a multi-node strongly
+//! connected component is therefore a combinational loop. Position-preserving
+//! operations retain an `aligned` edge so that, for example, `dst[0] = src[0]`
+//! does not imply a dependency between every bit of `dst` and every bit of
+//! `src`. Operations without a positional transfer conservatively connect the
+//! observed source and destination atoms all-to-all.
+//!
+//! Previous-value retention is deliberately not represented as a dependency
+//! edge. A conditional or partial write can leave a MemorySSA entry definition
+//! reaching the procedure exit, but that is incomplete assignment/inferred
+//! state, not by itself combinational feedback. The same MemorySSA result is
+//! used to produce coverage diagnostics through `check_analyzer`, while
+//! explicit reads of the old value remain ordinary dependencies and can form
+//! real loops.
+//!
+//! # Analysis pipeline
+//!
+//! 1. `comb_memory_ssa` lowers each combinational procedure to a CFG
+//!    with statement-ordered region reads and writes. Sparse MemorySSA resolves
+//!    overwrites, branch phis, loop-carried definitions, weak dynamic writes,
+//!    function arguments, output arguments, and module-scope captures. Each
+//!    procedure and instance-observer expression is an independent work item;
+//!    native builds analyze those work items in parallel after function
+//!    summaries have been frozen.
+//! 2. Procedure summaries are merged into one module graph. Region endpoints
+//!    observed by accesses partition objects into atomic spans. Large dense
+//!    spans and regular repeated copies have symbolic nodes, so graph size is
+//!    normally a function of accesses and boundaries rather than declared bit
+//!    width or unpacked-array length.
+//! 3. Child modules are analyzed before parents. A module summary contains only
+//!    input-to-output feedthrough proven in the child graph. Instance actuals
+//!    project the child's regions back into the parent, preserving bit
+//!    positions, aggregate layout, and Cartesian repetition axes when that
+//!    mapping is representable.
+//! 4. Iterative SCC discovery finds cyclic components without using the process
+//!    stack. For each SCC, diagnostics choose a stable source-backed edge and
+//!    the shortest directed return path to that edge. This yields one
+//!    deterministic simple cycle with assignment provenance, rather than every
+//!    member of a maximal SCC.
+//!
+//! # Cases modeled precisely
+//!
+//! The precise path includes:
+//!
+//! - sequential blocking-assignment order, dominating full writes, branch
+//!   joins, early `break`, empty/nonempty finite loops, and constant iterator
+//!   values for finite loops accepted by the evaluation limit;
+//! - constant `if`, `case`, ternary, and short-circuit pruning, while dynamic
+//!   conditions remain control dependencies;
+//! - exact packed and unpacked selections, disjoint struct fields and array
+//!   elements, concatenations, struct constructors, array literals, repeated
+//!   values, and fragmented instance output destinations;
+//! - position-preserving variables, supported casts and width extension,
+//!   pointwise bitwise operators, constant shifts, and function return/output
+//!   mappings; and
+//! - ordinary Veryl module instances, concrete generic specializations,
+//!   nested function calls, module-scope function captures, and side effects in
+//!   instance actual/address expressions.
+//!
+//! Dynamic selects are modeled structurally, not by value-range inference.
+//! The region is derived from the LRM static prefix and the declared object
+//! shape. Expressions such as `idx`, `~idx`, and `idx * 2` do not receive
+//! special candidate sets. Syntactically corresponding unresolved accesses can
+//! be promoted to must-alias only when MemorySSA proves that their selector
+//! reads observe the same SSA versions; otherwise they remain uncertain.
+//!
+//! # Conservative fallbacks and incomplete results
+//!
+//! A known expression whose exact bit transfer is unavailable falls back to
+//! structural dependencies on its known operands. This can lose bit-level
+//! precision, but it does not invent a value-domain proof. In contrast, an
+//! effect or boundary whose dependencies cannot be established is marked with
+//! [`IncompleteReason`]. Unknown edges never participate in a hard loop
+//! diagnostic, and their presence does not erase unrelated proven edges from
+//! the same procedure or module.
+//!
+//! [`check`] returns only proven loop errors for compatibility.
+//! [`check_detailed`] additionally exposes per-module incomplete reasons. The
+//! important incomplete boundaries are:
+//!
+//! - SystemVerilog/external components and `inout` ports;
+//! - hierarchical references and instance actual/destination mappings which
+//!   cannot preserve a region;
+//! - recursive functions or module-instantiation cycles;
+//! - runtime-bound loops and constant loops deliberately left above the
+//!   evaluation-size limit;
+//! - timed/event effects, unsupported or malformed analyzer IR, and generic
+//!   modules whose concrete shape was not elaborated.
+//!
+//! These cases may still contain a real loop that this pass cannot prove. No
+//! guessed feedthrough is added across an opaque boundary. Callers that require
+//! a completeness guarantee must inspect `CombAnalysisResult::incomplete`
+//! rather than interpreting an empty `errors` list as proof that the design is
+//! acyclic.
+//!
+//! # Complexity and limits
+//!
+//! Sparse exact spans, dense-region nodes, and `PeriodicRegion` keep the
+//! common cost independent of numerical declaration width and repetition
+//! count. The representation is not a general symbolic algebra, however:
+//!
+//! - a finite loop is expanded only while its exact iteration list is within
+//!   the configured evaluation limit; larger loops are incomplete even when a
+//!   human can see that an early `break` bounds their execution;
+//! - irregular or unaligned transfers can require an all-to-all product of
+//!   source and destination atoms, and adversarially overlapping access
+//!   boundaries or input/output feedthrough pairs can still make graph and
+//!   summary construction quadratic;
+//! - parallelism is across procedures, observer expressions, and partitions of
+//!   large module-summary walks. One enormous procedure and the bottom-up
+//!   module topology still contain serial work; and
+//! - the reported witness is shortest only for the selected stable anchor. It
+//!   is deterministic and actionable, but is not guaranteed to be the globally
+//!   shortest cycle in the SCC.
 
 use crate::AnalyzerError;
 use crate::HashMap;

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -45,10 +45,13 @@
 //!    spans and regular repeated copies have symbolic nodes, so graph size is
 //!    normally a function of accesses and boundaries rather than declared bit
 //!    width or unpacked-array length.
-//! 3. Child modules are analyzed before parents. A module summary contains only
-//!    input-to-output feedthrough proven in the child graph. Instance actuals
-//!    project the child's regions back into the parent, preserving bit
-//!    positions, aggregate layout, and Cartesian repetition axes when that
+//! 3. Traversal starts at source modules which are not instantiated by another
+//!    source template. Concrete child modules are analyzed before their parent;
+//!    the same child graph emits definition-local diagnostics and produces its
+//!    input-to-output summary, so the standalone template is not rebuilt.
+//!    Uninstantiated modules are roots and remain independently checked.
+//!    Instance actuals project child regions back into the parent, preserving
+//!    bit positions, aggregate layout, and Cartesian repetition axes when that
 //!    mapping is representable.
 //! 4. Iterative SCC discovery finds cyclic components without using the process
 //!    stack. For each SCC, diagnostics choose a stable source-backed edge and
@@ -456,6 +459,7 @@ enum ComponentSummaryKey {
 struct CombSummaryCache {
     modules: HashMap<ComponentSummaryKey, ModuleCombSummary>,
     procedures: crate::comb_memory_ssa::ProcedureSummaryCache,
+    analyzed_templates: HashSet<StrId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -527,12 +531,21 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
     let order = module_analysis_order(ir);
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
+            // A concrete instance analysis already checked this source
+            // template and produced the summary its parent consumes. Generic
+            // specializations are still all visited by
+            // `ensure_instance_summaries`; this skips only the redundant
+            // standalone template pass.
+            if summaries.analyzed_templates.contains(&module.name) {
+                continue;
+            }
             // Unevaluable generic params do not have a concrete module shape.
             if module.suppress_unassigned {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
                     reasons: [IncompleteReason::UnevaluatedGeneric].into(),
                 });
+                summaries.analyzed_templates.insert(module.name);
                 continue;
             }
             ensure_instance_summaries(
@@ -552,6 +565,7 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
             );
             extend_unique_errors(&mut coverage, module_coverage);
             check_graph(module, &graph, &mut loops);
+            summaries.analyzed_templates.insert(module.name);
             if !reasons.is_empty() {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
@@ -648,6 +662,7 @@ fn ensure_instance_summaries(
         );
         extend_unique_errors(coverage, child_coverage);
         check_graph(child, &graph, loops);
+        summaries.analyzed_templates.insert(child.name);
         let summary = compute_module_summary(child, &graph, &bit_part);
         summaries.modules.insert(key.clone(), summary);
         if !reasons.is_empty() {
@@ -695,7 +710,24 @@ fn module_analysis_order(ir: &Ir) -> Vec<usize> {
         .iter()
         .map(|component| matches!(component, Component::Module(_)))
         .collect::<Vec<_>>();
-    order_from_dependencies(&is_module, &deps, &rev_deps)
+    let order = order_from_dependencies(&is_module, &deps, &rev_deps);
+    prioritize_module_roots(order, &rev_deps)
+}
+
+fn prioritize_module_roots(
+    order: Vec<usize>,
+    reverse_dependencies: &[HashSet<usize>],
+) -> Vec<usize> {
+    // Start from modules which are not instantiated by another source
+    // template. Their recursive summary walk checks concrete children before
+    // those children's redundant standalone entries are encountered. Keep
+    // the previous deterministic order within both groups; a name-cycle has
+    // no root and remains in the fallback group.
+    let (mut roots, remaining): (Vec<_>, Vec<_>) = order
+        .into_iter()
+        .partition(|index| reverse_dependencies[*index].is_empty());
+    roots.extend(remaining);
+    roots
 }
 
 fn order_from_dependencies(
@@ -3501,6 +3533,12 @@ mod memory_ssa_tests {
 
         let order = order_from_dependencies(&is_module, &deps, &rev_deps);
         assert_eq!(order, vec![1, 3, 0, 2]);
+
+        // Why this case exists: concrete instance summaries are discovered
+        // only while visiting a parent. Roots must therefore run before the
+        // child-first fallback order, while a source-name cycle remains in a
+        // deterministic fallback position instead of disappearing.
+        assert_eq!(prioritize_module_roots(order, &rev_deps), vec![3, 2, 1, 0]);
     }
 
     #[test]

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1466,6 +1466,7 @@ fn map_destinations_span_positioned(
                 },
                 expression: overlap,
                 aligned: true,
+                kind: EdgeKind::Value,
             });
         }
         low = low.checked_add(span.length)?;

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1025,7 +1025,7 @@ fn add_inst_feedthrough_edges(
             && let Some(parent_outputs) =
                 map_destinations_span_positioned(&output.dst, child_output_span, parent_vars, ctx)
         {
-            for (source, destination) in aligned_instance_region_pairs(
+            for (source, destination, aligned) in aligned_instance_region_pairs(
                 &parent_inputs,
                 &parent_outputs,
                 child_input_span,
@@ -1035,7 +1035,7 @@ fn add_inst_feedthrough_edges(
             ) {
                 let source = ensure_node(graph, node_map, source);
                 let destination = ensure_node(graph, node_map, destination);
-                graph.add_edge(source, destination, true);
+                graph.add_edge(source, destination, aligned);
             }
             continue;
         }
@@ -1079,7 +1079,7 @@ fn aligned_instance_region_pairs(
     child_output: Span,
     parent_vars: &HashMap<VarId, Variable>,
     bit_part: &BitPartition,
-) -> Vec<(NodeKey, NodeKey)> {
+) -> Vec<(NodeKey, NodeKey, bool)> {
     let mut pairs = BTreeSet::new();
     for input in inputs {
         let Some(input_start) = input.expression.start.checked_sub(child_input.start) else {
@@ -1114,18 +1114,8 @@ fn aligned_instance_region_pairs(
             else {
                 continue;
             };
-            let Some(input_offset) = overlap.start.checked_sub(input_relative.start) else {
-                continue;
-            };
             let Some(output_offset) = overlap.start.checked_sub(output_relative.start) else {
                 continue;
-            };
-            let input_region = Region::Exact {
-                object: input_object,
-                span: Span {
-                    start: input_region.start + input_offset,
-                    length: overlap.length,
-                },
             };
             let output_region = Region::Exact {
                 object: output_object,
@@ -1134,12 +1124,29 @@ fn aligned_instance_region_pairs(
                     length: overlap.length,
                 },
             };
-            pairs.extend(aligned_region_node_pairs(
-                input_region,
-                output_region,
-                parent_vars,
-                bit_part,
-            ));
+            if input.aligned {
+                let Some(input_offset) = overlap.start.checked_sub(input_relative.start) else {
+                    continue;
+                };
+                let input_region = Region::Exact {
+                    object: input_object,
+                    span: Span {
+                        start: input_region.start + input_offset,
+                        length: overlap.length,
+                    },
+                };
+                pairs.extend(
+                    aligned_region_node_pairs(input_region, output_region, parent_vars, bit_part)
+                        .into_iter()
+                        .map(|(source, destination)| (source, destination, true)),
+                );
+            } else {
+                for source in region_node_keys(input.region, parent_vars, bit_part) {
+                    for destination in region_node_keys(output_region, parent_vars, bit_part) {
+                        pairs.insert((source, destination, false));
+                    }
+                }
+            }
         }
     }
     pairs.into_iter().collect()
@@ -1458,6 +1465,7 @@ fn map_destinations_span_positioned(
                     },
                 },
                 expression: overlap,
+                aligned: true,
             });
         }
         low = low.checked_add(span.length)?;
@@ -1647,6 +1655,15 @@ fn exact_variable_region(
     }
     let variable = variables.get(&id)?;
     let width = variable.total_width()?;
+    if index.0.is_empty() && select.0.is_empty() && select.1.is_none() {
+        return Some(Region::Exact {
+            object: id,
+            span: Span {
+                start: 0,
+                length: variable.r#type.total_array()?.checked_mul(width)?,
+            },
+        });
+    }
     let index_path = index.eval_value(ctx)?;
     let array_index = variable.r#type.array.calc_index(&index_path)?;
     let (high, low) = select.eval_value(ctx, &variable.r#type, false)?;

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -667,68 +667,70 @@ fn propagate_periodic_partition_regions(
 }
 
 fn periodic_overlaps_span(periodic: &PeriodicRegion, query: Span) -> bool {
-    let Some(query_end) = query.end() else {
-        return false;
-    };
-    let mut inner_extents = Vec::with_capacity(periodic.axes.len() + 1);
-    inner_extents.push(periodic.output.length);
-    for axis in &periodic.axes {
-        let inner_extent = inner_extents[inner_extents.len() - 1];
-        if axis.repetitions == 0 || axis.destination_stride < inner_extent {
-            return false;
-        }
-        let Some(extent) = axis
-            .destination_stride
-            .checked_mul(axis.repetitions.saturating_sub(1))
-            .and_then(|offset| inner_extent.checked_add(offset))
-        else {
-            return false;
+    fn overlaps(output: Span, axes: &[PeriodicAxis], query: Span) -> Option<bool> {
+        let query_end = query.end()?;
+        let Some((outer, inner_axes)) = axes.split_last() else {
+            return Some(output.intersection(query).is_some());
         };
-        inner_extents.push(extent);
-    }
-    let mut stack = vec![(periodic.output.start, periodic.axes.len())];
-    while let Some((base_start, depth)) = stack.pop() {
-        if depth == 0 {
-            if (Span {
-                start: base_start,
-                length: periodic.output.length,
-            })
-            .intersection(query)
-            .is_some()
-            {
-                return true;
+        let inner_extent = inner_axes.iter().try_fold(output.length, |extent, axis| {
+            if axis.repetitions == 0 || axis.destination_stride < extent {
+                return None;
             }
-            continue;
+            axis.destination_stride
+                .checked_mul(axis.repetitions - 1)
+                .and_then(|offset| extent.checked_add(offset))
+        })?;
+        if outer.repetitions == 0 || outer.destination_stride < inner_extent {
+            return None;
         }
-        let axis = periodic.axes[depth - 1];
-        let Some(inner_end) = base_start.checked_add(inner_extents[depth - 1]) else {
-            continue;
-        };
+        let inner_end = output.start.checked_add(inner_extent)?;
         let first = if query.start < inner_end {
             0
         } else {
-            (query.start - inner_end) / axis.destination_stride + 1
-        };
-        let end = if query_end <= base_start {
+            query
+                .start
+                .checked_sub(inner_end)?
+                .checked_div(outer.destination_stride)?
+                .checked_add(1)?
+        }
+        .min(outer.repetitions);
+        let end = if query_end <= output.start {
             0
         } else {
             query_end
-                .saturating_sub(base_start)
-                .saturating_add(axis.destination_stride - 1)
-                / axis.destination_stride
+                .checked_sub(output.start)?
+                .checked_add(outer.destination_stride - 1)?
+                .checked_div(outer.destination_stride)?
         }
-        .min(axis.repetitions);
-        for copy in first..end {
-            let Some(start) = copy
-                .checked_mul(axis.destination_stride)
-                .and_then(|offset| base_start.checked_add(offset))
-            else {
-                continue;
-            };
-            stack.push((start, depth - 1));
+        .min(outer.repetitions);
+        if first >= end {
+            return Some(false);
         }
+        let shifted = |copy: usize| {
+            copy.checked_mul(outer.destination_stride)
+                .and_then(|offset| output.start.checked_add(offset))
+                .map(|start| Span {
+                    start,
+                    length: output.length,
+                })
+        };
+        if overlaps(shifted(first)?, inner_axes, query)? {
+            return Some(true);
+        }
+        if end - first > 2 {
+            // A group strictly between the boundary candidates is wholly
+            // contained by the query, and every valid group has a nonempty
+            // innermost copy.
+            return Some(true);
+        }
+        end.checked_sub(1)
+            .filter(|&last| last != first)
+            .and_then(shifted)
+            .and_then(|last| overlaps(last, inner_axes, query))
+            .or(Some(false))
     }
-    false
+
+    overlaps(periodic.output, &periodic.axes, query).unwrap_or(false)
 }
 
 fn collect_region_masks(
@@ -2203,7 +2205,7 @@ fn map_child_periodic_output(
     if mapped.len() != 1 {
         return None;
     }
-    let positioned = mapped[0];
+    let positioned = &mapped[0];
     let Region::Exact {
         object,
         span: destination,
@@ -2475,8 +2477,7 @@ fn map_destinations_span_positioned(
                 expression: overlap,
                 aligned: true,
                 kind: EdgeKind::Value,
-                repetitions: 1,
-                expression_stride: 0,
+                axes: Vec::new(),
             });
         }
         low = low.checked_add(span.length)?;

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -3021,9 +3021,10 @@ mod memory_ssa_tests {
                 },
             ],
         };
-        let concrete = periodic.axes.iter().fold(
-            vec![periodic.output],
-            |copies, axis| {
+        let concrete = periodic
+            .axes
+            .iter()
+            .fold(vec![periodic.output], |copies, axis| {
                 copies
                     .into_iter()
                     .flat_map(|copy| {
@@ -3033,8 +3034,7 @@ mod memory_ssa_tests {
                         })
                     })
                     .collect()
-            },
-        );
+            });
         for start in 0..14 {
             for length in 1..=4 {
                 let query = Span { start, length };

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -423,6 +423,20 @@ struct ModuleCombSummary {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct LoopDiagnosticKey {
+    identifier: String,
+    locations: Vec<TokenRange>,
+}
+
+type LoopDiagnostic = (LoopDiagnosticKey, AnalyzerError);
+
+#[derive(Default)]
+struct LoopDiagnostics {
+    errors: Vec<AnalyzerError>,
+    keys: BTreeSet<LoopDiagnosticKey>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct CoverageDiagnosticKey {
     identifier: String,
     locations: Vec<TokenRange>,
@@ -468,7 +482,7 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
 }
 
 fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<AnalyzerError>) {
-    let mut errors = Vec::new();
+    let mut loops = LoopDiagnostics::default();
     let mut coverage = CoverageDiagnostics::default();
     let mut incomplete = Vec::new();
     let mut summaries: HashMap<usize, ModuleCombSummary> = HashMap::default();
@@ -490,7 +504,7 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
                 module,
                 &mut summaries,
                 &mut visiting_specializations,
-                &mut errors,
+                &mut loops,
                 &mut coverage,
                 &mut incomplete,
                 collect_coverage,
@@ -498,7 +512,7 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
             let (graph, reasons, _bit_part, module_coverage) =
                 build_module_graph(module, &summaries, collect_coverage);
             extend_unique_errors(&mut coverage, module_coverage);
-            check_graph(module, &graph, &mut errors);
+            check_graph(module, &graph, &mut loops);
             if !reasons.is_empty() {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
@@ -508,7 +522,20 @@ fn analyze(ir: &Ir, collect_coverage: bool) -> (CombAnalysisResult, Vec<Analyzer
         }
     }
 
-    (CombAnalysisResult { errors, incomplete }, coverage.errors)
+    (
+        CombAnalysisResult {
+            errors: loops.errors,
+            incomplete,
+        },
+        coverage.errors,
+    )
+}
+
+fn extend_unique_loops(loops: &mut LoopDiagnostics, new_loop: LoopDiagnostic) {
+    let (key, error) = new_loop;
+    if loops.keys.insert(key) {
+        loops.errors.push(error);
+    }
 }
 
 fn extend_unique_errors(coverage: &mut CoverageDiagnostics, new_errors: Vec<CoverageDiagnostic>) {
@@ -530,7 +557,7 @@ fn ensure_instance_summaries(
     module: &Module,
     summaries: &mut HashMap<usize, ModuleCombSummary>,
     visiting: &mut HashSet<usize>,
-    errors: &mut Vec<AnalyzerError>,
+    loops: &mut LoopDiagnostics,
     coverage: &mut CoverageDiagnostics,
     incomplete: &mut Vec<IncompleteCombAnalysis>,
     collect_coverage: bool,
@@ -554,7 +581,7 @@ fn ensure_instance_summaries(
             child,
             summaries,
             visiting,
-            errors,
+            loops,
             coverage,
             incomplete,
             collect_coverage,
@@ -562,7 +589,7 @@ fn ensure_instance_summaries(
         let (graph, reasons, bit_part, child_coverage) =
             build_module_graph(child, summaries, collect_coverage);
         extend_unique_errors(coverage, child_coverage);
-        check_graph(child, &graph, errors);
+        check_graph(child, &graph, loops);
         let summary = compute_module_summary(child, &graph, &bit_part);
         summaries.insert(key, summary);
         if !reasons.is_empty() {
@@ -2884,7 +2911,7 @@ fn is_pure_input_or_output(id: VarId, vars: &HashMap<VarId, Variable>, want: Dir
     actual == want
 }
 
-fn check_graph(module: &Module, graph: &CausalGraph, errors: &mut Vec<AnalyzerError>) {
+fn check_graph(module: &Module, graph: &CausalGraph, loops: &mut LoopDiagnostics) {
     let sccs = strongly_connected_components(graph);
     let mut reported: HashSet<Vec<NodeKey>> = HashSet::default();
     for scc in sccs {
@@ -2896,8 +2923,8 @@ fn check_graph(module: &Module, graph: &CausalGraph, errors: &mut Vec<AnalyzerEr
         if !reported.insert(keys.clone()) {
             continue;
         }
-        if let Some(error) = build_error(module, graph, &witness) {
-            errors.push(error);
+        if let Some(new_loop) = build_error(module, graph, &witness) {
+            extend_unique_loops(loops, new_loop);
         }
     }
 }
@@ -3071,7 +3098,7 @@ fn build_error(
     module: &Module,
     graph: &CausalGraph,
     witness: &[EdgeIndex],
-) -> Option<AnalyzerError> {
+) -> Option<LoopDiagnostic> {
     let anchor = *witness.first()?;
     let (_, anchor_target) = graph.edge_endpoints(anchor)?;
     let identifier = module
@@ -3095,11 +3122,12 @@ fn build_error(
     }
     let primary = *tokens.first()?;
     let participants: Vec<_> = tokens.iter().skip(1).copied().collect();
-    Some(AnalyzerError::combinational_loop(
-        &identifier,
-        &primary,
-        &participants,
-    ))
+    let key = LoopDiagnosticKey {
+        identifier: identifier.clone(),
+        locations: tokens,
+    };
+    let error = AnalyzerError::combinational_loop(&identifier, &primary, &participants);
+    Some((key, error))
 }
 
 fn is_module_scope_var(id: VarId, variables: &HashMap<VarId, Variable>) -> bool {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -2997,4 +2997,97 @@ mod memory_ssa_tests {
             ]
         );
     }
+
+    #[test]
+    fn periodic_overlap_matches_exhaustive_multiaxis_oracle() {
+        // Why this case exists: periodic outputs stay symbolic in the bit
+        // partition. Their arithmetic overlap predicate must agree exactly
+        // with concrete expansion for both copied bits and holes, while a
+        // distant query must not iterate over every preceding copy.
+        let periodic = PeriodicRegion {
+            object: VarId::from_raw(0),
+            output: Span {
+                start: 0,
+                length: 1,
+            },
+            axes: vec![
+                PeriodicAxis {
+                    repetitions: 2,
+                    destination_stride: 2,
+                },
+                PeriodicAxis {
+                    repetitions: 2,
+                    destination_stride: 10,
+                },
+            ],
+        };
+        let concrete = periodic.axes.iter().fold(
+            vec![periodic.output],
+            |copies, axis| {
+                copies
+                    .into_iter()
+                    .flat_map(|copy| {
+                        (0..axis.repetitions).map(move |index| Span {
+                            start: copy.start + index * axis.destination_stride,
+                            length: copy.length,
+                        })
+                    })
+                    .collect()
+            },
+        );
+        for start in 0..14 {
+            for length in 1..=4 {
+                let query = Span { start, length };
+                let expected = concrete
+                    .iter()
+                    .any(|copy| copy.intersection(query).is_some());
+                assert_eq!(
+                    periodic_overlaps_span(&periodic, query),
+                    expected,
+                    "query={query:?}, copies={concrete:?}"
+                );
+            }
+        }
+
+        let copies = 200_000usize;
+        let huge = PeriodicRegion {
+            object: VarId::from_raw(0),
+            output: Span {
+                start: 0,
+                length: 1,
+            },
+            axes: vec![
+                PeriodicAxis {
+                    repetitions: copies,
+                    destination_stride: 2,
+                },
+                PeriodicAxis {
+                    repetitions: copies,
+                    destination_stride: 500_000,
+                },
+            ],
+        };
+        let last = (copies - 1) * 2 + (copies - 1) * 500_000;
+        assert!(periodic_overlaps_span(
+            &huge,
+            Span {
+                start: last,
+                length: 1,
+            }
+        ));
+        assert!(!periodic_overlaps_span(
+            &huge,
+            Span {
+                start: 499_999,
+                length: 1,
+            }
+        ));
+        assert!(!periodic_overlaps_span(
+            &huge,
+            Span {
+                start: last + 1,
+                length: 1,
+            }
+        ));
+    }
 }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -51,7 +51,7 @@ struct SummaryWalk {
     current_key: Option<NodeKey>,
     visited: HashSet<(NodeIndex, bool)>,
     stack: Vec<(NodeIndex, bool)>,
-    dependencies: BTreeMap<(Region<VarId>, Region<VarId>), bool>,
+    dependencies: BTreeMap<(Region<VarId>, SummaryOutput), bool>,
 }
 
 impl SummaryWalk {
@@ -111,7 +111,7 @@ impl SummaryWalk {
             };
             if let Some((input_key, output_key)) = pair {
                 for input in node_key_regions(input_key, module, bit_part) {
-                    for output in node_key_regions(output_key, module, bit_part) {
+                    for output in node_key_summary_outputs(output_key, module, bit_part) {
                         self.dependencies
                             .entry((input, output))
                             .and_modify(|aligned| *aligned &= path_aligned)
@@ -180,6 +180,28 @@ fn live_summary_nodes(
 /// deliberately occupies no real array element or bit-partition slot.
 const UNKNOWN_REGION_INDEX: usize = usize::MAX;
 const DENSE_REGION_INDEX: usize = usize::MAX - 1;
+const PERIODIC_REGION_INDEX: usize = usize::MAX - 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct PeriodicRegion {
+    object: VarId,
+    output: Span,
+    repetitions: usize,
+    stride: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PeriodicTransferRegion {
+    input: Region<VarId>,
+    output: PeriodicRegion,
+    aligned: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum SummaryOutput {
+    Region(Region<VarId>),
+    Periodic(PeriodicRegion),
+}
 
 /// Per `IdxKey`, atomic bit-range masks. Two bits are in the same range
 /// iff they appear in the same set of per-decl masks.
@@ -189,6 +211,7 @@ struct BitPartition {
     /// Symbolic full-element interiors of large exact spans. Their graph-node
     /// count depends on observed spans, not on unpacked array length.
     dense_regions: Vec<Region<VarId>>,
+    periodic_regions: Vec<PeriodicRegion>,
     /// Stable identities for unresolved regions. They are graph nodes, not
     /// array elements, so their count depends on accesses rather than width.
     wildcards: Vec<Region<VarId>>,
@@ -227,7 +250,7 @@ impl BitPartition {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct ModuleCombDependency {
     input: Region<VarId>,
-    output: Region<VarId>,
+    output: SummaryOutput,
     aligned: bool,
 }
 
@@ -331,7 +354,8 @@ fn ensure_instance_summaries(
         ensure_instance_summaries(child, summaries, visiting, errors, incomplete);
         let (graph, reasons, bit_part) = build_module_graph(child, summaries);
         check_graph(child, &graph, errors);
-        summaries.insert(key, compute_module_summary(child, &graph, &bit_part));
+        let summary = compute_module_summary(child, &graph, &bit_part);
+        summaries.insert(key, summary);
         if !reasons.is_empty() {
             incomplete.push(IncompleteCombAnalysis {
                 module: child.name.to_string(),
@@ -460,13 +484,18 @@ fn atomic_ranges(masks: &[Span], width: usize) -> Vec<Span> {
     ranges
 }
 
-fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) -> BitPartition {
+fn build_bit_partition(
+    module: &Module,
+    memory_ssa_regions: &[Region<VarId>],
+    periodic_regions: &[PeriodicRegion],
+) -> BitPartition {
     let mut masks: HashMap<VarId, BTreeMap<usize, Vec<Span>>> = HashMap::default();
 
     // A shifted copy can propagate every observed endpoint through the copy
     // relation. Feed those sparse spans into the shared partition so distinct
     // causal atoms do not collapse into a spurious self-edge.
     let dense_regions = collect_region_masks(memory_ssa_regions, module, &mut masks);
+    collect_periodic_masks(periodic_regions, module, &mut masks);
 
     let mut ranges: HashMap<VarId, BTreeMap<usize, Vec<Span>>> = HashMap::default();
     for (object, elements) in masks {
@@ -501,8 +530,167 @@ fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) ->
     BitPartition {
         ranges,
         dense_regions,
+        periodic_regions: periodic_regions.to_vec(),
         wildcards,
     }
+}
+
+fn collect_periodic_masks(
+    periodic_regions: &[PeriodicRegion],
+    module: &Module,
+    masks: &mut HashMap<VarId, BTreeMap<usize, Vec<Span>>>,
+) {
+    for &periodic in periodic_regions {
+        if periodic.repetitions == 0 || periodic.output.length == 0 {
+            continue;
+        }
+        let Some(width) = module
+            .variables
+            .get(&periodic.object)
+            .and_then(Variable::total_width)
+        else {
+            continue;
+        };
+        if width == 0 {
+            continue;
+        }
+        let Some(last_start) = periodic
+            .stride
+            .checked_mul(periodic.repetitions - 1)
+            .and_then(|offset| periodic.output.start.checked_add(offset))
+        else {
+            continue;
+        };
+        let Some(pattern_end) = last_start.checked_add(periodic.output.length) else {
+            continue;
+        };
+        let first_element = periodic.output.start / width;
+        masks
+            .entry(periodic.object)
+            .or_default()
+            .entry(first_element)
+            .or_default();
+        let elements = masks.entry(periodic.object).or_default();
+        let materialized = elements
+            .range(first_element..=((pattern_end - 1) / width))
+            .map(|(&element, _)| element)
+            .collect::<Vec<_>>();
+        for element in materialized {
+            let Some(element_start) = element.checked_mul(width) else {
+                continue;
+            };
+            let query = Span {
+                start: element_start,
+                length: width,
+            };
+            for overlap in periodic_span_intersections(periodic, query) {
+                elements
+                    .get_mut(&element)
+                    .expect("materialized periodic element")
+                    .push(Span {
+                        start: overlap.start - element_start,
+                        length: overlap.length,
+                    });
+            }
+        }
+    }
+}
+
+fn propagate_periodic_partition_regions(
+    regions: &[Region<VarId>],
+    transfers: &[PeriodicTransferRegion],
+    periodic_regions: &mut Vec<PeriodicRegion>,
+) {
+    for transfer in transfers.iter().filter(|transfer| transfer.aligned) {
+        let Region::Exact {
+            object: input_object,
+            span: input_span,
+        } = transfer.input
+        else {
+            continue;
+        };
+        for &region in regions {
+            let Region::Exact {
+                object,
+                span: region_span,
+            } = region
+            else {
+                continue;
+            };
+            if object != input_object {
+                continue;
+            }
+            let Some(overlap) = region_span.intersection(input_span) else {
+                continue;
+            };
+            let Some(offset) = overlap.start.checked_sub(input_span.start) else {
+                continue;
+            };
+            let Some(start) = transfer.output.output.start.checked_add(offset) else {
+                continue;
+            };
+            periodic_regions.push(PeriodicRegion {
+                object: transfer.output.object,
+                output: Span {
+                    start,
+                    length: overlap.length,
+                },
+                repetitions: transfer.output.repetitions,
+                stride: transfer.output.stride,
+            });
+        }
+    }
+}
+
+fn periodic_span_intersections(periodic: PeriodicRegion, query: Span) -> Vec<Span> {
+    let Some(query_end) = query.end() else {
+        return Vec::new();
+    };
+    let Some(phase_end) = periodic.output.end() else {
+        return Vec::new();
+    };
+    if periodic.repetitions == 0 || periodic.stride == 0 {
+        return periodic.output.intersection(query).into_iter().collect();
+    }
+    if periodic.output.length == periodic.stride {
+        let Some(length) = periodic.stride.checked_mul(periodic.repetitions) else {
+            return Vec::new();
+        };
+        return (Span {
+            start: periodic.output.start,
+            length,
+        })
+        .intersection(query)
+        .into_iter()
+        .collect();
+    }
+    let first = if query.start < phase_end {
+        0
+    } else {
+        (query.start - phase_end) / periodic.stride + 1
+    };
+    let end = if query_end <= periodic.output.start {
+        0
+    } else {
+        query_end
+            .saturating_sub(periodic.output.start)
+            .saturating_add(periodic.stride - 1)
+            / periodic.stride
+    }
+    .min(periodic.repetitions);
+    (first..end)
+        .filter_map(|copy| {
+            let start = periodic
+                .output
+                .start
+                .checked_add(copy.checked_mul(periodic.stride)?)?;
+            (Span {
+                start,
+                length: periodic.output.length,
+            })
+            .intersection(query)
+        })
+        .collect()
 }
 
 fn collect_region_masks(
@@ -691,14 +879,48 @@ fn build_module_graph(
             })
         })
         .collect::<Vec<_>>();
+    partition_regions.extend(
+        procedure_summaries
+            .iter()
+            .filter_map(|result| result.as_ref().ok())
+            .flat_map(|summary| &summary.periodic_dependencies)
+            .map(|dependency| dependency.input),
+    );
     partition_regions = propagate_aligned_regions(partition_regions, &procedure_summaries);
+    let mut periodic_transfers = procedure_summaries
+        .iter()
+        .filter_map(|result| result.as_ref().ok())
+        .flat_map(|summary| &summary.periodic_dependencies)
+        .map(|dependency| PeriodicTransferRegion {
+            input: dependency.input,
+            output: PeriodicRegion {
+                object: dependency.output_object,
+                output: dependency.output,
+                repetitions: dependency.repetitions,
+                stride: dependency.destination_stride,
+            },
+            aligned: dependency.aligned,
+        })
+        .collect::<Vec<_>>();
     let mut ctx = Context::default();
     ctx.variables = module.variables.clone();
     ctx.functions = module.functions.clone();
-    partition_regions.extend(collect_instance_summary_regions(
-        module, summaries, &mut ctx,
-    ));
-    let bit_part = build_bit_partition(module, &partition_regions);
+    let (instance_regions, instance_periodic_transfers) =
+        collect_instance_summary_regions(module, summaries, &mut ctx);
+    partition_regions.extend(instance_regions);
+    periodic_transfers.extend(instance_periodic_transfers);
+    let mut periodic_regions = periodic_transfers
+        .iter()
+        .map(|transfer| transfer.output)
+        .collect::<Vec<_>>();
+    propagate_periodic_partition_regions(
+        &partition_regions,
+        &periodic_transfers,
+        &mut periodic_regions,
+    );
+    periodic_regions.sort_unstable();
+    periodic_regions.dedup();
+    let bit_part = build_bit_partition(module, &partition_regions, &periodic_regions);
 
     let mut graph: Graph<NodeKey, bool> = Graph::new();
     let mut node_map: HashMap<NodeKey, NodeIndex> = HashMap::default();
@@ -733,6 +955,13 @@ fn build_module_graph(
             Ok(summary) => {
                 incomplete.extend(summary.incomplete.iter().copied());
                 add_memory_ssa_edges(module, summary, &bit_part, &mut graph, &mut node_map);
+                add_periodic_memory_ssa_edges(
+                    module,
+                    summary,
+                    &bit_part,
+                    &mut graph,
+                    &mut node_map,
+                );
             }
             Err(error) => {
                 incomplete.insert(IncompleteReason::MalformedModel);
@@ -977,6 +1206,101 @@ fn add_memory_ssa_edges(
     }
 }
 
+fn add_periodic_memory_ssa_edges(
+    module: &Module,
+    summary: &ProcedureSummary<VarId>,
+    bit_part: &BitPartition,
+    graph: &mut Graph<NodeKey, bool>,
+    node_map: &mut HashMap<NodeKey, NodeIndex>,
+) {
+    for dependency in &summary.periodic_dependencies {
+        if dependency.kind == EdgeKind::Unknown {
+            continue;
+        }
+        let input = restore_uncertain_region(&summary.uncertain_input_regions, dependency.input);
+        let periodic = PeriodicRegion {
+            object: dependency.output_object,
+            output: dependency.output,
+            repetitions: dependency.repetitions,
+            stride: dependency.destination_stride,
+        };
+        let pairs = if dependency.aligned {
+            aligned_periodic_node_pairs(input, periodic, &module.variables, bit_part)
+        } else {
+            let destinations = periodic_region_node_keys(periodic, &module.variables, bit_part);
+            region_node_keys(input, &module.variables, bit_part)
+                .into_iter()
+                .flat_map(|source| {
+                    destinations
+                        .iter()
+                        .copied()
+                        .map(move |destination| (source, destination))
+                })
+                .collect()
+        };
+        for (source, destination) in pairs {
+            if !is_module_scope_var(source.0, &module.variables) {
+                continue;
+            }
+            if !is_module_scope_var(destination.0, &module.variables) {
+                continue;
+            }
+            let source = ensure_node(graph, node_map, source);
+            let destination = ensure_node(graph, node_map, destination);
+            graph.add_edge(source, destination, dependency.aligned);
+        }
+    }
+}
+
+fn aligned_periodic_node_pairs(
+    input: Region<VarId>,
+    periodic: PeriodicRegion,
+    variables: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<(NodeKey, NodeKey)> {
+    let Region::Exact {
+        span: input_span, ..
+    } = input
+    else {
+        return Vec::new();
+    };
+    let mut pairs = BTreeSet::new();
+    for source in region_node_keys(input, variables, bit_part) {
+        for source_region in node_key_regions_for_variables(source, variables, bit_part) {
+            let Region::Exact {
+                span: source_span, ..
+            } = source_region
+            else {
+                continue;
+            };
+            let Some(overlap) = source_span.intersection(input_span) else {
+                continue;
+            };
+            let Some(offset) = overlap.start.checked_sub(input_span.start) else {
+                continue;
+            };
+            let Some(output_start) = periodic.output.start.checked_add(offset) else {
+                continue;
+            };
+            let mapped = PeriodicRegion {
+                object: periodic.object,
+                output: Span {
+                    start: output_start,
+                    length: overlap.length,
+                },
+                repetitions: periodic.repetitions,
+                stride: periodic.stride,
+            };
+            pairs.extend(
+                periodic_region_node_keys(mapped, variables, bit_part)
+                    .into_iter()
+                    .map(|destination| (source, destination)),
+            );
+        }
+    }
+    pairs.into_iter().collect()
+}
+
 fn aligned_region_node_pairs(
     input: Region<VarId>,
     output: Region<VarId>,
@@ -1170,6 +1494,59 @@ fn dense_region_node_keys(object: VarId, span: Span, bit_part: &BitPartition) ->
         .collect()
 }
 
+fn periodic_region_node_keys(
+    periodic: PeriodicRegion,
+    variables: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<NodeKey> {
+    let mut keys = bit_part
+        .periodic_regions
+        .iter()
+        .position(|candidate| *candidate == periodic)
+        .map(|index| vec![(periodic.object, PERIODIC_REGION_INDEX, index)])
+        .unwrap_or_default();
+    let Some(width) = variables
+        .get(&periodic.object)
+        .and_then(Variable::total_width)
+    else {
+        return keys;
+    };
+    let Some(last_start) = periodic
+        .stride
+        .checked_mul(periodic.repetitions.saturating_sub(1))
+        .and_then(|offset| periodic.output.start.checked_add(offset))
+    else {
+        return keys;
+    };
+    let Some(end) = last_start.checked_add(periodic.output.length) else {
+        return keys;
+    };
+    let Some(elements) = bit_part.ranges.get(&periodic.object) else {
+        return keys;
+    };
+    for (&element, ranges) in elements.range((periodic.output.start / width)..=((end - 1) / width))
+    {
+        let Some(element_start) = element.checked_mul(width) else {
+            continue;
+        };
+        for (range_index, range) in ranges.iter().enumerate() {
+            let Some(start) = element_start.checked_add(range.start) else {
+                continue;
+            };
+            let query = Span {
+                start,
+                length: range.length,
+            };
+            if !periodic_span_intersections(periodic, query).is_empty() {
+                keys.push((periodic.object, element, range_index));
+            }
+        }
+    }
+    keys.sort_unstable();
+    keys.dedup();
+    keys
+}
+
 /// Convert the MemorySSA engine's flattened, half-open bit region back to the
 /// graph `(array element, bit partition)` coordinates. The loop is
 /// proportional to touched elements, never to the declared array size.
@@ -1208,8 +1585,9 @@ fn collect_instance_summary_regions(
     module: &Module,
     summaries: &HashMap<usize, ModuleCombSummary>,
     ctx: &mut Context,
-) -> Vec<Region<VarId>> {
+) -> (Vec<Region<VarId>>, Vec<PeriodicTransferRegion>) {
     let mut regions = Vec::new();
+    let mut periodic_transfers = Vec::new();
     for inst in walk_insts(module) {
         let Component::Module(child) = inst.component.as_ref() else {
             continue;
@@ -1233,7 +1611,7 @@ fn collect_instance_summary_regions(
             let Some(child_input) = region_object(dependency.input) else {
                 continue;
             };
-            let Some(child_output) = region_object(dependency.output) else {
+            let Some(child_output) = summary_output_object(dependency.output) else {
                 continue;
             };
             let Some(input) = inst.inputs.iter().find(|input| input.id == child_input) else {
@@ -1242,23 +1620,45 @@ fn collect_instance_summary_regions(
             let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
                 continue;
             };
-            regions.extend(map_child_input_region(
+            let parent_inputs = map_child_input_region(
                 dependency.input,
                 child,
                 &input.expr,
                 &module.variables,
                 ctx,
-            ));
-            regions.extend(map_child_output_region(
-                dependency.output,
-                child,
-                &output.dst,
-                &module.variables,
-                ctx,
-            ));
+            );
+            regions.extend(parent_inputs.iter().copied());
+            match dependency.output {
+                SummaryOutput::Region(region) => regions.extend(map_child_output_region(
+                    region,
+                    child,
+                    &output.dst,
+                    &module.variables,
+                    ctx,
+                )),
+                SummaryOutput::Periodic(periodic) => {
+                    let parent_outputs = map_child_periodic_output(
+                        periodic,
+                        child,
+                        &output.dst,
+                        &module.variables,
+                        ctx,
+                    )
+                    .unwrap_or_default();
+                    for &input in &parent_inputs {
+                        for &output in &parent_outputs {
+                            periodic_transfers.push(PeriodicTransferRegion {
+                                input,
+                                output,
+                                aligned: dependency.aligned,
+                            });
+                        }
+                    }
+                }
+            }
         }
     }
-    regions
+    (regions, periodic_transfers)
 }
 
 fn add_inst_output_address_edges(
@@ -1312,7 +1712,7 @@ fn add_inst_feedthrough_edges(
         let Some(child_input) = region_object(dependency.input) else {
             continue;
         };
-        let Some(child_output) = region_object(dependency.output) else {
+        let Some(child_output) = summary_output_object(dependency.output) else {
             continue;
         };
         if !is_pure_input_or_output(child_input, &child.variables, Direction::Input)
@@ -1329,6 +1729,48 @@ fn add_inst_feedthrough_edges(
         if expression_has_hierarchical_reference(&input.expr) {
             incomplete.insert(IncompleteReason::HierarchicalReference);
         }
+        if let SummaryOutput::Periodic(periodic) = dependency.output {
+            let parent_inputs =
+                map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
+            let Some(parent_outputs) =
+                map_child_periodic_output(periodic, child, &output.dst, parent_vars, ctx)
+            else {
+                continue;
+            };
+            for input_region in parent_inputs {
+                for &parent_output in &parent_outputs {
+                    let pairs = if dependency.aligned {
+                        aligned_periodic_node_pairs(
+                            input_region,
+                            parent_output,
+                            parent_vars,
+                            bit_part,
+                        )
+                    } else {
+                        let destinations =
+                            periodic_region_node_keys(parent_output, parent_vars, bit_part);
+                        region_node_keys(input_region, parent_vars, bit_part)
+                            .into_iter()
+                            .flat_map(|source| {
+                                destinations
+                                    .iter()
+                                    .copied()
+                                    .map(move |destination| (source, destination))
+                            })
+                            .collect()
+                    };
+                    for (source, destination) in pairs {
+                        let source = ensure_node(graph, node_map, source);
+                        let destination = ensure_node(graph, node_map, destination);
+                        graph.add_edge(source, destination, dependency.aligned);
+                    }
+                }
+            }
+            continue;
+        }
+        let SummaryOutput::Region(dependency_output) = dependency.output else {
+            continue;
+        };
         if dependency.aligned
             && let (
                 Region::Exact {
@@ -1339,7 +1781,7 @@ fn add_inst_feedthrough_edges(
                     span: child_output_span,
                     ..
                 },
-            ) = (dependency.input, dependency.output)
+            ) = (dependency.input, dependency_output)
             && child_input_span.length == child_output_span.length
             && let Some(input_type) = child
                 .variables
@@ -1371,7 +1813,7 @@ fn add_inst_feedthrough_edges(
         let parent_input_regions =
             map_child_input_region(dependency.input, child, &input.expr, parent_vars, ctx);
         let parent_output_regions =
-            map_child_output_region(dependency.output, child, &output.dst, parent_vars, ctx);
+            map_child_output_region(dependency_output, child, &output.dst, parent_vars, ctx);
         let pairs = parent_input_regions
             .iter()
             .copied()
@@ -1500,6 +1942,13 @@ fn region_object(region: Region<VarId>) -> Option<VarId> {
     }
 }
 
+fn summary_output_object(output: SummaryOutput) -> Option<VarId> {
+    match output {
+        SummaryOutput::Region(region) => region_object(region),
+        SummaryOutput::Periodic(periodic) => Some(periodic.object),
+    }
+}
+
 fn child_region_span(region: Region<VarId>, child: &Module) -> Option<(Span, bool)> {
     match region {
         Region::Exact { span, .. } => Some((span, false)),
@@ -1572,6 +2021,48 @@ fn map_child_output_region(
     let mapped = map_destinations_span_to_regions(actual, span, parent_vars, ctx)
         .unwrap_or_else(|| collect_destination_regions(actual, parent_vars, ctx));
     retain_uncertainty(mapped, uncertain)
+}
+
+fn map_child_periodic_output(
+    periodic: PeriodicRegion,
+    child: &Module,
+    destinations: &[AssignDestination],
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Option<Vec<PeriodicRegion>> {
+    let variable = child.variables.get(&periodic.object)?;
+    let length = variable
+        .total_width()?
+        .checked_mul(variable.r#type.total_array().unwrap_or(1))?;
+    let mapped =
+        map_destinations_span_positioned(destinations, Span { start: 0, length }, variables, ctx)?;
+    if mapped.len() != 1 {
+        return None;
+    }
+    let positioned = mapped[0];
+    let Region::Exact {
+        object,
+        span: destination,
+    } = positioned.region
+    else {
+        return None;
+    };
+    if !positioned.aligned
+        || positioned.expression.start != 0
+        || positioned.expression.length != length
+        || destination.length != length
+    {
+        return None;
+    }
+    Some(vec![PeriodicRegion {
+        object,
+        output: Span {
+            start: destination.start.checked_add(periodic.output.start)?,
+            length: periodic.output.length,
+        },
+        repetitions: periodic.repetitions,
+        stride: periodic.stride,
+    }])
 }
 
 fn expression_has_hierarchical_reference(expression: &Expression) -> bool {
@@ -1816,6 +2307,8 @@ fn map_destinations_span_positioned(
                 expression: overlap,
                 aligned: true,
                 kind: EdgeKind::Value,
+                repetitions: 1,
+                expression_stride: 0,
             });
         }
         low = low.checked_add(span.length)?;
@@ -2365,6 +2858,9 @@ fn node_key_regions_for_variables(
     variables: &HashMap<VarId, Variable>,
     bit_part: &BitPartition,
 ) -> Vec<Region<VarId>> {
+    if key.1 == PERIODIC_REGION_INDEX {
+        return Vec::new();
+    }
     if key.1 == UNKNOWN_REGION_INDEX {
         return bit_part.wildcards.get(key.2).copied().into_iter().collect();
     }
@@ -2396,6 +2892,26 @@ fn node_key_regions_for_variables(
             length: span.length,
         },
     }]
+}
+
+fn node_key_summary_outputs(
+    key: NodeKey,
+    module: &Module,
+    bit_part: &BitPartition,
+) -> Vec<SummaryOutput> {
+    if key.1 == PERIODIC_REGION_INDEX {
+        return bit_part
+            .periodic_regions
+            .get(key.2)
+            .copied()
+            .map(SummaryOutput::Periodic)
+            .into_iter()
+            .collect();
+    }
+    node_key_regions(key, module, bit_part)
+        .into_iter()
+        .map(SummaryOutput::Region)
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -116,7 +116,8 @@ pub struct CombAnalysisResult {
 pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
     let mut errors = Vec::new();
     let mut incomplete = Vec::new();
-    let mut summaries: HashMap<StrId, ModuleCombSummary> = HashMap::default();
+    let mut summaries: HashMap<usize, ModuleCombSummary> = HashMap::default();
+    let mut visiting_specializations = HashSet::default();
 
     let (order, recursion_affected_modules) = topo_order_modules(ir);
 
@@ -130,13 +131,18 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
                 });
                 continue;
             }
-            let (graph, mut reasons, bit_part) = build_module_graph(module, &summaries);
+            ensure_instance_summaries(
+                module,
+                &mut summaries,
+                &mut visiting_specializations,
+                &mut errors,
+                &mut incomplete,
+            );
+            let (graph, mut reasons, _bit_part) = build_module_graph(module, &summaries);
             if recursion_affected_modules.contains(&idx) {
                 reasons.insert(IncompleteReason::RecursiveCall);
             }
             check_graph(module, &graph, &mut errors);
-            let summary = compute_module_summary(module, &graph, &bit_part);
-            summaries.insert(module.name, summary);
             if !reasons.is_empty() {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
@@ -147,6 +153,49 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
     }
 
     CombAnalysisResult { errors, incomplete }
+}
+
+fn component_summary_key(inst: &InstDeclaration) -> usize {
+    std::sync::Arc::as_ptr(&inst.component) as *const () as usize
+}
+
+/// Analyze the concrete module carried by each instance. Generic parameter
+/// overrides are already elaborated in this `Arc<Component>` and therefore
+/// cannot share the declaration-default summary keyed only by module name.
+fn ensure_instance_summaries(
+    module: &Module,
+    summaries: &mut HashMap<usize, ModuleCombSummary>,
+    visiting: &mut HashSet<usize>,
+    errors: &mut Vec<AnalyzerError>,
+    incomplete: &mut Vec<IncompleteCombAnalysis>,
+) {
+    for inst in walk_insts(module) {
+        let Component::Module(child) = inst.component.as_ref() else {
+            continue;
+        };
+        let key = component_summary_key(inst);
+        if summaries.contains_key(&key) {
+            continue;
+        }
+        if !visiting.insert(key) {
+            incomplete.push(IncompleteCombAnalysis {
+                module: child.name.to_string(),
+                reasons: [IncompleteReason::RecursiveCall].into(),
+            });
+            continue;
+        }
+        ensure_instance_summaries(child, summaries, visiting, errors, incomplete);
+        let (graph, reasons, bit_part) = build_module_graph(child, summaries);
+        check_graph(child, &graph, errors);
+        summaries.insert(key, compute_module_summary(child, &graph, &bit_part));
+        if !reasons.is_empty() {
+            incomplete.push(IncompleteCombAnalysis {
+                module: child.name.to_string(),
+                reasons,
+            });
+        }
+        visiting.remove(&key);
+    }
 }
 
 /// Children before parents. Modules in, or transitively depending on, an
@@ -360,7 +409,7 @@ fn collect_region_mask(
 
 fn build_module_graph(
     module: &Module,
-    summaries: &HashMap<StrId, ModuleCombSummary>,
+    summaries: &HashMap<usize, ModuleCombSummary>,
 ) -> (
     Graph<NodeKey, bool>,
     BTreeSet<IncompleteReason>,
@@ -494,7 +543,7 @@ fn build_module_graph(
                     &module.variables,
                     &mut ctx,
                 );
-                let Some(summary) = summaries.get(&child.name) else {
+                let Some(summary) = summaries.get(&component_summary_key(inst)) else {
                     continue;
                 };
                 add_inst_feedthrough_edges(
@@ -833,7 +882,7 @@ fn region_node_keys(
 
 fn collect_instance_summary_regions(
     module: &Module,
-    summaries: &HashMap<StrId, ModuleCombSummary>,
+    summaries: &HashMap<usize, ModuleCombSummary>,
     ctx: &mut Context,
 ) -> Vec<Region<VarId>> {
     let mut regions = Vec::new();
@@ -853,7 +902,7 @@ fn collect_instance_summary_regions(
                 ctx,
             ));
         }
-        let Some(summary) = summaries.get(&child.name) else {
+        let Some(summary) = summaries.get(&component_summary_key(inst)) else {
             continue;
         };
         for dependency in &summary.dependencies {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1249,9 +1249,14 @@ fn add_inst_feedthrough_edges(
                 },
             ) = (dependency.input, dependency.output)
             && child_input_span.length == child_output_span.length
-            && let Some(parent_inputs) = crate::comb_memory_ssa::map_expression_span_positioned(
+            && let Some(input_type) = child
+                .variables
+                .get(&child_input)
+                .map(|variable| &variable.r#type)
+            && let Some(parent_inputs) = crate::comb_memory_ssa::map_expression_span_positioned_as(
                 ctx,
                 &input.expr,
+                input_type,
                 child_input_span,
             )
             && let Some(parent_outputs) =
@@ -1441,7 +1446,23 @@ fn map_child_input_region(
     let Some((span, uncertain)) = child_region_span(region, child) else {
         return Vec::new();
     };
-    let mapped = map_expression_span_to_regions(actual, span, parent_vars, ctx)
+    let mapped = region_object(region)
+        .and_then(|object| child.variables.get(&object))
+        .and_then(|variable| {
+            crate::comb_memory_ssa::map_expression_span_positioned_as(
+                ctx,
+                actual,
+                &variable.r#type,
+                span,
+            )
+        })
+        .map(|positioned| {
+            positioned
+                .into_iter()
+                .map(|positioned| positioned.region)
+                .collect()
+        })
+        .or_else(|| map_expression_span_to_regions(actual, span, parent_vars, ctx))
         .unwrap_or_else(|| collect_expression_regions(actual, parent_vars, ctx));
     retain_uncertainty(mapped, uncertain)
 }
@@ -1542,7 +1563,11 @@ fn map_expression_span_to_regions(
     variables: &HashMap<VarId, Variable>,
     ctx: &mut Context,
 ) -> Option<Vec<Region<VarId>>> {
-    if requested.end()? > expression.comptime().r#type.total_width()? {
+    let expression_type = &expression.comptime().r#type;
+    let expression_length = expression_type
+        .total_width()?
+        .checked_mul(expression_type.total_array().unwrap_or(1))?;
+    if requested.end()? > expression_length {
         return None;
     }
     if let Some(mapped) = crate::comb_memory_ssa::map_expression_span(ctx, expression, requested) {

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1,8 +1,8 @@
 //! Combinational loop detection on the analyzer IR (issue #931).
 //!
-//! Builds a per-module `(VarId, array_index)` dependency graph from
-//! `FfTable` and per-decl `ReferencedEntry` masks, then reports SCCs.
-//! Module instance feedthrough is summarized bottom-up in topo order.
+//! Builds a sparse per-module region dependency graph from independently
+//! analyzable Memory SSA procedure summaries, then reports SCCs. Module
+//! instance feedthrough is summarized bottom-up in topo order.
 //!
 //! Under-detect by design: opaque constructs (SystemVerilog black
 //! boxes, `inout` ports, recursive functions) add no edges; the
@@ -15,9 +15,8 @@ use crate::HashSet;
 use crate::conv::Context;
 use crate::ir::VarId;
 use crate::ir::{
-    ArrayLiteralItem, AssignDestination, AssignStatement, CaseStatement, Component, Declaration,
-    Expression, Factor, ForBound, ForRange, ForStatement, FunctionCall, IfStatement,
-    InstDeclaration, Ir, Module, Op, Statement, SystemFunctionKind, VarIndex, VarSelect, Variable,
+    ArrayLiteralItem, AssignDestination, Component, Declaration, Expression, Factor,
+    InstDeclaration, Ir, Module, Op, SystemFunctionKind, VarIndex, VarSelect, Variable,
 };
 use crate::symbol::{Affiliation, Direction};
 use crate::value::ValueBigUint;
@@ -34,7 +33,7 @@ use veryl_causal::procedure::ProcedureSummary;
 use veryl_causal::region::{Region, Span};
 use veryl_parser::resource_table::StrId;
 
-/// `FfTable` / `per_decl_refs` granularity. Bit-precision lives in masks.
+/// One concrete unpacked-array element. Bit-precision lives in masks.
 type IdxKey = (VarId, usize);
 
 /// `(VarId, array_idx, range_idx)`. `range_idx` indexes the variable's
@@ -110,7 +109,7 @@ pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
 
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
-            // Unevaluable generic params -> empty per_decl_refs.
+            // Unevaluable generic params do not have a concrete module shape.
             if module.suppress_unassigned {
                 incomplete.push(IncompleteCombAnalysis {
                     module: module.name.to_string(),
@@ -269,95 +268,12 @@ fn atomic_ranges(masks: &[BigUint], width: usize) -> Vec<BigUint> {
     ret
 }
 
-/// Arrays larger than this are under-detected: a dynamic write (`arr[i] = ...`
-/// with no foldable index) fans out to every element, so the per-element graph
-/// / bit-partition expansion below is O(elements). A memory this large is not a
-/// realistic combinational-loop participant, so adding no edges stays sound.
-const OVERSIZED_ARRAY: usize = 1 << 16;
-
-fn oversized_array(id: VarId, variables: &HashMap<VarId, Variable>) -> bool {
-    variables
-        .get(&id)
-        .and_then(|v| v.r#type.total_array())
-        .is_some_and(|n| n > OVERSIZED_ARRAY)
-}
-
-fn build_bit_partition(
-    module: &Module,
-    ctx: &mut Context,
-    memory_ssa_regions: &[Region<VarId>],
-) -> BitPartition {
+fn build_bit_partition(module: &Module, memory_ssa_regions: &[Region<VarId>]) -> BitPartition {
     let mut masks: HashMap<(VarId, usize), Vec<BigUint>> = HashMap::default();
 
-    // Intra-module reads / writes captured during eval_assign.
-    for refs in module.per_decl_refs.values() {
-        for (id, entry) in refs {
-            for (i, m) in entry.mask_ref.iter().enumerate() {
-                if *m != BigUint::default() {
-                    masks.entry((*id, i)).or_default().push(m.clone());
-                }
-            }
-            for (i, m) in entry.mask_assign.iter().enumerate() {
-                if *m != BigUint::default() {
-                    masks.entry((*id, i)).or_default().push(m.clone());
-                }
-            }
-        }
-    }
-
-    // Per-reference masks. Per-decl aggregates alone would collapse
-    // bit-disjoint reads/writes of the same var into one atomic range
-    // (e.g. `b = a[0]; c = a[1];` aggregates a's mask to {0,1}).
-    for ((src_id, src_idx), entry) in &module.ff_table.table {
-        for (_, assign_target, src_read_mask, _) in &entry.refered {
-            if *src_read_mask != BigUint::default() {
-                masks
-                    .entry((*src_id, *src_idx))
-                    .or_default()
-                    .push(src_read_mask.clone());
-            }
-            if let Some((dst_id, dst_idx_opt, lhs_mask)) = assign_target
-                && *lhs_mask != BigUint::default()
-            {
-                if let Some(dst_idx) = dst_idx_opt {
-                    masks
-                        .entry((*dst_id, *dst_idx))
-                        .or_default()
-                        .push(lhs_mask.clone());
-                } else if let Some(var) = module.variables.get(dst_id)
-                    && let Some(total) = var.r#type.total_array()
-                    && total <= OVERSIZED_ARRAY
-                {
-                    for i in 0..total {
-                        masks
-                            .entry((*dst_id, i))
-                            .or_default()
-                            .push(lhs_mask.clone());
-                    }
-                }
-            }
-        }
-    }
-
-    // Inst input expressions: gather_ff records them but without masks.
-    for inst in walk_insts(module) {
-        for inp in &inst.inputs {
-            collect_expr_masks(&inp.expr, &mut masks, ctx);
-        }
-        for out in &inst.outputs {
-            for dst in &out.dst {
-                if let Some((idx, mask)) = eval_dst_mask(dst, &module.variables, ctx) {
-                    masks.entry((dst.id, idx)).or_default().push(mask);
-                }
-            }
-        }
-    }
-
-    // MemorySSA can discover finer positional boundaries than the legacy
-    // read/write masks.  A shifted copy, for example, propagates every
-    // observed endpoint through the copy relation.  Feed those sparse spans
-    // back into the shared partition so distinct causal atoms do not collapse
-    // into a spurious self-edge.
+    // A shifted copy can propagate every observed endpoint through the copy
+    // relation. Feed those sparse spans into the shared partition so distinct
+    // causal atoms do not collapse into a spurious self-edge.
     for &region in memory_ssa_regions {
         collect_region_mask(region, module, &mut masks);
     }
@@ -410,87 +326,10 @@ fn collect_region_mask(
     }
 }
 
-fn collect_expr_masks(
-    expr: &Expression,
-    out: &mut HashMap<(VarId, usize), Vec<BigUint>>,
-    ctx: &mut Context,
-) {
-    match expr {
-        Expression::Term(t) => collect_factor_masks(t, out, ctx),
-        Expression::Unary(_, e, _) => collect_expr_masks(e, out, ctx),
-        Expression::Binary(a, _, b, _) => {
-            collect_expr_masks(a, out, ctx);
-            collect_expr_masks(b, out, ctx);
-        }
-        Expression::Ternary(a, b, c, _) => {
-            collect_expr_masks(a, out, ctx);
-            collect_expr_masks(b, out, ctx);
-            collect_expr_masks(c, out, ctx);
-        }
-        Expression::Concatenation(parts, _) => {
-            for (a, b) in parts {
-                collect_expr_masks(a, out, ctx);
-                if let Some(b) = b {
-                    collect_expr_masks(b, out, ctx);
-                }
-            }
-        }
-        Expression::StructConstructor(_, fields, _) => {
-            for (_, e) in fields {
-                collect_expr_masks(e, out, ctx);
-            }
-        }
-        Expression::ArrayLiteral(_, _) => {}
-    }
-}
-
-fn collect_factor_masks(
-    factor: &Factor,
-    out: &mut HashMap<(VarId, usize), Vec<BigUint>>,
-    ctx: &mut Context,
-) {
-    match factor {
-        Factor::Variable(id, index, select, _) => {
-            for (idx, mask) in var_reads(*id, index, select, ctx) {
-                out.entry((*id, idx)).or_default().push(mask);
-            }
-        }
-        Factor::FunctionCall(call) => {
-            for input in call.inputs.values() {
-                collect_expr_masks(input, out, ctx);
-            }
-        }
-        _ => {}
-    }
-}
-
-/// None if the index is dynamic.
-fn eval_dst_mask(
-    dst: &AssignDestination,
-    parent_vars: &HashMap<VarId, Variable>,
-    ctx: &mut Context,
-) -> Option<(usize, BigUint)> {
-    let v = parent_vars.get(&dst.id)?;
-    let idx_path = dst.index.eval_value(ctx)?;
-    let flat = v.r#type.array.calc_index(&idx_path)?;
-    let mask = if let Some((beg, end)) = dst.select.eval_value(ctx, &v.r#type, false) {
-        ValueBigUint::gen_mask_range(beg, end)
-    } else {
-        let width = v.total_width()?;
-        ValueBigUint::gen_mask(width)
-    };
-    Some((flat, mask))
-}
-
 fn build_module_graph(
     module: &Module,
     summaries: &HashMap<StrId, ModuleCombSummary>,
 ) -> (Graph<NodeKey, ()>, BTreeSet<IncompleteReason>, BitPartition) {
-    let ff_table = &module.ff_table;
-    let union_writes = compute_union_writes(&module.per_decl_refs);
-    let writes_per_decl = compute_writes_per_decl(&module.per_decl_refs);
-    let undom_per_decl = compute_undominated_per_decl(module);
-
     // Procedural combinational declarations use statement-ordered region
     // MemorySSA. Keep instance declarations on the existing bottom-up module
     // summary path until the same region vocabulary crosses module boundaries.
@@ -514,8 +353,14 @@ fn build_module_graph(
     let mut partition_regions = procedure_summaries
         .iter()
         .filter_map(|result| result.as_ref().ok())
-        .flat_map(|summary| &summary.dependencies)
-        .flat_map(|dependency| [dependency.input, dependency.output])
+        .flat_map(|summary| {
+            summary.dependencies.iter().flat_map(|dependency| {
+                [
+                    dependency.input,
+                    sparse_output_region(summary, dependency.output),
+                ]
+            })
+        })
         .collect::<Vec<_>>();
     let mut ctx = Context::default();
     ctx.variables = module.variables.clone();
@@ -523,7 +368,7 @@ fn build_module_graph(
     partition_regions.extend(collect_instance_summary_regions(
         module, summaries, &mut ctx,
     ));
-    let bit_part = build_bit_partition(module, &mut ctx, &partition_regions);
+    let bit_part = build_bit_partition(module, &partition_regions);
 
     let mut graph: Graph<NodeKey, ()> = Graph::new();
     let mut node_map: HashMap<NodeKey, NodeIndex> = HashMap::default();
@@ -571,152 +416,6 @@ fn build_module_graph(
                     "failed to build comb MemorySSA for {}: {error}",
                     module.name
                 );
-            }
-        }
-    }
-
-    for ((src_id, src_idx), entry) in &ff_table.table {
-        if entry.is_ff {
-            continue;
-        }
-        if !is_module_scope_var(*src_id, &module.variables) {
-            continue;
-        }
-        // Under-detect oversized arrays (see `OVERSIZED_ARRAY`).
-        if oversized_array(*src_id, &module.variables) {
-            continue;
-        }
-        let src_id_idx = (*src_id, *src_idx);
-
-        for (reader_decl, assign_target, src_read_mask, from_ff) in &entry.refered {
-            if *from_ff {
-                continue;
-            }
-            if matches!(
-                module.declarations.get(*reader_decl),
-                Some(Declaration::Comb(_))
-            ) {
-                continue;
-            }
-            // `decl_read_mask == 0` also filters out reads gathered by
-            // `gather_ff` but missing from `eval_assign` (notably inst
-            // input expressions, which `add_inst_feedthrough_edges` handles).
-            let decl_read_mask = lookup_read_mask(&module.per_decl_refs, *reader_decl, src_id_idx);
-            if decl_read_mask == BigUint::default() {
-                continue;
-            }
-            let read_mask = if *src_read_mask != BigUint::default() {
-                &decl_read_mask & src_read_mask
-            } else {
-                decl_read_mask
-            };
-            if read_mask == BigUint::default() {
-                continue;
-            }
-            // Internal sources need a comb writer overlapping the read bits.
-            // Input ports are driven externally so they always carry data.
-            let effective_read = if is_input_port(*src_id, &module.variables) {
-                read_mask.clone()
-            } else {
-                let Some(driven) = union_writes.get(&src_id_idx) else {
-                    continue;
-                };
-                let overlap = &read_mask & driven;
-                if overlap == BigUint::default() {
-                    continue;
-                }
-                overlap
-            };
-
-            // Per-statement LHS mask preferred over per-decl aggregate.
-            // Otherwise `t1[0] = 0; t1[1] = src;` would route src into both
-            // bits.
-            let dst_with_masks: Vec<((VarId, usize), BigUint)> = match assign_target {
-                Some((dst_id, Some(dst_idx), lhs_mask)) => {
-                    let mask = if *lhs_mask != BigUint::default() {
-                        lhs_mask.clone()
-                    } else {
-                        lookup_write_mask(&module.per_decl_refs, *reader_decl, (*dst_id, *dst_idx))
-                    };
-                    if mask != BigUint::default() {
-                        vec![((*dst_id, *dst_idx), mask)]
-                    } else {
-                        vec![]
-                    }
-                }
-                // Under-detect oversized arrays (see `OVERSIZED_ARRAY`).
-                Some((dst_id, None, _)) if oversized_array(*dst_id, &module.variables) => vec![],
-                Some((dst_id, None, lhs_mask)) => writes_per_decl
-                    .get(reader_decl)
-                    .map(|w| {
-                        w.iter()
-                            .filter(|(id, _, _)| id == dst_id)
-                            .map(|(id, idx, decl_mask)| {
-                                let mask = if *lhs_mask != BigUint::default() {
-                                    lhs_mask & decl_mask
-                                } else {
-                                    decl_mask.clone()
-                                };
-                                ((*id, *idx), mask)
-                            })
-                            .filter(|(_, m)| m != &BigUint::default())
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                None => writes_per_decl
-                    .get(reader_decl)
-                    .map(|w| {
-                        w.iter()
-                            .filter(|(id, _, _)| *id == *src_id)
-                            .map(|(id, idx, m)| ((*id, *idx), m.clone()))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-            };
-
-            for (dst_id_idx, write_mask) in dst_with_masks {
-                if write_mask == BigUint::default() {
-                    continue;
-                }
-                if !is_module_scope_var(dst_id_idx.0, &module.variables) {
-                    continue;
-                }
-                // Same `(VarId, idx)`: only undominated reads can close a cycle through
-                // this declaration (`a = 0; a = a + 1` must not). Disjoint bits still form
-                // real multi-bit cycles (`o_y[1] = o_y[2]; o_y[2] = o_y[1]`), so read/write
-                // masks need not overlap — the bit-partition ranges stop `a[1] = a[0]` self-edges.
-                //
-                // A condition read (`assign_target` is None, e.g. `if yw[i]`) is
-                // recorded against EVERY same-variable write, so on a feed-forward
-                // array chain it wires `yw[i]` to every `yw[j]` — a false cross-index
-                // cycle. Extend the same undominated filter to it: a condition read
-                // dominated by an earlier write to the same element cannot close a
-                // loop; a real (undominated) condition loop is still detected.
-                let mut effective_read = effective_read.clone();
-                if src_id_idx == dst_id_idx || assign_target.is_none() {
-                    let undom = undom_per_decl
-                        .get(reader_decl)
-                        .and_then(|m| m.get(&src_id_idx))
-                        .cloned()
-                        .unwrap_or_default();
-                    let undom_read = &undom & &effective_read;
-                    if undom_read == BigUint::default() {
-                        continue;
-                    }
-                    effective_read = undom_read;
-                }
-
-                let src_ranges = bit_part.overlapping(src_id_idx, &effective_read);
-                let dst_ranges = bit_part.overlapping(dst_id_idx, &write_mask);
-                for sr in &src_ranges {
-                    let src_node_key = (src_id_idx.0, src_id_idx.1, *sr);
-                    let src_node = ensure_node(&mut graph, &mut node_map, src_node_key);
-                    for dr in &dst_ranges {
-                        let dst_node_key = (dst_id_idx.0, dst_id_idx.1, *dr);
-                        let dst_node = ensure_node(&mut graph, &mut node_map, dst_node_key);
-                        graph.add_edge(src_node, dst_node, ());
-                    }
-                }
             }
         }
     }
@@ -774,7 +473,11 @@ fn add_memory_ssa_edges(
             continue;
         }
         let sources = region_node_keys(dependency.input, &module.variables, bit_part);
-        let destinations = region_node_keys(dependency.output, &module.variables, bit_part);
+        let destinations = region_node_keys(
+            sparse_output_region(summary, dependency.output),
+            &module.variables,
+            bit_part,
+        );
         for source in &sources {
             if !is_module_scope_var(source.0, &module.variables) {
                 continue;
@@ -791,8 +494,21 @@ fn add_memory_ssa_edges(
     }
 }
 
+/// Memory SSA expands an unknown-object write over its sparse atom endpoints
+/// so kill/phi semantics stay exact. Do not turn the resulting large exact
+/// output spans back into per-element graph nodes: the object-local alias node
+/// carries the same uncertainty and aliases only regions touched elsewhere.
+fn sparse_output_region(summary: &ProcedureSummary<VarId>, output: Region<VarId>) -> Region<VarId> {
+    match output {
+        Region::Exact { object, .. } if summary.uncertain_write_objects.contains(&object) => {
+            Region::UnknownObject(object)
+        }
+        output => output,
+    }
+}
+
 /// Convert the MemorySSA engine's flattened, half-open bit region back to the
-/// legacy graph's `(array element, bit partition)` coordinates. The loop is
+/// graph `(array element, bit partition)` coordinates. The loop is
 /// proportional to touched elements, never to the declared array size.
 fn region_node_keys(
     region: Region<VarId>,
@@ -1375,66 +1091,6 @@ fn has_self_edge(graph: &Graph<NodeKey, ()>, node: NodeIndex) -> bool {
         .any(|e| e.source() == node && e.target() == node)
 }
 
-fn compute_union_writes(
-    per_decl_refs: &HashMap<usize, HashMap<VarId, crate::ir::ReferencedEntry>>,
-) -> HashMap<(VarId, usize), BigUint> {
-    let mut out: HashMap<(VarId, usize), BigUint> = HashMap::default();
-    for refs in per_decl_refs.values() {
-        for (id, entry) in refs {
-            for (i, mask) in entry.mask_assign.iter().enumerate() {
-                if *mask == BigUint::default() {
-                    continue;
-                }
-                let cur = out.entry((*id, i)).or_default();
-                *cur |= mask;
-            }
-        }
-    }
-    out
-}
-
-/// `decl -> Vec<(VarId, idx, write_mask)>`. Includes inst-output dsts.
-fn compute_writes_per_decl(
-    per_decl_refs: &HashMap<usize, HashMap<VarId, crate::ir::ReferencedEntry>>,
-) -> HashMap<usize, Vec<(VarId, usize, BigUint)>> {
-    let mut out: HashMap<usize, Vec<(VarId, usize, BigUint)>> = HashMap::default();
-    for (decl, refs) in per_decl_refs {
-        for (id, entry) in refs {
-            for (i, mask) in entry.mask_assign.iter().enumerate() {
-                if *mask == BigUint::default() {
-                    continue;
-                }
-                out.entry(*decl).or_default().push((*id, i, mask.clone()));
-            }
-        }
-    }
-    out
-}
-
-fn lookup_read_mask(
-    per_decl_refs: &HashMap<usize, HashMap<VarId, crate::ir::ReferencedEntry>>,
-    decl: usize,
-    key: (VarId, usize),
-) -> BigUint {
-    per_decl_refs
-        .get(&decl)
-        .and_then(|m| m.get(&key.0))
-        .and_then(|e| e.mask_ref.get(key.1).cloned())
-        .unwrap_or_default()
-}
-
-fn lookup_write_mask(
-    per_decl_refs: &HashMap<usize, HashMap<VarId, crate::ir::ReferencedEntry>>,
-    decl: usize,
-    key: (VarId, usize),
-) -> BigUint {
-    per_decl_refs
-        .get(&decl)
-        .and_then(|m| m.get(&key.0))
-        .and_then(|e| e.mask_assign.get(key.1).cloned())
-        .unwrap_or_default()
-}
-
 fn build_error(module: &Module, keys: &[NodeKey]) -> Option<AnalyzerError> {
     let mut tokens: Vec<veryl_parser::token_range::TokenRange> = Vec::new();
     let mut identifier: Option<String> = None;
@@ -1443,13 +1099,22 @@ fn build_error(module: &Module, keys: &[NodeKey]) -> Option<AnalyzerError> {
         if !seen_var.insert(*id) {
             continue;
         }
-        if let Some(var) = module.variables.get(id)
+        let variable = module.variables.get(id);
+        if let Some(var) = variable
             && identifier.is_none()
         {
             identifier = Some(var.path.to_string());
         }
-        if let Some(toks) = module.assign_tokens.get(id) {
+        if let Some(toks) = module.assign_tokens.get(id)
+            && !toks.is_empty()
+        {
             tokens.extend(toks.iter().copied());
+        } else if let Some(var) = variable {
+            // Large dynamic assignments intentionally do not allocate the
+            // legacy per-element AssignTable, so no assignment-token vector
+            // exists. The declaration still provides a stable diagnostic
+            // anchor for a loop proven by the sparse causal graph.
+            tokens.push(var.token);
         }
     }
     {
@@ -1463,11 +1128,6 @@ fn build_error(module: &Module, keys: &[NodeKey]) -> Option<AnalyzerError> {
         &primary,
         &participants,
     ))
-}
-
-fn is_input_port(id: VarId, variables: &HashMap<VarId, Variable>) -> bool {
-    use crate::ir::VarKind;
-    matches!(variables.get(&id).map(|v| v.kind), Some(VarKind::Input))
 }
 
 fn is_module_scope_var(id: VarId, variables: &HashMap<VarId, Variable>) -> bool {
@@ -1592,335 +1252,6 @@ fn mask_spans(mask: &BigUint, width: usize) -> Vec<Span> {
         });
     }
     spans
-}
-
-// Statement-level dominance analysis.
-
-/// `defs`: bits guaranteed-written on the current path.
-/// `undom`: bits read without a covering preceding write.
-#[derive(Default, Clone)]
-struct DominanceState {
-    defs: HashMap<IdxKey, BigUint>,
-    undom: HashMap<IdxKey, BigUint>,
-}
-
-fn compute_undominated_per_decl(module: &Module) -> HashMap<usize, HashMap<IdxKey, BigUint>> {
-    let mut out: HashMap<usize, HashMap<IdxKey, BigUint>> = HashMap::default();
-    let mut ctx = Context::default();
-    ctx.variables = module.variables.clone();
-    ctx.functions = module.functions.clone();
-
-    for (decl_idx, decl) in module.declarations.iter().enumerate() {
-        if let Declaration::Comb(c) = decl {
-            let mut state = DominanceState::default();
-            walk_block(&c.statements, &mut state, &mut ctx);
-            state.undom.retain(|_, m| *m != BigUint::default());
-            if !state.undom.is_empty() {
-                out.insert(decl_idx, state.undom);
-            }
-        }
-    }
-    out
-}
-
-fn walk_block(stmts: &[Statement], state: &mut DominanceState, ctx: &mut Context) {
-    for stmt in stmts {
-        walk_stmt(stmt, state, ctx);
-    }
-}
-
-fn walk_stmt(stmt: &Statement, state: &mut DominanceState, ctx: &mut Context) {
-    match stmt {
-        Statement::Assign(a) => walk_assign(a, state, ctx),
-        Statement::If(i) => walk_if(i, state, ctx),
-        Statement::Case(c) => walk_case(c, state, ctx),
-        Statement::For(f) => walk_for(f, state, ctx),
-        Statement::FunctionCall(c) => walk_function_call(c.as_ref(), state, ctx),
-        // IfReset is always_ff-only; the rest have no LHS to track.
-        Statement::IfReset(_)
-        | Statement::SystemFunctionCall(_)
-        | Statement::TbMethodCall(_)
-        | Statement::Break
-        | Statement::Unsupported(_)
-        | Statement::Null => {}
-    }
-}
-
-fn walk_assign(stmt: &AssignStatement, state: &mut DominanceState, ctx: &mut Context) {
-    // RHS before LHS: otherwise `a = a + 1` sees itself as dominated.
-    walk_expr(&stmt.expr, state, ctx);
-    for dst in &stmt.dst {
-        for (idx, mask) in dst_writes(dst, ctx) {
-            let key = (dst.id, idx);
-            *state.defs.entry(key).or_default() |= &mask;
-        }
-    }
-}
-
-fn walk_if(stmt: &IfStatement, state: &mut DominanceState, ctx: &mut Context) {
-    walk_expr(&stmt.cond, state, ctx);
-
-    let saved_defs = state.defs.clone();
-    let saved_undom = state.undom.clone();
-
-    let mut true_state = DominanceState {
-        defs: saved_defs.clone(),
-        undom: saved_undom.clone(),
-    };
-    walk_block(&stmt.true_side, &mut true_state, ctx);
-
-    let mut false_state = DominanceState {
-        defs: saved_defs,
-        undom: saved_undom,
-    };
-    walk_block(&stmt.false_side, &mut false_state, ctx);
-
-    // Merge: defs = intersection (only both-paths writes dominate
-    // downstream); undom = union (any path's undom contributes).
-    let mut keys: HashSet<IdxKey> = HashSet::default();
-    for k in true_state.defs.keys().chain(false_state.defs.keys()) {
-        keys.insert(*k);
-    }
-    let mut merged_defs: HashMap<IdxKey, BigUint> = HashMap::default();
-    for key in keys {
-        let zero = BigUint::default();
-        let t = true_state.defs.get(&key).unwrap_or(&zero);
-        let f = false_state.defs.get(&key).unwrap_or(&zero);
-        let merged = t & f;
-        if merged != zero {
-            merged_defs.insert(key, merged);
-        }
-    }
-    state.defs = merged_defs;
-
-    state.undom = true_state.undom;
-    for (key, mask) in false_state.undom {
-        *state.undom.entry(key).or_default() |= &mask;
-    }
-}
-
-fn walk_case(stmt: &CaseStatement, state: &mut DominanceState, ctx: &mut Context) {
-    walk_expr(&stmt.case_target, state, ctx);
-    for arm in &stmt.arms {
-        for p in &arm.patterns {
-            match p {
-                crate::ir::CasePattern::Eq(e) => walk_expr(e, state, ctx),
-                crate::ir::CasePattern::Range { lo, hi, .. } => {
-                    walk_expr(lo, state, ctx);
-                    walk_expr(hi, state, ctx);
-                }
-            }
-        }
-    }
-
-    let saved_defs = state.defs.clone();
-    let saved_undom = state.undom.clone();
-
-    let mut branch_states: Vec<DominanceState> = Vec::with_capacity(stmt.arms.len() + 1);
-    for arm in &stmt.arms {
-        let mut s = DominanceState {
-            defs: saved_defs.clone(),
-            undom: saved_undom.clone(),
-        };
-        walk_block(&arm.body, &mut s, ctx);
-        branch_states.push(s);
-    }
-    // Empty default behaves as the saved state, modeling "no arm matched".
-    let mut default_state = DominanceState {
-        defs: saved_defs,
-        undom: saved_undom,
-    };
-    walk_block(&stmt.default, &mut default_state, ctx);
-    branch_states.push(default_state);
-
-    // defs = intersection across branches; undom = union.
-    let mut keys: HashSet<IdxKey> = HashSet::default();
-    for b in &branch_states {
-        for k in b.defs.keys() {
-            keys.insert(*k);
-        }
-    }
-    let mut merged_defs: HashMap<IdxKey, BigUint> = HashMap::default();
-    for key in keys {
-        let zero = BigUint::default();
-        let mut acc: Option<BigUint> = None;
-        for b in &branch_states {
-            let v = b.defs.get(&key).unwrap_or(&zero).clone();
-            acc = Some(match acc {
-                Some(a) => a & v,
-                None => v,
-            });
-        }
-        if let Some(merged) = acc
-            && merged != zero
-        {
-            merged_defs.insert(key, merged);
-        }
-    }
-    state.defs = merged_defs;
-
-    let mut merged_undom: HashMap<IdxKey, BigUint> = HashMap::default();
-    for b in branch_states {
-        for (key, mask) in b.undom {
-            *merged_undom.entry(key).or_default() |= &mask;
-        }
-    }
-    state.undom = merged_undom;
-}
-
-fn walk_for(stmt: &ForStatement, state: &mut DominanceState, ctx: &mut Context) {
-    walk_for_range(&stmt.range, state, ctx);
-    // Body may run zero times: surface undom reads but don't trust
-    // its writes to dominate anything afterwards.
-    let saved_defs = state.defs.clone();
-    walk_block(&stmt.body, state, ctx);
-    state.defs = saved_defs;
-}
-
-fn walk_for_range(range: &ForRange, state: &mut DominanceState, ctx: &mut Context) {
-    let bounds = match range {
-        ForRange::Forward { start, end, .. }
-        | ForRange::Reverse { start, end, .. }
-        | ForRange::Stepped { start, end, .. } => [start, end],
-    };
-    for b in bounds {
-        if let ForBound::Expression(e) = b {
-            walk_expr(e, state, ctx);
-        }
-    }
-}
-
-fn walk_function_call(call: &FunctionCall, state: &mut DominanceState, ctx: &mut Context) {
-    for input in call.inputs.values() {
-        walk_expr(input, state, ctx);
-    }
-    for outputs in call.outputs.values() {
-        for dst in outputs {
-            for (idx, mask) in dst_writes(dst, ctx) {
-                let key = (dst.id, idx);
-                *state.defs.entry(key).or_default() |= &mask;
-            }
-        }
-    }
-}
-
-fn walk_expr(expr: &Expression, state: &mut DominanceState, ctx: &mut Context) {
-    match expr {
-        Expression::Term(t) => walk_factor(t, state, ctx),
-        Expression::Unary(_, e, _) => walk_expr(e, state, ctx),
-        Expression::Binary(a, _, b, _) => {
-            walk_expr(a, state, ctx);
-            walk_expr(b, state, ctx);
-        }
-        Expression::Ternary(a, b, c, _) => {
-            walk_expr(a, state, ctx);
-            walk_expr(b, state, ctx);
-            walk_expr(c, state, ctx);
-        }
-        Expression::Concatenation(parts, _) => {
-            for (a, b) in parts {
-                walk_expr(a, state, ctx);
-                if let Some(b) = b {
-                    walk_expr(b, state, ctx);
-                }
-            }
-        }
-        Expression::StructConstructor(_, fields, _) => {
-            for (_, e) in fields {
-                walk_expr(e, state, ctx);
-            }
-        }
-        Expression::ArrayLiteral(_, _) => {}
-    }
-}
-
-fn walk_factor(factor: &Factor, state: &mut DominanceState, ctx: &mut Context) {
-    match factor {
-        Factor::Variable(id, index, select, _) => {
-            for (idx, mask) in var_reads(*id, index, select, ctx) {
-                let key = (*id, idx);
-                let dominated = state.defs.get(&key).cloned().unwrap_or_default();
-                let undom_bits = &mask ^ (&mask & &dominated);
-                if undom_bits != BigUint::default() {
-                    *state.undom.entry(key).or_default() |= undom_bits;
-                }
-            }
-        }
-        Factor::FunctionCall(call) => walk_function_call(call, state, ctx),
-        _ => {}
-    }
-}
-
-/// Mirrors the masking logic of `AssignDestination::eval_assign`.
-fn dst_writes(dst: &AssignDestination, ctx: &mut Context) -> Vec<(usize, BigUint)> {
-    let Some(variable) = ctx.get_variable_info(dst.id) else {
-        return Vec::new();
-    };
-    let is_index_const = dst.index.is_const();
-    let is_select_const = dst.select.is_const();
-
-    let range = if !is_index_const {
-        variable.r#type.array.calc_range(&[])
-    } else {
-        let Some(index) = dst.index.eval_value(ctx) else {
-            return Vec::new();
-        };
-        variable.r#type.array.calc_range(&index)
-    };
-
-    let mask = if !is_select_const {
-        let Some(width) = variable.total_width() else {
-            return Vec::new();
-        };
-        ValueBigUint::gen_mask(width)
-    } else {
-        let Some((beg, end)) = dst.select.eval_value(ctx, &variable.r#type, false) else {
-            return Vec::new();
-        };
-        ValueBigUint::gen_mask_range(beg, end)
-    };
-
-    let mut out = Vec::new();
-    if let Some((beg, end)) = range {
-        if end.saturating_sub(beg) > OVERSIZED_ARRAY {
-            return out;
-        }
-        for i in beg..=end {
-            out.push((i, mask.clone()));
-        }
-    }
-    out
-}
-
-fn var_reads(
-    id: VarId,
-    index: &VarIndex,
-    select: &VarSelect,
-    ctx: &mut Context,
-) -> Vec<(usize, BigUint)> {
-    let Some(variable) = ctx.variables.get(&id).cloned() else {
-        return Vec::new();
-    };
-    let mask = if let Some((beg, end)) = select.eval_value(ctx, &variable.r#type, false) {
-        ValueBigUint::gen_mask_range(beg, end)
-    } else {
-        let Some(width) = variable.total_width() else {
-            return Vec::new();
-        };
-        ValueBigUint::gen_mask(width)
-    };
-    if let Some(idx_path) = index.eval_value(ctx)
-        && let Some(flat) = variable.r#type.array.calc_index(&idx_path)
-    {
-        return vec![(flat, mask)];
-    }
-    // Legacy dominance bridge only: exact comb dependencies are handled by
-    // region MemorySSA. Never expand a dynamic access to a huge array here.
-    let total = variable.r#type.total_array().unwrap_or(1);
-    if total > OVERSIZED_ARRAY {
-        return Vec::new();
-    }
-    (0..total).map(|i| (i, mask.clone())).collect()
 }
 
 #[cfg(test)]

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1086,7 +1086,8 @@ fn build_module_graph(
     // Build each specialization once before entering Rayon. Procedure tasks
     // then share an immutable summary table instead of racing to initialize
     // the same callee behind a global mutex.
-    let all_function_analyses = crate::comb_memory_ssa::analyze_functions(module, &function_cache);
+    let (all_function_analyses, mut analysis_context) =
+        crate::comb_memory_ssa::analyze_functions(module, &function_cache);
     function_cache.freeze();
     let analyze_declaration = |declaration: &Declaration| match declaration {
         Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze(
@@ -1119,7 +1120,20 @@ fn build_module_graph(
         module
             .declarations
             .iter()
-            .filter_map(analyze_declaration)
+            .filter_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze_in_context(
+                    &mut analysis_context,
+                    comb,
+                    &function_cache,
+                )),
+                Declaration::Ff(_)
+                | Declaration::Inst(_)
+                | Declaration::External(_)
+                | Declaration::Initial(_)
+                | Declaration::Final(_)
+                | Declaration::Unsupported(_)
+                | Declaration::Null => None,
+            })
             .collect::<Vec<_>>()
     };
     #[cfg(target_family = "wasm")]
@@ -1162,8 +1176,8 @@ fn build_module_graph(
         instance_observers
             .iter()
             .map(|expression| {
-                crate::comb_memory_ssa::analyze_observer_expression(
-                    module,
+                crate::comb_memory_ssa::analyze_observer_expression_in_context(
+                    &mut analysis_context,
                     expression,
                     &function_cache,
                 )
@@ -1173,7 +1187,11 @@ fn build_module_graph(
 
     #[cfg(target_family = "wasm")]
     procedure_summaries.extend(instance_observers.iter().map(|expression| {
-        crate::comb_memory_ssa::analyze_observer_expression(module, expression, &function_cache)
+        crate::comb_memory_ssa::analyze_observer_expression_in_context(
+            &mut analysis_context,
+            expression,
+            &function_cache,
+        )
     }));
     let function_analyses = if collect_coverage {
         all_function_analyses

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -60,16 +60,23 @@ impl BitPartition {
         self.ranges.get(&key).map(|v| v.as_slice()).unwrap_or(&[])
     }
 
-    fn wildcard_key(&self, region: Region<VarId>) -> Option<NodeKey> {
+    fn wildcard_keys(&self, region: Region<VarId>) -> Vec<NodeKey> {
         self.wildcards
-            .binary_search(&region)
-            .ok()
-            .and_then(|index| match region {
-                Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
-                    Some((object, UNKNOWN_REGION_INDEX, index))
+            .iter()
+            .copied()
+            .enumerate()
+            .filter_map(|(index, wildcard)| {
+                if !region.may_alias(wildcard) {
+                    return None;
                 }
-                Region::Exact { .. } | Region::UnknownAll => None,
+                match wildcard {
+                    Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
+                        Some((object, UNKNOWN_REGION_INDEX, index))
+                    }
+                    Region::Exact { .. } | Region::UnknownAll => None,
+                }
             })
+            .collect()
     }
 }
 
@@ -784,9 +791,7 @@ fn region_node_keys(
             .collect(),
         Region::UnknownAll => return Vec::new(),
     };
-    if let Some(wildcard) = bit_part.wildcard_key(region) {
-        keys.push(wildcard);
-    }
+    keys.extend(bit_part.wildcard_keys(region));
     keys.sort_unstable();
     keys.dedup();
     keys

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -3403,6 +3403,35 @@ mod memory_ssa_tests {
     }
 
     #[test]
+    fn periodic_symbolic_node_lookup_scales_with_region_count() {
+        // Why this case exists: every symbolic periodic region already has a
+        // stable sorted identity. Resolving P such regions must not linearly
+        // scan the P-entry table for each lookup.
+        let object = VarId::from_raw(0);
+        let periodic_regions = (0..8192)
+            .map(|start| PeriodicRegion {
+                object,
+                output: Span { start, length: 1 },
+                axes: vec![PeriodicAxis {
+                    repetitions: 2,
+                    destination_stride: 8192,
+                }],
+            })
+            .collect::<Vec<_>>();
+        let bit_part = BitPartition {
+            periodic_regions: periodic_regions.clone(),
+            ..BitPartition::default()
+        };
+        let variables = HashMap::default();
+        for (index, periodic) in periodic_regions.into_iter().enumerate() {
+            assert_eq!(
+                periodic_region_node_keys(periodic, &variables, &bit_part),
+                vec![(object, PERIODIC_REGION_INDEX, index)]
+            );
+        }
+    }
+
+    #[test]
     fn diagnostic_witness_uses_one_short_real_cycle_from_a_larger_scc() {
         // Why this case exists: a maximal SCC can contain both a short cycle
         // and a longer return path. Once the source-level anchor is selected,

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1962,7 +1962,7 @@ fn is_pure_input_or_output(id: VarId, vars: &HashMap<VarId, Variable>, want: Dir
 }
 
 fn check_graph(module: &Module, graph: &Graph<NodeKey, bool>, errors: &mut Vec<AnalyzerError>) {
-    let sccs = tarjan_scc(graph);
+    let sccs = strongly_connected_components(graph);
     let mut reported: HashSet<Vec<NodeKey>> = HashSet::default();
     for scc in sccs {
         let is_loop = scc.len() > 1 || (scc.len() == 1 && has_self_edge(graph, scc[0]));
@@ -1978,6 +1978,10 @@ fn check_graph(module: &Module, graph: &Graph<NodeKey, bool>, errors: &mut Vec<A
             errors.push(error);
         }
     }
+}
+
+fn strongly_connected_components(graph: &Graph<NodeKey, bool>) -> Vec<Vec<NodeIndex>> {
+    tarjan_scc(graph)
 }
 
 fn ensure_node(
@@ -2284,6 +2288,26 @@ mod memory_ssa_tests {
         let (order, affected) = order_from_dependencies(&is_module, &deps, &rev_deps);
         assert_eq!(order, vec![1, 3, 0, 2]);
         assert_eq!(affected, set(&[0, 2]));
+    }
+
+    #[test]
+    fn scc_handles_a_deep_valid_chain_without_recursion() {
+        // Why this case exists: a valid 25,600-node acyclic dependency chain
+        // overflowed the process stack in petgraph's recursive Tarjan DFS.
+        // SCC discovery must use heap-backed worklists regardless of graph
+        // depth; every node in this chain is its own component.
+        let count = 25_600usize;
+        let mut graph = Graph::<NodeKey, bool>::new();
+        let nodes = (0..count)
+            .map(|index| graph.add_node((VarId::from_raw(index as u32), 0, 0)))
+            .collect::<Vec<_>>();
+        for pair in nodes.windows(2) {
+            graph.add_edge(pair[0], pair[1], false);
+        }
+
+        let components = strongly_connected_components(&graph);
+        assert_eq!(components.len(), count);
+        assert!(components.iter().all(|component| component.len() == 1));
     }
 
     #[test]

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -1,10 +1,14 @@
 //! Region-sensitive combinational loop detection on the analyzer IR (issue
 //! #931).
 //!
+//! The user-visible acceptance bounds are specified in
+//! `crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md`. This module documents the
+//! current implementation within those bounds.
+//!
 //! # Problem model
 //!
-//! This analysis decides whether the elaborated design contains a cycle of
-//! **structural combinational dependencies**. It does not compute Boolean
+//! This implementation finds cycles of **structural combinational
+//! dependencies** in the elaborated design. It does not compute Boolean
 //! functions, prove algebraic cancellation, or reproduce the implicit
 //! sensitivity list of `always_comb`.
 //!
@@ -70,7 +74,7 @@
 //!   nested function calls, module-scope function captures, and side effects in
 //!   instance actual/address expressions.
 //!
-//! Dynamic selects are modeled structurally, not by value-range inference.
+//! This implementation models dynamic selects without value-range inference.
 //! The region is derived from the LRM static prefix and the declared object
 //! shape. Expressions such as `idx`, `~idx`, and `idx * 2` do not receive
 //! special candidate sets. Syntactically corresponding unresolved accesses can

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -13,14 +13,15 @@
 //! sensitivity list of `always_comb`.
 //!
 //! A graph node is an `(object, sparse region)` pair rather than a whole
-//! variable or one node per bit. A directed edge `A -> B` means that a proven
-//! value, control, or address dependency can make a write to region `B`
-//! structurally depend on region `A`. A self-edge or a multi-node strongly
+//! variable or one node per bit. A directed edge `A -> B` means that the
+//! selected structural model makes a write to region `B` value-, control-, or
+//! address-dependent on region `A`. A self-edge or a multi-node strongly
 //! connected component is therefore a combinational loop. Position-preserving
 //! operations retain an `aligned` edge so that, for example, `dst[0] = src[0]`
 //! does not imply a dependency between every bit of `dst` and every bit of
 //! `src`. Operations without a positional transfer conservatively connect the
-//! observed source and destination atoms all-to-all.
+//! observed source and destination atoms all-to-all, as permitted by the
+//! acceptance contract.
 //!
 //! Previous-value retention is deliberately not represented as a dependency
 //! edge. A conditional or partial write can leave a MemorySSA entry definition
@@ -91,7 +92,7 @@
 //! diagnostic, and their presence does not erase unrelated proven edges from
 //! the same procedure or module.
 //!
-//! [`check`] returns only proven loop errors for compatibility.
+//! [`check`] returns only hard loop errors for compatibility.
 //! [`check_detailed`] additionally exposes per-module incomplete reasons. The
 //! important incomplete boundaries are:
 //!

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -80,7 +80,9 @@
 //! shape. Expressions such as `idx`, `~idx`, and `idx * 2` do not receive
 //! special candidate sets. Syntactically corresponding unresolved accesses can
 //! be promoted to must-alias only when MemorySSA proves that their selector
-//! reads observe the same SSA versions; otherwise they remain uncertain.
+//! reads observe the same SSA versions; otherwise they retain a conservative
+//! bounded region. A bounded dynamic region is complete even though its exact
+//! selected element remains uncertain.
 //!
 //! # Conservative fallbacks and incomplete results
 //!

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -16,8 +16,8 @@ use crate::conv::Context;
 use crate::ir::VarId;
 use crate::ir::{
     AssignDestination, AssignStatement, CaseStatement, Component, Declaration, Expression, Factor,
-    ForBound, ForRange, ForStatement, FunctionCall, IfStatement, InstDeclaration, Ir, Module,
-    Statement, VarIndex, VarSelect, Variable,
+    ForBound, ForRange, ForStatement, FunctionCall, IfStatement, InstDeclaration, Ir, Module, Op,
+    Statement, SystemFunctionKind, VarIndex, VarSelect, Variable,
 };
 use crate::symbol::{Affiliation, Direction};
 use crate::value::ValueBigUint;
@@ -25,7 +25,13 @@ use daggy::petgraph::Graph;
 use daggy::petgraph::algo::tarjan_scc;
 use daggy::petgraph::graph::NodeIndex;
 use daggy::petgraph::visit::EdgeRef;
+#[cfg(not(target_family = "wasm"))]
+use rayon::prelude::*;
+use std::collections::BTreeSet;
 use std::collections::VecDeque;
+use veryl_causal::graph::{EdgeKind, IncompleteReason};
+use veryl_causal::procedure::ProcedureSummary;
+use veryl_causal::region::{Region, Span};
 use veryl_parser::resource_table::StrId;
 
 /// `FfTable` / `per_decl_refs` granularity. Bit-precision lives in masks.
@@ -34,6 +40,10 @@ type IdxKey = (VarId, usize);
 /// `(VarId, array_idx, range_idx)`. `range_idx` indexes the variable's
 /// `BitPartition`, so bit-disjoint reads/writes form disjoint nodes.
 type NodeKey = (VarId, usize, usize);
+
+/// Sparse alias node for a dynamically selected region of one object.  This
+/// deliberately occupies no real array element or bit-partition slot.
+const UNKNOWN_REGION_INDEX: usize = usize::MAX;
 
 /// Per `IdxKey`, atomic bit-range masks. Two bits are in the same range
 /// iff they appear in the same set of per-decl masks.
@@ -59,38 +69,77 @@ impl BitPartition {
     }
 }
 
-/// `feedthrough[child_in_id] = { child_out_ids reachable purely combinationally }`.
-/// Port-level only -- the parent keeps bit precision via `BitPartition`.
-#[derive(Clone, Debug, Default)]
-struct ModuleCombSummary {
-    feedthrough: HashMap<VarId, HashSet<VarId>>,
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ModuleCombDependency {
+    input: Region<VarId>,
+    output: Region<VarId>,
 }
 
+/// Region-preserving combinational feedthrough across one module boundary.
+#[derive(Clone, Debug, Default)]
+struct ModuleCombSummary {
+    dependencies: Vec<ModuleCombDependency>,
+}
+
+/// Compatibility entry point: emit only proven loop diagnostics. Tools which
+/// need to surface analysis coverage must call [`check_detailed`].
 pub fn check(ir: &Ir) -> Vec<AnalyzerError> {
+    check_detailed(ir).errors
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IncompleteCombAnalysis {
+    pub module: String,
+    pub reasons: BTreeSet<IncompleteReason>,
+}
+
+#[derive(Debug, Default)]
+pub struct CombAnalysisResult {
+    pub errors: Vec<AnalyzerError>,
+    pub incomplete: Vec<IncompleteCombAnalysis>,
+}
+
+/// Run loop detection while retaining uncertainty which must not be promoted
+/// to a hard combinational-loop diagnostic.
+pub fn check_detailed(ir: &Ir) -> CombAnalysisResult {
     let mut errors = Vec::new();
+    let mut incomplete = Vec::new();
     let mut summaries: HashMap<StrId, ModuleCombSummary> = HashMap::default();
 
-    let order = topo_order_modules(ir);
+    let (order, recursive_modules) = topo_order_modules(ir);
 
     for &idx in &order {
         if let Component::Module(module) = &ir.components[idx] {
             // Unevaluable generic params -> empty per_decl_refs.
             if module.suppress_unassigned {
+                incomplete.push(IncompleteCombAnalysis {
+                    module: module.name.to_string(),
+                    reasons: [IncompleteReason::UnsupportedSyntax].into(),
+                });
                 continue;
             }
-            let graph = build_module_graph(module, &summaries);
+            let (graph, mut reasons, bit_part) = build_module_graph(module, &summaries);
+            if recursive_modules {
+                reasons.insert(IncompleteReason::RecursiveCall);
+            }
             check_graph(module, &graph, &mut errors);
-            let summary = compute_module_summary(module, &graph);
+            let summary = compute_module_summary(module, &graph, &bit_part);
             summaries.insert(module.name, summary);
+            if !reasons.is_empty() {
+                incomplete.push(IncompleteCombAnalysis {
+                    module: module.name.to_string(),
+                    reasons,
+                });
+            }
         }
     }
 
-    errors
+    CombAnalysisResult { errors, incomplete }
 }
 
 /// Children before parents. Falls back to input order on cycle
 /// (`infinite_recursion` is reported separately).
-fn topo_order_modules(ir: &Ir) -> Vec<usize> {
+fn topo_order_modules(ir: &Ir) -> (Vec<usize>, bool) {
     let mut name_to_idx: HashMap<StrId, usize> = HashMap::default();
     for (i, c) in ir.components.iter().enumerate() {
         if let Component::Module(m) = c {
@@ -141,11 +190,14 @@ fn topo_order_modules(ir: &Ir) -> Vec<usize> {
             .count()
     {
         // Cycle in module graph -- emit imprecise reports anyway.
-        return (0..n)
-            .filter(|i| matches!(ir.components.get(*i), Some(Component::Module(_))))
-            .collect();
+        return (
+            (0..n)
+                .filter(|i| matches!(ir.components.get(*i), Some(Component::Module(_))))
+                .collect(),
+            true,
+        );
     }
-    order
+    (order, false)
 }
 
 fn walk_insts(module: &Module) -> impl Iterator<Item = &InstDeclaration> {
@@ -158,12 +210,44 @@ fn walk_insts(module: &Module) -> impl Iterator<Item = &InstDeclaration> {
 /// Group bits into atomic ranges by signature: bits with the same set
 /// of containing masks form one range. Bits in zero masks are dropped.
 fn atomic_ranges(masks: &[BigUint], width: usize) -> Vec<BigUint> {
+    // Split only at mask transitions. The previous implementation visited
+    // every declared bit and built a signature BigUint for it, making a sparse
+    // access to a million-bit object take O(width * accesses). Here the work is
+    // O(mask limbs + transitions * accesses), independent of untouched spans.
+    let mut endpoints = BTreeSet::new();
+    endpoints.insert(0usize);
+    endpoints.insert(width);
+    for mask in masks {
+        let digits = mask.iter_u64_digits().collect::<Vec<_>>();
+        let mut previous_bit = false;
+        for word_index in 0..=digits.len() {
+            let word = digits.get(word_index).copied().unwrap_or(0);
+            let shifted = word.wrapping_shl(1) | u64::from(previous_bit);
+            let mut transitions = word ^ shifted;
+            while transitions != 0 {
+                let bit = transitions.trailing_zeros() as usize;
+                let endpoint = word_index.saturating_mul(64).saturating_add(bit);
+                if endpoint <= width {
+                    endpoints.insert(endpoint);
+                }
+                transitions &= transitions - 1;
+            }
+            previous_bit = word >> 63 != 0;
+        }
+    }
+
     let mut by_sig: HashMap<BigUint, BigUint> = HashMap::default();
     let one = BigUint::from(1u32);
-    for b in 0..width {
+    let endpoints = endpoints.into_iter().collect::<Vec<_>>();
+    for window in endpoints.windows(2) {
+        let start = window[0];
+        let end = window[1];
+        if start >= end {
+            continue;
+        }
         let mut sig = BigUint::default();
         for (i, m) in masks.iter().enumerate() {
-            if m.bit(b as u64) {
+            if m.bit(start as u64) {
                 sig |= &one << i;
             }
         }
@@ -171,7 +255,7 @@ fn atomic_ranges(masks: &[BigUint], width: usize) -> Vec<BigUint> {
             continue;
         }
         let entry = by_sig.entry(sig).or_default();
-        *entry |= &one << b;
+        *entry |= ValueBigUint::gen_mask_range(end - 1, start);
     }
     let mut ret: Vec<BigUint> = by_sig.into_values().collect();
     // Stable order by lowest set bit so NodeKey range_idx is deterministic.
@@ -192,7 +276,11 @@ fn oversized_array(id: VarId, variables: &HashMap<VarId, Variable>) -> bool {
         .is_some_and(|n| n > OVERSIZED_ARRAY)
 }
 
-fn build_bit_partition(module: &Module, ctx: &mut Context) -> BitPartition {
+fn build_bit_partition(
+    module: &Module,
+    ctx: &mut Context,
+    memory_ssa_regions: &[Region<VarId>],
+) -> BitPartition {
     let mut masks: HashMap<(VarId, usize), Vec<BigUint>> = HashMap::default();
 
     // Intra-module reads / writes captured during eval_assign.
@@ -259,6 +347,15 @@ fn build_bit_partition(module: &Module, ctx: &mut Context) -> BitPartition {
         }
     }
 
+    // MemorySSA can discover finer positional boundaries than the legacy
+    // read/write masks.  A shifted copy, for example, propagates every
+    // observed endpoint through the copy relation.  Feed those sparse spans
+    // back into the shared partition so distinct causal atoms do not collapse
+    // into a spurious self-edge.
+    for &region in memory_ssa_regions {
+        collect_region_mask(region, module, &mut masks);
+    }
+
     let mut ranges: HashMap<(VarId, usize), Vec<BigUint>> = HashMap::default();
     for (key, ms) in masks {
         let width = module
@@ -273,6 +370,38 @@ fn build_bit_partition(module: &Module, ctx: &mut Context) -> BitPartition {
     }
 
     BitPartition { ranges }
+}
+
+fn collect_region_mask(
+    region: Region<VarId>,
+    module: &Module,
+    masks: &mut HashMap<(VarId, usize), Vec<BigUint>>,
+) {
+    let Region::Exact { object, span } = region else {
+        return;
+    };
+    let Some(width) = module
+        .variables
+        .get(&object)
+        .and_then(Variable::total_width)
+    else {
+        return;
+    };
+    let Some(end) = span.end() else {
+        return;
+    };
+    let mut cursor = span.start;
+    while cursor < end {
+        let element = cursor / width;
+        let bit_start = cursor % width;
+        let element_end = end.min((element + 1).saturating_mul(width));
+        let bit_end = element_end - element * width;
+        masks
+            .entry((object, element))
+            .or_default()
+            .push(ValueBigUint::gen_mask_range(bit_end - 1, bit_start));
+        cursor = element_end;
+    }
 }
 
 fn collect_expr_masks(
@@ -350,19 +479,84 @@ fn eval_dst_mask(
 fn build_module_graph(
     module: &Module,
     summaries: &HashMap<StrId, ModuleCombSummary>,
-) -> Graph<NodeKey, ()> {
+) -> (Graph<NodeKey, ()>, BTreeSet<IncompleteReason>, BitPartition) {
     let ff_table = &module.ff_table;
     let union_writes = compute_union_writes(&module.per_decl_refs);
     let writes_per_decl = compute_writes_per_decl(&module.per_decl_refs);
     let undom_per_decl = compute_undominated_per_decl(module);
 
+    // Procedural combinational declarations use statement-ordered region
+    // MemorySSA. Keep instance declarations on the existing bottom-up module
+    // summary path until the same region vocabulary crosses module boundaries.
+    let analyze_declaration = |declaration: &Declaration| match declaration {
+        Declaration::Comb(comb) => Some(crate::comb_memory_ssa::analyze(module, comb)),
+        _ => None,
+    };
+    #[cfg(not(target_family = "wasm"))]
+    let procedure_summaries = module
+        .declarations
+        .par_iter()
+        .filter_map(analyze_declaration)
+        .collect::<Vec<_>>();
+
+    let mut partition_regions = procedure_summaries
+        .iter()
+        .filter_map(|result| result.as_ref().ok())
+        .flat_map(|summary| &summary.dependencies)
+        .flat_map(|dependency| [dependency.input, dependency.output])
+        .collect::<Vec<_>>();
     let mut ctx = Context::default();
     ctx.variables = module.variables.clone();
     ctx.functions = module.functions.clone();
-    let bit_part = build_bit_partition(module, &mut ctx);
+    partition_regions.extend(collect_instance_summary_regions(
+        module, summaries, &mut ctx,
+    ));
+    let bit_part = build_bit_partition(module, &mut ctx, &partition_regions);
 
     let mut graph: Graph<NodeKey, ()> = Graph::new();
     let mut node_map: HashMap<NodeKey, NodeIndex> = HashMap::default();
+    let mut incomplete = BTreeSet::new();
+
+    if module
+        .variables
+        .values()
+        .any(|variable| matches!(variable.kind, crate::ir::VarKind::Inout))
+    {
+        incomplete.insert(IncompleteReason::InoutPort);
+    }
+
+    for declaration in &module.declarations {
+        match declaration {
+            Declaration::External(_) => {
+                incomplete.insert(IncompleteReason::ExternalComponent);
+            }
+            Declaration::Unsupported(_) => {
+                incomplete.insert(IncompleteReason::UnsupportedSyntax);
+            }
+            _ => {}
+        }
+    }
+    #[cfg(target_family = "wasm")]
+    let procedure_summaries = module
+        .declarations
+        .iter()
+        .filter_map(analyze_declaration)
+        .collect::<Vec<_>>();
+    for result in &procedure_summaries {
+        match result {
+            Ok(summary) => {
+                incomplete.extend(summary.incomplete.iter().copied());
+                add_memory_ssa_edges(module, summary, &bit_part, &mut graph, &mut node_map);
+            }
+            Err(error) => {
+                incomplete.insert(IncompleteReason::UnsupportedSyntax);
+                log::debug!(
+                    "failed to build comb MemorySSA for {}: {error}",
+                    module.name
+                );
+            }
+        }
+    }
 
     for ((src_id, src_idx), entry) in &ff_table.table {
         if entry.is_ff {
@@ -379,6 +573,12 @@ fn build_module_graph(
 
         for (reader_decl, assign_target, src_read_mask, from_ff) in &entry.refered {
             if *from_ff {
+                continue;
+            }
+            if matches!(
+                module.declarations.get(*reader_decl),
+                Some(Declaration::Comb(_))
+            ) {
                 continue;
             }
             // `decl_read_mask == 0` also filters out reads gathered by
@@ -507,6 +707,13 @@ fn build_module_graph(
     for inst in walk_insts(module) {
         match inst.component.as_ref() {
             Component::Module(child) => {
+                if child
+                    .variables
+                    .values()
+                    .any(|variable| matches!(variable.kind, crate::ir::VarKind::Inout))
+                {
+                    incomplete.insert(IncompleteReason::InoutPort);
+                }
                 let Some(summary) = summaries.get(&child.name) else {
                     continue;
                 };
@@ -518,17 +725,149 @@ fn build_module_graph(
                     &mut graph,
                     &mut node_map,
                     &module.variables,
+                    &mut incomplete,
                     &mut ctx,
                 );
             }
             // SV black box: under-detect.
-            Component::SystemVerilog(_) => {}
+            Component::SystemVerilog(_) => {
+                incomplete.insert(IncompleteReason::ExternalComponent);
+            }
             // Interface signals are already lifted into the parent.
             Component::Interface(_) => {}
         }
     }
 
-    graph
+    (graph, incomplete, bit_part)
+}
+
+fn add_memory_ssa_edges(
+    module: &Module,
+    summary: &ProcedureSummary<VarId>,
+    bit_part: &BitPartition,
+    graph: &mut Graph<NodeKey, ()>,
+    node_map: &mut HashMap<NodeKey, NodeIndex>,
+) {
+    // Unknown control/effects invalidate a whole procedure. Dynamic regions
+    // are narrower: they invalidate only their owning objects, so a dynamic
+    // memory write cannot hide an unrelated scalar loop.
+    if summary.unknown_all
+        || summary
+            .incomplete
+            .iter()
+            .any(|reason| *reason != IncompleteReason::DynamicRegion)
+    {
+        return;
+    }
+    for dependency in &summary.dependencies {
+        if dependency.kind == EdgeKind::Unknown {
+            continue;
+        }
+        let sources = region_node_keys(dependency.input, &module.variables, bit_part);
+        let destinations = region_node_keys(dependency.output, &module.variables, bit_part);
+        for source in &sources {
+            if !is_module_scope_var(source.0, &module.variables) {
+                continue;
+            }
+            for destination in &destinations {
+                if !is_module_scope_var(destination.0, &module.variables) {
+                    continue;
+                }
+                let source = ensure_node(graph, node_map, *source);
+                let destination = ensure_node(graph, node_map, *destination);
+                graph.add_edge(source, destination, ());
+            }
+        }
+    }
+}
+
+/// Convert the MemorySSA engine's flattened, half-open bit region back to the
+/// legacy graph's `(array element, bit partition)` coordinates. The loop is
+/// proportional to touched elements, never to the declared array size.
+fn region_node_keys(
+    region: Region<VarId>,
+    variables: &HashMap<VarId, Variable>,
+    bit_part: &BitPartition,
+) -> Vec<NodeKey> {
+    let (object, span) = match region {
+        Region::Exact { object, span } => (object, span),
+        Region::UnknownObject(object) => {
+            return vec![(object, UNKNOWN_REGION_INDEX, UNKNOWN_REGION_INDEX)];
+        }
+        Region::UnknownAll => return Vec::new(),
+    };
+    let Some(width) = variables.get(&object).and_then(Variable::total_width) else {
+        return Vec::new();
+    };
+    let Some(end) = span.end() else {
+        return Vec::new();
+    };
+    let mut keys = Vec::new();
+    let mut cursor = span.start;
+    while cursor < end {
+        let element = cursor / width;
+        let bit_start = cursor % width;
+        let element_end = end.min((element + 1).saturating_mul(width));
+        let bit_end = element_end - element * width;
+        let mask = ValueBigUint::gen_mask_range(bit_end - 1, bit_start);
+        keys.extend(
+            bit_part
+                .overlapping((object, element), &mask)
+                .into_iter()
+                .map(|range| (object, element, range)),
+        );
+        cursor = element_end;
+    }
+    keys
+}
+
+fn collect_instance_summary_regions(
+    module: &Module,
+    summaries: &HashMap<StrId, ModuleCombSummary>,
+    ctx: &mut Context,
+) -> Vec<Region<VarId>> {
+    let mut regions = Vec::new();
+    for inst in walk_insts(module) {
+        let Component::Module(child) = inst.component.as_ref() else {
+            continue;
+        };
+        let Some(summary) = summaries.get(&child.name) else {
+            continue;
+        };
+        for dependency in &summary.dependencies {
+            let Region::Exact {
+                object: child_input,
+                span: input_span,
+            } = dependency.input
+            else {
+                continue;
+            };
+            let Region::Exact {
+                object: child_output,
+                span: output_span,
+            } = dependency.output
+            else {
+                continue;
+            };
+            let Some(input) = inst.inputs.iter().find(|input| input.id == child_input) else {
+                continue;
+            };
+            let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
+                continue;
+            };
+            if let Some(mapped) =
+                map_expression_span_to_regions(&input.expr, input_span, &module.variables, ctx)
+            {
+                regions.extend(mapped);
+            }
+            if let Some(mapped) =
+                map_destinations_span_to_regions(&output.dst, output_span, &module.variables, ctx)
+            {
+                regions.extend(mapped);
+            }
+        }
+    }
+    regions
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -540,54 +879,208 @@ fn add_inst_feedthrough_edges(
     graph: &mut Graph<NodeKey, ()>,
     node_map: &mut HashMap<NodeKey, NodeIndex>,
     parent_vars: &HashMap<VarId, Variable>,
+    incomplete: &mut BTreeSet<IncompleteReason>,
     ctx: &mut Context,
 ) {
-    let mut input_reads: HashMap<VarId, Vec<NodeKey>> = HashMap::default();
-    for inp in &inst.inputs {
-        if !is_pure_input_or_output(inp.id, &child.variables, Direction::Input) {
-            continue;
-        }
-        let mut reads = Vec::new();
-        collect_expr_node_keys(&inp.expr, bit_part, &mut reads, ctx);
-        if !reads.is_empty() {
-            input_reads.insert(inp.id, reads);
-        }
-    }
-
-    let mut output_dsts: HashMap<VarId, Vec<NodeKey>> = HashMap::default();
-    for out in &inst.outputs {
-        if !is_pure_input_or_output(out.id, &child.variables, Direction::Output) {
-            continue;
-        }
-        let mut keys = Vec::new();
-        for dst in &out.dst {
-            collect_dst_node_keys(dst, bit_part, &mut keys, parent_vars, ctx);
-        }
-        if !keys.is_empty() {
-            output_dsts.insert(out.id, keys);
-        }
-    }
-
-    for (child_in_id, out_set) in &summary.feedthrough {
-        let Some(parent_reads) = input_reads.get(child_in_id) else {
+    for dependency in &summary.dependencies {
+        let Region::Exact {
+            object: child_input,
+            span: input_span,
+        } = dependency.input
+        else {
             continue;
         };
-        for child_out_id in out_set {
-            let Some(parent_dsts) = output_dsts.get(child_out_id) else {
-                continue;
-            };
-            for r in parent_reads {
-                for d in parent_dsts {
-                    if r == d {
-                        continue;
+        let Region::Exact {
+            object: child_output,
+            span: output_span,
+        } = dependency.output
+        else {
+            continue;
+        };
+        if !is_pure_input_or_output(child_input, &child.variables, Direction::Input)
+            || !is_pure_input_or_output(child_output, &child.variables, Direction::Output)
+        {
+            continue;
+        }
+        let Some(input) = inst.inputs.iter().find(|input| input.id == child_input) else {
+            continue;
+        };
+        let Some(output) = inst.outputs.iter().find(|output| output.id == child_output) else {
+            continue;
+        };
+        let Some(parent_input_regions) =
+            map_expression_span_to_regions(&input.expr, input_span, parent_vars, ctx)
+        else {
+            incomplete.insert(IncompleteReason::UnsupportedSyntax);
+            continue;
+        };
+        let Some(parent_output_regions) =
+            map_destinations_span_to_regions(&output.dst, output_span, parent_vars, ctx)
+        else {
+            incomplete.insert(IncompleteReason::UnsupportedSyntax);
+            continue;
+        };
+        for input_region in parent_input_regions {
+            for source in region_node_keys(input_region, parent_vars, bit_part) {
+                for &output_region in &parent_output_regions {
+                    for destination in region_node_keys(output_region, parent_vars, bit_part) {
+                        let source = ensure_node(graph, node_map, source);
+                        let destination = ensure_node(graph, node_map, destination);
+                        graph.add_edge(source, destination, ());
                     }
-                    let s = ensure_node(graph, node_map, *r);
-                    let t = ensure_node(graph, node_map, *d);
-                    graph.add_edge(s, t, ());
                 }
             }
         }
     }
+}
+
+fn map_expression_span_to_regions(
+    expression: &Expression,
+    requested: Span,
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Option<Vec<Region<VarId>>> {
+    if requested.end()? > expression.comptime().r#type.total_width()? {
+        return None;
+    }
+    match expression {
+        Expression::Term(factor) => match factor.as_ref() {
+            Factor::Variable(id, index, select, _) => {
+                let Region::Exact { object, span } =
+                    exact_variable_region(*id, index, select, variables, ctx)?
+                else {
+                    return None;
+                };
+                if requested.end()? > span.length {
+                    return None;
+                }
+                Some(vec![Region::Exact {
+                    object,
+                    span: Span {
+                        start: span.start.checked_add(requested.start)?,
+                        length: requested.length,
+                    },
+                }])
+            }
+            Factor::Value(_) => Some(Vec::new()),
+            Factor::SystemFunctionCall(call) => match &call.kind {
+                SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
+                    map_expression_span_to_regions(&input.0, requested, variables, ctx)
+                }
+                _ => None,
+            },
+            _ => None,
+        },
+        Expression::Concatenation(parts, _) => {
+            let mut low = 0usize;
+            let mut mapped = Vec::new();
+            for (part, repeat) in parts.iter().rev() {
+                if repeat.is_some() {
+                    return None;
+                }
+                let width = part.comptime().r#type.total_width()?;
+                let part_span = Span {
+                    start: low,
+                    length: width,
+                };
+                if let Some(overlap) = requested.intersection(part_span) {
+                    mapped.extend(map_expression_span_to_regions(
+                        part,
+                        Span {
+                            start: overlap.start.checked_sub(low)?,
+                            length: overlap.length,
+                        },
+                        variables,
+                        ctx,
+                    )?);
+                }
+                low = low.checked_add(width)?;
+            }
+            Some(mapped)
+        }
+        Expression::Unary(op, operand, _)
+            if matches!(op, Op::BitNot | Op::Add)
+                && operand.comptime().r#type.total_width()?
+                    == expression.comptime().r#type.total_width()? =>
+        {
+            map_expression_span_to_regions(operand, requested, variables, ctx)
+        }
+        Expression::Binary(left, op, right, _)
+            if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
+                && left.comptime().r#type.total_width()?
+                    == expression.comptime().r#type.total_width()?
+                && right.comptime().r#type.total_width()?
+                    == expression.comptime().r#type.total_width()? =>
+        {
+            let mut mapped = map_expression_span_to_regions(left, requested, variables, ctx)?;
+            mapped.extend(map_expression_span_to_regions(
+                right, requested, variables, ctx,
+            )?);
+            Some(mapped)
+        }
+        _ => None,
+    }
+}
+
+fn map_destinations_span_to_regions(
+    destinations: &[AssignDestination],
+    requested: Span,
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Option<Vec<Region<VarId>>> {
+    let mut low = 0usize;
+    let mut mapped = Vec::new();
+    for destination in destinations.iter().rev() {
+        let Region::Exact { object, span } = exact_variable_region(
+            destination.id,
+            &destination.index,
+            &destination.select,
+            variables,
+            ctx,
+        )?
+        else {
+            return None;
+        };
+        let destination_span = Span {
+            start: low,
+            length: span.length,
+        };
+        if let Some(overlap) = requested.intersection(destination_span) {
+            mapped.push(Region::Exact {
+                object,
+                span: Span {
+                    start: span.start.checked_add(overlap.start.checked_sub(low)?)?,
+                    length: overlap.length,
+                },
+            });
+        }
+        low = low.checked_add(span.length)?;
+    }
+    (requested.end()? <= low).then_some(mapped)
+}
+
+fn exact_variable_region(
+    id: VarId,
+    index: &VarIndex,
+    select: &VarSelect,
+    variables: &HashMap<VarId, Variable>,
+    ctx: &mut Context,
+) -> Option<Region<VarId>> {
+    if !index.is_const() || !select.is_const_with_range() {
+        return None;
+    }
+    let variable = variables.get(&id)?;
+    let width = variable.total_width()?;
+    let index_path = index.eval_value(ctx)?;
+    let array_index = variable.r#type.array.calc_index(&index_path)?;
+    let (high, low) = select.eval_value(ctx, &variable.r#type, false)?;
+    Some(Region::Exact {
+        object: id,
+        span: Span {
+            start: array_index.checked_mul(width)?.checked_add(low)?,
+            length: high.checked_sub(low)?.checked_add(1)?,
+        },
+    })
 }
 
 fn is_pure_input_or_output(id: VarId, vars: &HashMap<VarId, Variable>, want: Direction) -> bool {
@@ -599,77 +1092,6 @@ fn is_pure_input_or_output(id: VarId, vars: &HashMap<VarId, Variable>, want: Dir
         _ => return false,
     };
     actual == want
-}
-
-fn collect_expr_node_keys(
-    expr: &Expression,
-    bit_part: &BitPartition,
-    out: &mut Vec<NodeKey>,
-    ctx: &mut Context,
-) {
-    match expr {
-        Expression::Term(t) => collect_factor_node_keys(t, bit_part, out, ctx),
-        Expression::Unary(_, e, _) => collect_expr_node_keys(e, bit_part, out, ctx),
-        Expression::Binary(a, _, b, _) => {
-            collect_expr_node_keys(a, bit_part, out, ctx);
-            collect_expr_node_keys(b, bit_part, out, ctx);
-        }
-        Expression::Ternary(a, b, c, _) => {
-            collect_expr_node_keys(a, bit_part, out, ctx);
-            collect_expr_node_keys(b, bit_part, out, ctx);
-            collect_expr_node_keys(c, bit_part, out, ctx);
-        }
-        Expression::Concatenation(parts, _) => {
-            for (a, b) in parts {
-                collect_expr_node_keys(a, bit_part, out, ctx);
-                if let Some(b) = b {
-                    collect_expr_node_keys(b, bit_part, out, ctx);
-                }
-            }
-        }
-        Expression::StructConstructor(_, fields, _) => {
-            for (_, e) in fields {
-                collect_expr_node_keys(e, bit_part, out, ctx);
-            }
-        }
-        Expression::ArrayLiteral(_, _) => {}
-    }
-}
-
-fn collect_factor_node_keys(
-    factor: &Factor,
-    bit_part: &BitPartition,
-    out: &mut Vec<NodeKey>,
-    ctx: &mut Context,
-) {
-    match factor {
-        Factor::Variable(id, index, select, _) => {
-            for (idx, mask) in var_reads(*id, index, select, ctx) {
-                for r in bit_part.overlapping((*id, idx), &mask) {
-                    out.push((*id, idx, r));
-                }
-            }
-        }
-        Factor::FunctionCall(_) | Factor::SystemFunctionCall(_) => {
-            // No caller LHS at an inst input -- under-detect.
-        }
-        _ => {}
-    }
-}
-
-fn collect_dst_node_keys(
-    dst: &AssignDestination,
-    bit_part: &BitPartition,
-    out: &mut Vec<NodeKey>,
-    parent_vars: &HashMap<VarId, Variable>,
-    ctx: &mut Context,
-) {
-    let Some((idx, mask)) = eval_dst_mask(dst, parent_vars, ctx) else {
-        return;
-    };
-    for r in bit_part.overlapping((dst.id, idx), &mask) {
-        out.push((dst.id, idx, r));
-    }
 }
 
 fn check_graph(module: &Module, graph: &Graph<NodeKey, ()>, errors: &mut Vec<AnalyzerError>) {
@@ -807,7 +1229,11 @@ fn is_module_scope_var(id: VarId, variables: &HashMap<VarId, Variable>) -> bool 
     }
 }
 
-fn compute_module_summary(module: &Module, graph: &Graph<NodeKey, ()>) -> ModuleCombSummary {
+fn compute_module_summary(
+    module: &Module,
+    graph: &Graph<NodeKey, ()>,
+    bit_part: &BitPartition,
+) -> ModuleCombSummary {
     use crate::ir::VarKind;
 
     let mut input_ids: HashSet<VarId> = HashSet::default();
@@ -824,7 +1250,7 @@ fn compute_module_summary(module: &Module, graph: &Graph<NodeKey, ()>) -> Module
         }
     }
 
-    let mut feedthrough: HashMap<VarId, HashSet<VarId>> = HashMap::default();
+    let mut dependencies = BTreeSet::new();
     let mut visited: HashSet<NodeIndex> = HashSet::default();
     let mut stack: Vec<NodeIndex> = Vec::new();
     for ni in graph.node_indices() {
@@ -841,14 +1267,83 @@ fn compute_module_summary(module: &Module, graph: &Graph<NodeKey, ()>) -> Module
             }
             let nk = graph[n];
             if output_ids.contains(&nk.0) {
-                feedthrough.entry(key.0).or_default().insert(nk.0);
+                for input in node_key_regions(key, module, bit_part) {
+                    for output in node_key_regions(nk, module, bit_part) {
+                        dependencies.insert(ModuleCombDependency { input, output });
+                    }
+                }
             }
             for e in graph.edges(n) {
                 stack.push(e.target());
             }
         }
     }
-    ModuleCombSummary { feedthrough }
+    ModuleCombSummary {
+        dependencies: dependencies.into_iter().collect(),
+    }
+}
+
+fn node_key_regions(key: NodeKey, module: &Module, bit_part: &BitPartition) -> Vec<Region<VarId>> {
+    if key.1 == UNKNOWN_REGION_INDEX || key.2 == UNKNOWN_REGION_INDEX {
+        return Vec::new();
+    }
+    let Some(width) = module.variables.get(&key.0).and_then(Variable::total_width) else {
+        return Vec::new();
+    };
+    let Some(mask) = bit_part.ranges_of((key.0, key.1)).get(key.2) else {
+        return Vec::new();
+    };
+    mask_spans(mask, width)
+        .into_iter()
+        .filter_map(|span| {
+            let start = key.1.checked_mul(width)?.checked_add(span.start)?;
+            Some(Region::Exact {
+                object: key.0,
+                span: Span {
+                    start,
+                    length: span.length,
+                },
+            })
+        })
+        .collect()
+}
+
+fn mask_spans(mask: &BigUint, width: usize) -> Vec<Span> {
+    let digits = mask.iter_u64_digits().collect::<Vec<_>>();
+    let mut spans = Vec::new();
+    let mut start = None;
+    for word_index in 0..=digits.len() {
+        let word = digits.get(word_index).copied().unwrap_or(0);
+        let previous_bit = word_index
+            .checked_sub(1)
+            .and_then(|index| digits.get(index))
+            .is_some_and(|word| word >> 63 != 0);
+        let mut transitions = word ^ (word.wrapping_shl(1) | u64::from(previous_bit));
+        while transitions != 0 {
+            let bit = transitions.trailing_zeros() as usize;
+            let point = word_index.saturating_mul(64).saturating_add(bit).min(width);
+            if mask.bit(point as u64) {
+                start = Some(point);
+            } else if let Some(span_start) = start.take()
+                && span_start < point
+            {
+                spans.push(Span {
+                    start: span_start,
+                    length: point - span_start,
+                });
+            }
+            transitions &= transitions - 1;
+        }
+    }
+    if let Some(span_start) = start
+        && span_start < width
+    {
+        spans.push(Span {
+            start: span_start,
+            length: width - span_start,
+        });
+    }
+    spans
 }
 
 // Statement-level dominance analysis.
@@ -1139,6 +1634,9 @@ fn dst_writes(dst: &AssignDestination, ctx: &mut Context) -> Vec<(usize, BigUint
 
     let mut out = Vec::new();
     if let Some((beg, end)) = range {
+        if end.saturating_sub(beg) > OVERSIZED_ARRAY {
+            return out;
+        }
         for i in beg..=end {
             out.push((i, mask.clone()));
         }
@@ -1168,7 +1666,63 @@ fn var_reads(
     {
         return vec![(flat, mask)];
     }
-    // Dynamic index: conservatively treat every element as read.
+    // Legacy dominance bridge only: exact comb dependencies are handled by
+    // region MemorySSA. Never expand a dynamic access to a huge array here.
     let total = variable.r#type.total_array().unwrap_or(1);
+    if total > OVERSIZED_ARRAY {
+        return Vec::new();
+    }
     (0..total).map(|i| (i, mask.clone())).collect()
+}
+
+#[cfg(test)]
+mod memory_ssa_tests {
+    use super::*;
+
+    #[test]
+    fn atomic_ranges_split_at_sparse_mask_transitions() {
+        let width = 1_000_000;
+        let low = ValueBigUint::gen_mask_range(15, 8);
+        let high = ValueBigUint::gen_mask_range(width - 9, width - 16);
+        let ranges = atomic_ranges(&[low.clone(), high.clone()], width);
+        assert_eq!(ranges.len(), 2);
+        assert!(ranges.contains(&low));
+        assert!(ranges.contains(&high));
+    }
+
+    #[test]
+    fn atomic_ranges_preserve_shared_and_disjoint_signatures() {
+        let first = ValueBigUint::gen_mask_range(127, 0);
+        let second = ValueBigUint::gen_mask_range(191, 64);
+        let ranges = atomic_ranges(&[first, second], 192);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0], ValueBigUint::gen_mask_range(63, 0));
+        assert_eq!(ranges[1], ValueBigUint::gen_mask_range(127, 64));
+        assert_eq!(ranges[2], ValueBigUint::gen_mask_range(191, 128));
+    }
+
+    #[test]
+    fn module_summary_masks_split_across_word_boundaries() {
+        let mask = ValueBigUint::gen_mask_range(1, 0)
+            | ValueBigUint::gen_mask_range(65, 63)
+            | ValueBigUint::gen_mask_range(127, 127);
+        assert_eq!(
+            mask_spans(&mask, 192),
+            vec![
+                Span {
+                    start: 0,
+                    length: 2,
+                },
+                Span {
+                    start: 63,
+                    length: 3,
+                },
+                Span {
+                    start: 127,
+                    length: 1,
+                },
+            ]
+        );
+        assert!(mask_spans(&BigUint::default(), 192).is_empty());
+    }
 }

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -624,43 +624,47 @@ fn build_bit_partition(
 fn propagate_periodic_partition_regions(
     regions: &[Region<VarId>],
     transfers: &[PeriodicTransferRegion],
-    periodic_regions: &mut Vec<PeriodicRegion>,
+    periodic_regions: &mut BTreeSet<PeriodicRegion>,
 ) {
-    for transfer in transfers.iter().filter(|transfer| transfer.aligned) {
+    let mut regions_by_object = BTreeMap::<VarId, BTreeSet<Span>>::new();
+    for &region in regions {
+        if let Region::Exact { object, span } = region {
+            regions_by_object.entry(object).or_default().insert(span);
+        }
+    }
+    let transfers = transfers
+        .iter()
+        .filter(|transfer| transfer.aligned)
+        .map(|transfer| (transfer.input, transfer.output.clone()))
+        .collect::<BTreeSet<_>>();
+    for (input, output) in transfers {
         let Region::Exact {
             object: input_object,
             span: input_span,
-        } = transfer.input
+        } = input
         else {
             continue;
         };
-        for &region in regions {
-            let Region::Exact {
-                object,
-                span: region_span,
-            } = region
-            else {
-                continue;
-            };
-            if object != input_object {
-                continue;
-            }
+        let Some(object_regions) = regions_by_object.get(&input_object) else {
+            continue;
+        };
+        for &region_span in object_regions {
             let Some(overlap) = region_span.intersection(input_span) else {
                 continue;
             };
             let Some(offset) = overlap.start.checked_sub(input_span.start) else {
                 continue;
             };
-            let Some(start) = transfer.output.output.start.checked_add(offset) else {
+            let Some(start) = output.output.start.checked_add(offset) else {
                 continue;
             };
-            periodic_regions.push(PeriodicRegion {
-                object: transfer.output.object,
+            periodic_regions.insert(PeriodicRegion {
+                object: output.object,
                 output: Span {
                     start,
                     length: overlap.length,
                 },
-                axes: transfer.output.axes.clone(),
+                axes: output.axes.clone(),
             });
         }
     }
@@ -1007,14 +1011,13 @@ fn build_module_graph(
     let mut periodic_regions = periodic_transfers
         .iter()
         .map(|transfer| transfer.output.clone())
-        .collect::<Vec<_>>();
+        .collect::<BTreeSet<_>>();
     propagate_periodic_partition_regions(
         &partition_regions,
         &periodic_transfers,
         &mut periodic_regions,
     );
-    periodic_regions.sort_unstable();
-    periodic_regions.dedup();
+    let periodic_regions = periodic_regions.into_iter().collect::<Vec<_>>();
     let bit_part = build_bit_partition(module, &partition_regions, &periodic_regions);
 
     let mut graph = CausalGraph::new();
@@ -1643,8 +1646,8 @@ fn periodic_region_node_keys(
 ) -> Vec<NodeKey> {
     let mut keys = bit_part
         .periodic_regions
-        .iter()
-        .position(|candidate| *candidate == periodic)
+        .binary_search(&periodic)
+        .ok()
         .map(|index| vec![(periodic.object, PERIODIC_REGION_INDEX, index)])
         .unwrap_or_default();
     let Some(width) = variables

--- a/crates/analyzer/src/comb_loop_detect.rs
+++ b/crates/analyzer/src/comb_loop_detect.rs
@@ -18,10 +18,10 @@ use crate::ir::{
     InstDeclaration, Ir, Module, Op, SystemFunctionKind, VarIndex, VarSelect, Variable,
 };
 use crate::symbol::{Affiliation, Direction};
-use daggy::petgraph::Direction::Incoming;
-use daggy::petgraph::Graph;
-use daggy::petgraph::graph::NodeIndex;
-use daggy::petgraph::visit::EdgeRef;
+use petgraph::Direction::Incoming;
+use petgraph::Graph;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef;
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 use std::collections::VecDeque;

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -42,6 +42,16 @@ pub(crate) fn map_expression_span(
     Builder::with_context(nested_context).map_expression_span_to_actual(expression, requested)
 }
 
+fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) -> bool {
+    matches!(
+        (left, right),
+        (
+            Region::Exact { span: left, .. },
+            Region::Exact { span: right, .. }
+        ) if left.length == right.length
+    )
+}
+
 struct Builder {
     context: Context,
     procedure: Procedure<VarId>,
@@ -50,6 +60,14 @@ struct Builder {
     unresolved_writes: BTreeMap<String, Vec<(usize, Vec<usize>)>>,
     call_stack: Vec<VarId>,
     model_error: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct MappedFunctionRead {
+    read: usize,
+    kind: EdgeKind,
+    input: Region<VarId>,
+    aligned: bool,
 }
 
 impl Builder {
@@ -510,7 +528,7 @@ impl Builder {
             .values()
             .copied()
             .collect::<BTreeSet<_>>();
-        let mut dependencies_by_output = BTreeMap::<Region<VarId>, Vec<(usize, EdgeKind)>>::new();
+        let mut dependencies_by_output = BTreeMap::<Region<VarId>, Vec<MappedFunctionRead>>::new();
         for dependency in &summary.dependencies {
             let mut mapped = Vec::new();
             let input_object = match dependency.input {
@@ -526,12 +544,25 @@ impl Builder {
                 if let Some(actual_regions) =
                     self.map_formal_region_to_actual(actual_expression, dependency.input)
                 {
+                    let preserve_alignment = dependency.aligned
+                        && actual_regions.len() == 1
+                        && exact_regions_have_equal_length(actual_regions[0], dependency.output);
                     mapped.extend(actual_regions.into_iter().map(|actual_region| {
-                        (self.push_read(block, actual_region), dependency.kind)
+                        MappedFunctionRead {
+                            read: self.push_read(block, actual_region),
+                            kind: dependency.kind,
+                            input: actual_region,
+                            aligned: preserve_alignment,
+                        }
                     }));
                 } else {
                     mapped.extend(fallback_reads.iter().map(|&(read, actual_kind)| {
-                        (read, combine_edge_kinds(dependency.kind, actual_kind))
+                        MappedFunctionRead {
+                            read,
+                            kind: combine_edge_kinds(dependency.kind, actual_kind),
+                            input: Region::UnknownAll,
+                            aligned: false,
+                        }
                     }));
                 }
             } else if input_object.is_some_and(|object| {
@@ -539,7 +570,13 @@ impl Builder {
                     variable.affiliation == crate::symbol::Affiliation::Module
                 })
             }) {
-                mapped.push((self.push_read(block, dependency.input), dependency.kind));
+                mapped.push(MappedFunctionRead {
+                    read: self.push_read(block, dependency.input),
+                    kind: dependency.kind,
+                    input: dependency.input,
+                    aligned: dependency.aligned
+                        && exact_regions_have_equal_length(dependency.input, dependency.output),
+                });
             } else if input_object.is_some_and(|object| formal_ids.contains(&object)) {
                 self.model_error
                     .get_or_insert("function dependency refers to an unmapped input argument");
@@ -548,18 +585,23 @@ impl Builder {
                 self.procedure
                     .incomplete
                     .insert(IncompleteReason::MalformedModel);
-                mapped.push((self.unknown_read(block), EdgeKind::Unknown));
+                mapped.push(MappedFunctionRead {
+                    read: self.unknown_read(block),
+                    kind: EdgeKind::Unknown,
+                    input: Region::UnknownAll,
+                    aligned: false,
+                });
             }
-            mapped.sort_unstable();
-            mapped.dedup();
+            mapped.sort_unstable_by_key(|dependency| (dependency.read, dependency.kind));
+            mapped.dedup_by_key(|dependency| (dependency.read, dependency.kind));
             dependencies_by_output
                 .entry(dependency.output)
                 .or_default()
                 .extend(mapped);
         }
         for dependencies in dependencies_by_output.values_mut() {
-            dependencies.sort_unstable();
-            dependencies.dedup();
+            dependencies.sort_unstable_by_key(|dependency| (dependency.read, dependency.kind));
+            dependencies.dedup_by_key(|dependency| (dependency.read, dependency.kind));
         }
         for &output in &summary.outputs {
             dependencies_by_output.entry(output).or_default();
@@ -580,7 +622,10 @@ impl Builder {
             if !is_module_capture {
                 continue;
             }
-            let mut dependencies = dependencies.clone();
+            let mut dependencies = dependencies
+                .iter()
+                .map(|dependency| (dependency.read, dependency.kind))
+                .collect::<Vec<_>>();
             dependencies.extend_from_slice(controls);
             let id = self.next_write;
             self.next_write += 1;
@@ -598,23 +643,37 @@ impl Builder {
                     .get_or_insert("function call output has no formal argument mapping");
                 continue;
             };
-            let mut dependencies = dependencies_by_output
+            let mapped_dependencies = dependencies_by_output
                 .iter()
                 .filter_map(|(output, dependencies)| match output {
                     Region::Exact { object, .. } | Region::UnknownObject(object)
                         if *object == formal =>
                     {
-                        Some(dependencies.iter().copied())
+                        Some((*output, dependencies.clone()))
                     }
                     _ => None,
                 })
-                .flatten()
+                .collect::<Vec<_>>();
+            let mut dependencies = mapped_dependencies
+                .iter()
+                .flat_map(|(_, dependencies)| dependencies.iter().copied())
+                .map(|dependency| (dependency.read, dependency.kind))
                 .collect::<Vec<_>>();
             dependencies.sort_unstable();
             dependencies.dedup();
             dependencies.extend_from_slice(controls);
+            let aligned =
+                self.function_output_aligned_dependencies(formal, outputs, &mapped_dependencies);
+            if aligned.is_some() {
+                dependencies = controls.to_vec();
+            }
             for destination in outputs {
-                self.write_destination(block, destination, dependencies.clone(), Vec::new());
+                self.write_destination(
+                    block,
+                    destination,
+                    dependencies.clone(),
+                    aligned.clone().unwrap_or_default(),
+                );
             }
         }
 
@@ -630,6 +689,7 @@ impl Builder {
                     _ => None,
                 })
                 .flatten()
+                .map(|dependency| (dependency.read, dependency.kind))
                 .collect::<Vec<_>>();
             dependencies.sort_unstable();
             dependencies.dedup();
@@ -637,6 +697,75 @@ impl Builder {
         } else {
             Vec::new()
         }
+    }
+
+    fn function_output_aligned_dependencies(
+        &mut self,
+        formal: VarId,
+        outputs: &[AssignDestination],
+        mapped_dependencies: &[(Region<VarId>, Vec<MappedFunctionRead>)],
+    ) -> Option<Vec<AlignedDependency>> {
+        let [destination] = outputs else {
+            return None;
+        };
+        let Region::Exact {
+            span: destination_span,
+            ..
+        } = self.variable_region(destination.id, &destination.index, &destination.select)
+        else {
+            return None;
+        };
+        let formal_length = self
+            .context
+            .variables
+            .get(&formal)?
+            .total_width()?
+            .checked_mul(
+                self.context
+                    .variables
+                    .get(&formal)?
+                    .r#type
+                    .total_array()
+                    .unwrap_or(1),
+            )?;
+        if destination_span.length != formal_length {
+            return None;
+        }
+
+        let mut aligned = Vec::new();
+        for &(output, ref dependencies) in mapped_dependencies {
+            let Region::Exact {
+                object,
+                span: output_span,
+            } = output
+            else {
+                return None;
+            };
+            if object != formal || output_span.end()? > formal_length {
+                return None;
+            }
+            for dependency in dependencies {
+                let Region::Exact {
+                    span: input_span, ..
+                } = dependency.input
+                else {
+                    return None;
+                };
+                if !dependency.aligned || input_span.length != output_span.length {
+                    return None;
+                }
+                aligned.push(AlignedDependency {
+                    read: dependency.read,
+                    kind: dependency.kind,
+                    source: Span {
+                        start: 0,
+                        length: input_span.length,
+                    },
+                    destination: output_span,
+                });
+            }
+        }
+        Some(aligned)
     }
 
     fn map_formal_region_to_actual(
@@ -696,9 +825,9 @@ impl Builder {
                     }
                     _ => None,
                 },
-                Factor::FunctionCall(call) => {
-                    self.map_function_return_span_to_actual(call, requested)
-                }
+                Factor::FunctionCall(call) => self
+                    .map_function_return_spans_to_actual(call, requested)
+                    .map(|mapped| mapped.into_iter().map(|(region, _)| region).collect()),
                 _ => None,
             },
             Expression::Concatenation(parts, _) => {
@@ -749,11 +878,11 @@ impl Builder {
         }
     }
 
-    fn map_function_return_span_to_actual(
+    fn map_function_return_spans_to_actual(
         &mut self,
         call: &FunctionCall,
         requested: Span,
-    ) -> Option<Vec<Region<VarId>>> {
+    ) -> Option<Vec<(Region<VarId>, Span)>> {
         if self.call_stack.contains(&call.id) {
             return None;
         }
@@ -822,7 +951,25 @@ impl Builder {
                     length: output_overlap.length,
                 },
             };
-            mapped.extend(self.map_formal_region_to_actual(actual, formal_region)?);
+            let actual_regions = self.map_formal_region_to_actual(actual, formal_region)?;
+            for actual_region in actual_regions {
+                let Region::Exact {
+                    span: actual_span, ..
+                } = actual_region
+                else {
+                    return None;
+                };
+                if actual_span.length != output_overlap.length {
+                    return None;
+                }
+                mapped.push((
+                    actual_region,
+                    Span {
+                        start: output_overlap.start.checked_sub(requested.start)?,
+                        length: output_overlap.length,
+                    },
+                ));
+            }
         }
         mapped.sort_unstable();
         mapped.dedup();
@@ -1092,7 +1239,7 @@ impl Builder {
                     Some(())
                 }
                 Factor::FunctionCall(call) => {
-                    let regions = self.map_function_return_span_to_actual(
+                    let regions = self.map_function_return_spans_to_actual(
                         call,
                         Span {
                             start: 0,
@@ -1100,11 +1247,11 @@ impl Builder {
                         },
                     )?;
                     let dependency_count = regions.len();
-                    for region in regions {
+                    for (region, mapped_destination) in regions {
                         let Region::Exact { span, .. } = region else {
                             return None;
                         };
-                        if span.length != destination.length {
+                        if span.length != mapped_destination.length {
                             return None;
                         }
                         aligned.push(AlignedDependency {
@@ -1114,7 +1261,10 @@ impl Builder {
                                 start: 0,
                                 length: span.length,
                             },
-                            destination,
+                            destination: Span {
+                                start: destination.start.checked_add(mapped_destination.start)?,
+                                length: mapped_destination.length,
+                            },
                         });
                     }
                     for _ in 0..dependency_count {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -742,17 +742,20 @@ impl Builder {
             dependencies.sort_unstable();
             dependencies.dedup();
             dependencies.extend_from_slice(controls);
-            let aligned =
+            let aligned_by_destination =
                 self.function_output_aligned_dependencies(formal, outputs, &mapped_dependencies);
-            if aligned.is_some() {
+            if aligned_by_destination.is_some() {
                 dependencies = controls.to_vec();
             }
-            for destination in outputs {
+            for (index, destination) in outputs.iter().enumerate() {
                 self.write_destination(
                     block,
                     destination,
                     dependencies.clone(),
-                    aligned.clone().unwrap_or_default(),
+                    aligned_by_destination
+                        .as_ref()
+                        .map(|aligned| aligned[index].clone())
+                        .unwrap_or_default(),
                 );
             }
         }
@@ -784,17 +787,7 @@ impl Builder {
         formal: VarId,
         outputs: &[AssignDestination],
         mapped_dependencies: &[(Region<VarId>, Vec<MappedFunctionRead>)],
-    ) -> Option<Vec<AlignedDependency>> {
-        let [destination] = outputs else {
-            return None;
-        };
-        let Region::Exact {
-            span: destination_span,
-            ..
-        } = self.variable_region(destination.id, &destination.index, &destination.select)
-        else {
-            return None;
-        };
+    ) -> Option<Vec<Vec<AlignedDependency>>> {
         let formal_length = self
             .context
             .variables
@@ -808,11 +801,27 @@ impl Builder {
                     .total_array()
                     .unwrap_or(1),
             )?;
-        if destination_span.length != formal_length {
+        let mut high = formal_length;
+        let mut destination_spans = Vec::with_capacity(outputs.len());
+        for destination in outputs {
+            let Region::Exact {
+                span: destination_span,
+                ..
+            } = self.variable_region(destination.id, &destination.index, &destination.select)
+            else {
+                return None;
+            };
+            high = high.checked_sub(destination_span.length)?;
+            destination_spans.push(Span {
+                start: high,
+                length: destination_span.length,
+            });
+        }
+        if high != 0 {
             return None;
         }
 
-        let mut aligned = Vec::new();
+        let mut aligned = vec![Vec::new(); outputs.len()];
         for &(output, ref dependencies) in mapped_dependencies {
             let Region::Exact {
                 object,
@@ -834,15 +843,23 @@ impl Builder {
                 if !dependency.aligned || input_span.length != output_span.length {
                     return None;
                 }
-                aligned.push(AlignedDependency {
-                    read: dependency.read,
-                    kind: dependency.kind,
-                    source: Span {
-                        start: 0,
-                        length: input_span.length,
-                    },
-                    destination: output_span,
-                });
+                for (index, destination_span) in destination_spans.iter().copied().enumerate() {
+                    let Some(overlap) = output_span.intersection(destination_span) else {
+                        continue;
+                    };
+                    aligned[index].push(AlignedDependency {
+                        read: dependency.read,
+                        kind: dependency.kind,
+                        source: Span {
+                            start: overlap.start.checked_sub(output_span.start)?,
+                            length: overlap.length,
+                        },
+                        destination: Span {
+                            start: overlap.start.checked_sub(destination_span.start)?,
+                            length: overlap.length,
+                        },
+                    });
+                }
             }
         }
         Some(aligned)

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -1520,9 +1520,6 @@ impl Builder {
             if dependency.kind == EdgeKind::Unknown {
                 continue;
             }
-            if !dependency.aligned {
-                return None;
-            }
             let Region::Exact {
                 object: input,
                 span: input_span,
@@ -1530,38 +1527,51 @@ impl Builder {
             else {
                 continue;
             };
-            let actual = actual_inputs.get(&input)?;
-            if input_span.length != output_span.length {
-                return None;
-            }
-            let relative_start = output_overlap.start.checked_sub(output_span.start)?;
-            let formal_region = Region::Exact {
-                object: input,
-                span: Span {
-                    start: input_span.start.checked_add(relative_start)?,
-                    length: output_overlap.length,
-                },
+            let relative_output = Span {
+                start: output_overlap.start.checked_sub(requested.start)?,
+                length: output_overlap.length,
             };
-            let actual_regions = self.map_formal_region_to_actual(actual, formal_region)?;
-            for actual in actual_regions {
-                let actual_region = actual.region;
-                let Region::Exact {
-                    span: actual_span, ..
-                } = actual_region
-                else {
-                    return None;
-                };
-                if actual_span.length != output_overlap.length {
+
+            let mapped_input = if dependency.aligned {
+                if input_span.length != output_span.length {
                     return None;
                 }
-                mapped.push((
-                    actual_region,
-                    Span {
-                        start: output_overlap.start.checked_sub(requested.start)?,
+                let relative_start = output_overlap.start.checked_sub(output_span.start)?;
+                Region::Exact {
+                    object: input,
+                    span: Span {
+                        start: input_span.start.checked_add(relative_start)?,
                         length: output_overlap.length,
                     },
-                    actual.aligned,
-                ));
+                }
+            } else {
+                dependency.input
+            };
+
+            if let Some(actual) = actual_inputs.get(&input) {
+                for actual in self.map_formal_region_to_actual(actual, mapped_input)? {
+                    let actual_region = actual.region;
+                    let Region::Exact {
+                        span: actual_span, ..
+                    } = actual_region
+                    else {
+                        return None;
+                    };
+                    let aligned = dependency.aligned && actual.aligned;
+                    if aligned && actual_span.length != output_overlap.length {
+                        return None;
+                    }
+                    mapped.push((actual_region, relative_output, aligned));
+                }
+            } else if self
+                .context
+                .variables
+                .get(&input)
+                .is_some_and(|variable| variable.affiliation == crate::symbol::Affiliation::Module)
+            {
+                mapped.push((mapped_input, relative_output, dependency.aligned));
+            } else {
+                return None;
             }
         }
         mapped.sort_unstable();

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -3,6 +3,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::attribute::{Attribute, CondTypeItem};
+use crate::attribute_table;
 use crate::conv::Context;
 use crate::ir::{
     ArrayLiteralItem, AssignDestination, CasePattern, CombDeclaration, Expression, Factor,
@@ -380,6 +382,19 @@ fn weak_region(region: Region<VarId>) -> Region<VarId> {
     }
 }
 
+fn has_cond_type(token: &TokenRange) -> bool {
+    let mut attrs = attribute_table::get(&token.beg);
+    attrs.reverse();
+    for attr in attrs {
+        match attr {
+            Attribute::CondType(CondTypeItem::None) => return false,
+            Attribute::CondType(_) => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
 struct Builder {
     context: Context,
     procedure: Procedure<VarId>,
@@ -567,6 +582,9 @@ impl Builder {
         let mut sites = BTreeSet::new();
         let mut retained_spans = BTreeMap::<VarId, Vec<Span>>::new();
         for retained in &summary.retained_outputs {
+            if !retained.coverage_diagnostic {
+                continue;
+            }
             let object = match retained.output {
                 Region::Exact { object, .. }
                 | Region::UnknownRegion { object, .. }
@@ -908,6 +926,9 @@ impl Builder {
                     None
                 } else {
                     let join = self.new_block();
+                    if has_cond_type(&statement.token) {
+                        self.procedure.events[join].push(Event::SuppressRetentionDiagnostic);
+                    }
                     for exit in exits {
                         self.edge(exit, join);
                     }
@@ -993,6 +1014,9 @@ impl Builder {
                     None
                 } else {
                     let join = self.new_block();
+                    if has_cond_type(&statement.token) {
+                        self.procedure.events[join].push(Event::SuppressRetentionDiagnostic);
+                    }
                     for exit in exits {
                         self.edge(exit, join);
                     }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -2322,7 +2322,6 @@ impl Builder {
             span: Span { start, length },
         }
     }
-
 }
 
 fn combine_edge_kinds(left: EdgeKind, right: EdgeKind) -> EdgeKind {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -12,7 +12,7 @@ use crate::ir::{
 use crate::value::Value;
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
-    self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError,
+    self, AlignedDependency, Event, MustAliasCandidate, PeriodicAxis, Procedure, ProcedureError,
     ProcedureSummary, WriteId,
 };
 use veryl_causal::region::{Region, Span};
@@ -170,7 +170,7 @@ pub(crate) fn map_expression_span(
         .map_expression_span_to_actual(expression, requested)
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct PositionedRegion {
     pub region: Region<VarId>,
     /// Bit coordinates in the mapped expression which this region supplies.
@@ -179,9 +179,152 @@ pub(crate) struct PositionedRegion {
     pub aligned: bool,
     /// Value for data (including replicated fill); Control for selectors.
     pub kind: EdgeKind,
-    /// Regular copies of this source-to-expression mapping.
-    pub repetitions: usize,
-    pub expression_stride: usize,
+    /// Cartesian expression-copy axes, innermost first.
+    pub axes: Vec<PeriodicAxis>,
+}
+
+fn positioned_extent(length: usize, axes: &[PeriodicAxis]) -> Option<usize> {
+    axes.iter().try_fold(length, |extent, axis| {
+        if axis.repetitions == 0 || axis.destination_stride < extent {
+            return None;
+        }
+        axis.destination_stride
+            .checked_mul(axis.repetitions - 1)
+            .and_then(|offset| extent.checked_add(offset))
+    })
+}
+
+fn clip_aligned_dependency(
+    dependency: &AlignedDependency,
+    destination: Span,
+) -> Option<Vec<AlignedDependency>> {
+    fn visit(
+        dependency: &AlignedDependency,
+        source: Span,
+        output: Span,
+        axes: &[PeriodicAxis],
+        query: Span,
+        clipped: &mut Vec<AlignedDependency>,
+    ) -> Option<()> {
+        let pattern_end = output
+            .start
+            .checked_add(positioned_extent(output.length, axes)?)?;
+        let query_end = query.end()?;
+        if pattern_end <= query.start || query_end <= output.start {
+            return Some(());
+        }
+        if query.start <= output.start && pattern_end <= query_end {
+            clipped.push(AlignedDependency {
+                read: dependency.read,
+                kind: dependency.kind,
+                source,
+                destination: Span {
+                    start: output.start.checked_sub(query.start)?,
+                    length: output.length,
+                },
+                axes: axes.to_vec(),
+            });
+            return Some(());
+        }
+        let Some((outer, inner_axes)) = axes.split_last() else {
+            let overlap = output.intersection(query)?;
+            let relative = overlap.start.checked_sub(output.start)?;
+            clipped.push(AlignedDependency {
+                read: dependency.read,
+                kind: dependency.kind,
+                source: Span {
+                    start: source.start.checked_add(relative)?,
+                    length: overlap.length,
+                },
+                destination: Span {
+                    start: overlap.start.checked_sub(query.start)?,
+                    length: overlap.length,
+                },
+                axes: Vec::new(),
+            });
+            return Some(());
+        };
+        let inner_extent = positioned_extent(output.length, inner_axes)?;
+        let inner_end = output.start.checked_add(inner_extent)?;
+        let first = if query.start < inner_end {
+            0
+        } else {
+            query
+                .start
+                .checked_sub(inner_end)?
+                .checked_div(outer.destination_stride)?
+                .checked_add(1)?
+        }
+        .min(outer.repetitions);
+        let end = if query_end <= output.start {
+            0
+        } else {
+            query_end
+                .checked_sub(output.start)?
+                .checked_add(outer.destination_stride - 1)?
+                .checked_div(outer.destination_stride)?
+        }
+        .min(outer.repetitions);
+        if first >= end {
+            return Some(());
+        }
+        let shifted = |copy: usize| {
+            copy.checked_mul(outer.destination_stride)
+                .and_then(|offset| output.start.checked_add(offset))
+                .map(|start| Span {
+                    start,
+                    length: output.length,
+                })
+        };
+        let mut full_first = first;
+        let mut full_end = end;
+        let first_output = shifted(first)?;
+        if query.start > first_output.start
+            || first_output.start.checked_add(inner_extent)? > query_end
+        {
+            visit(dependency, source, first_output, inner_axes, query, clipped)?;
+            full_first += 1;
+        }
+        if full_first < full_end {
+            let last = full_end - 1;
+            let last_output = shifted(last)?;
+            if query.start > last_output.start
+                || last_output.start.checked_add(inner_extent)? > query_end
+            {
+                visit(dependency, source, last_output, inner_axes, query, clipped)?;
+                full_end -= 1;
+            }
+        }
+        if full_first < full_end {
+            let mut axes = inner_axes.to_vec();
+            axes.push(PeriodicAxis {
+                repetitions: full_end - full_first,
+                destination_stride: outer.destination_stride,
+            });
+            clipped.push(AlignedDependency {
+                read: dependency.read,
+                kind: dependency.kind,
+                source,
+                destination: Span {
+                    start: shifted(full_first)?.start.checked_sub(query.start)?,
+                    length: output.length,
+                },
+                axes,
+            });
+        }
+        Some(())
+    }
+
+    let mut clipped = Vec::new();
+    visit(
+        dependency,
+        dependency.source,
+        dependency.destination,
+        &dependency.axes,
+        destination,
+        &mut clipped,
+    )?;
+    Some(clipped)
 }
 
 pub(crate) fn map_expression_span_positioned(
@@ -679,8 +822,13 @@ impl Builder {
                     start: 0,
                     length: source_span.length,
                 },
-                repetitions: destinations.len(),
-                destination_stride: source_span.length,
+                axes: (destinations.len() > 1)
+                    .then_some(PeriodicAxis {
+                        repetitions: destinations.len(),
+                        destination_stride: source_span.length,
+                    })
+                    .into_iter()
+                    .collect(),
             }],
         });
         Some(destinations.len())
@@ -1531,8 +1679,7 @@ impl Builder {
                             start: overlap.start.checked_sub(destination_span.start)?,
                             length: overlap.length,
                         },
-                        repetitions: 1,
-                        destination_stride: 0,
+                        axes: Vec::new(),
                     });
                 }
             }
@@ -1631,8 +1778,7 @@ impl Builder {
                         expression: extension,
                         aligned: false,
                         kind: EdgeKind::Value,
-                        repetitions: 1,
-                        expression_stride: 0,
+                        axes: Vec::new(),
                     }),
                 );
             }
@@ -1662,8 +1808,7 @@ impl Builder {
                         expression: requested,
                         aligned: true,
                         kind: EdgeKind::Value,
-                        repetitions: 1,
-                        expression_stride: 0,
+                        axes: Vec::new(),
                     }])
                 }
                 Factor::Value(_) => Some(Vec::new()),
@@ -1689,8 +1834,7 @@ impl Builder {
                                 },
                                 aligned,
                                 kind: EdgeKind::Value,
-                                repetitions: 1,
-                                expression_stride: 0,
+                                axes: Vec::new(),
                             })
                             .collect()
                     }),
@@ -1729,8 +1873,7 @@ impl Builder {
                         expression: requested,
                         aligned: false,
                         kind: EdgeKind::Control,
-                        repetitions: 1,
-                        expression_stride: 0,
+                        axes: Vec::new(),
                     }),
                 );
                 Some(mapped)
@@ -1745,36 +1888,71 @@ impl Builder {
                     } else {
                         1
                     };
-                    for copy in 0..repeat {
-                        let copy_start = low.checked_add(copy.checked_mul(width)?)?;
-                        let copy_span = Span {
-                            start: copy_start,
-                            length: width,
-                        };
-                        let Some(overlap) = requested.intersection(copy_span) else {
-                            continue;
-                        };
-                        let local = Span {
-                            start: overlap.start.checked_sub(copy_start)?,
-                            length: overlap.length,
-                        };
-                        mapped.extend(
-                            self.map_expression_span_positioned_to_actual(part, local)?
-                                .into_iter()
-                                .map(|positioned| PositionedRegion {
-                                    region: positioned.region,
-                                    expression: Span {
-                                        start: positioned.expression.start + copy_start,
-                                        length: positioned.expression.length,
-                                    },
-                                    aligned: positioned.aligned,
-                                    kind: positioned.kind,
-                                    repetitions: positioned.repetitions,
-                                    expression_stride: positioned.expression_stride,
-                                }),
-                        );
+                    let repeated_length = width.checked_mul(repeat)?;
+                    let covered = Span {
+                        start: low,
+                        length: repeated_length,
+                    };
+                    if let Some(overlap) = requested.intersection(covered) {
+                        let relative_start = overlap.start.checked_sub(low)?;
+                        let relative_end = overlap.end()?.checked_sub(low)?;
+                        let first_copy = relative_start / width;
+                        let last_copy = relative_end.checked_sub(1)? / width;
+                        for copy in [
+                            Some(first_copy),
+                            (last_copy != first_copy).then_some(last_copy),
+                        ]
+                        .into_iter()
+                        .flatten()
+                        {
+                            let copy_start = low.checked_add(copy.checked_mul(width)?)?;
+                            let copy_span = Span {
+                                start: copy_start,
+                                length: width,
+                            };
+                            let copy_overlap = requested.intersection(copy_span)?;
+                            if copy_overlap == copy_span {
+                                continue;
+                            }
+                            let local = Span {
+                                start: copy_overlap.start.checked_sub(copy_start)?,
+                                length: copy_overlap.length,
+                            };
+                            for mut positioned in
+                                self.map_expression_span_positioned_to_actual(part, local)?
+                            {
+                                positioned.expression.start =
+                                    positioned.expression.start.checked_add(copy_start)?;
+                                mapped.push(positioned);
+                            }
+                        }
+
+                        let first_full =
+                            relative_start.checked_add(width - 1)?.checked_div(width)?;
+                        let end_full = relative_end.checked_div(width)?;
+                        if first_full < end_full {
+                            let copies = end_full - first_full;
+                            let copy_start = low.checked_add(first_full.checked_mul(width)?)?;
+                            for mut positioned in self.map_expression_span_positioned_to_actual(
+                                part,
+                                Span {
+                                    start: 0,
+                                    length: width,
+                                },
+                            )? {
+                                positioned.expression.start =
+                                    positioned.expression.start.checked_add(copy_start)?;
+                                if copies > 1 {
+                                    positioned.axes.push(PeriodicAxis {
+                                        repetitions: copies,
+                                        destination_stride: width,
+                                    });
+                                }
+                                mapped.push(positioned);
+                            }
+                        }
                     }
-                    low = low.checked_add(width.checked_mul(repeat)?)?;
+                    low = low.checked_add(repeated_length)?;
                 }
                 Some(mapped)
             }
@@ -1825,8 +2003,7 @@ impl Builder {
                             },
                             aligned: positioned.aligned,
                             kind: positioned.kind,
-                            repetitions: positioned.repetitions,
-                            expression_stride: positioned.expression_stride,
+                            axes: positioned.axes,
                         });
                     }
                 }
@@ -1955,8 +2132,7 @@ impl Builder {
                             },
                             aligned: positioned.aligned,
                             kind: positioned.kind,
-                            repetitions: positioned.repetitions,
-                            expression_stride: positioned.expression_stride,
+                            axes: positioned.axes,
                         })
                         .collect(),
                 )
@@ -1992,8 +2168,7 @@ impl Builder {
                             },
                             aligned: positioned.aligned,
                             kind: positioned.kind,
-                            repetitions: positioned.repetitions,
-                            expression_stride: positioned.expression_stride,
+                            axes: positioned.axes,
                         })
                         .collect(),
                 )
@@ -2030,8 +2205,7 @@ impl Builder {
                                 },
                                 aligned: positioned.aligned,
                                 kind: positioned.kind,
-                                repetitions: positioned.repetitions,
-                                expression_stride: positioned.expression_stride,
+                                axes: positioned.axes,
                             }),
                     );
                 }
@@ -2053,8 +2227,7 @@ impl Builder {
                             expression: fill,
                             aligned: false,
                             kind: EdgeKind::Value,
-                            repetitions: 1,
-                            expression_stride: 0,
+                            axes: Vec::new(),
                         }),
                     );
                 }
@@ -2142,8 +2315,7 @@ impl Builder {
                     },
                     aligned: positioned.aligned,
                     kind: positioned.kind,
-                    repetitions: positioned.repetitions,
-                    expression_stride: positioned.expression_stride,
+                    axes: positioned.axes,
                 });
             }
         }
@@ -2162,29 +2334,10 @@ impl Builder {
                 positioned.expression.start =
                     positioned.expression.start.checked_add(copy_start)?;
                 if copies > 1 {
-                    if positioned.repetitions == 1 {
-                        positioned.repetitions = copies;
-                        positioned.expression_stride = element_length;
-                    } else if positioned
-                        .expression_stride
-                        .checked_mul(positioned.repetitions)
-                        == Some(element_length)
-                    {
-                        positioned.repetitions = positioned.repetitions.checked_mul(copies)?;
-                    } else {
-                        // A non-flattenable nested pattern retains one compact
-                        // inner pattern per outer copy. The number of explicit
-                        // items then reflects source structure, not bit width.
-                        for copy in 0..copies {
-                            let mut positioned = positioned;
-                            positioned.expression.start = positioned
-                                .expression
-                                .start
-                                .checked_add(copy.checked_mul(element_length)?)?;
-                            mapped.push(positioned);
-                        }
-                        continue;
-                    }
+                    positioned.axes.push(PeriodicAxis {
+                        repetitions: copies,
+                        destination_stride: element_length,
+                    });
                 }
                 mapped.push(positioned);
             }
@@ -2560,8 +2713,7 @@ impl Builder {
                         length: span.length,
                     },
                     destination: positioned.expression,
-                    repetitions: positioned.repetitions,
-                    destination_stride: positioned.expression_stride,
+                    axes: positioned.axes,
                 });
             } else {
                 retained.push((read, positioned.kind));
@@ -2570,66 +2722,8 @@ impl Builder {
         *dependencies = retained;
         let mut ret = vec![Vec::new(); destinations.len()];
         for dependency in aligned {
-            let pattern_end = dependency
-                .destination_stride
-                .checked_mul(dependency.repetitions.saturating_sub(1))?
-                .checked_add(dependency.destination.end()?)?;
-            if dependency.repetitions > 1
-                && let Some((index, destination)) = destination_spans
-                    .iter()
-                    .copied()
-                    .enumerate()
-                    .find(|(_, destination)| {
-                        dependency.destination.start >= destination.start
-                            && pattern_end <= destination.end().unwrap_or(0)
-                    })
-            {
-                ret[index].push(AlignedDependency {
-                    read: dependency.read,
-                    kind: dependency.kind,
-                    source: dependency.source,
-                    destination: Span {
-                        start: dependency
-                            .destination
-                            .start
-                            .checked_sub(destination.start)?,
-                        length: dependency.destination.length,
-                    },
-                    repetitions: dependency.repetitions,
-                    destination_stride: dependency.destination_stride,
-                });
-                continue;
-            }
             for (index, destination) in destination_spans.iter().copied().enumerate() {
-                for copy in 0..dependency.repetitions {
-                    let copy_start = dependency
-                        .destination
-                        .start
-                        .checked_add(copy.checked_mul(dependency.destination_stride)?)?;
-                    let copy_span = Span {
-                        start: copy_start,
-                        length: dependency.destination.length,
-                    };
-                    let Some(overlap) = copy_span.intersection(destination) else {
-                        continue;
-                    };
-                    let source_offset = overlap.start.checked_sub(copy_span.start)?;
-                    let destination_offset = overlap.start.checked_sub(destination.start)?;
-                    ret[index].push(AlignedDependency {
-                        read: dependency.read,
-                        kind: dependency.kind,
-                        source: Span {
-                            start: dependency.source.start.checked_add(source_offset)?,
-                            length: overlap.length,
-                        },
-                        destination: Span {
-                            start: destination_offset,
-                            length: overlap.length,
-                        },
-                        repetitions: 1,
-                        destination_stride: 0,
-                    });
-                }
+                ret[index].extend(clip_aligned_dependency(&dependency, destination)?);
             }
         }
         Some(ret)

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -125,6 +125,44 @@ pub(crate) fn analyze(
     Ok(builder.finish((*summary).clone()))
 }
 
+#[derive(Default)]
+pub(crate) struct ModuleAnalysisContext {
+    // Why these are returned by each serial analysis: they are immutable
+    // module seed data apart from loop iterators, which lowering restores.
+    // Moving them between builders avoids cloning every variable and
+    // recomputing every declared object span for each small procedure.
+    context: Context,
+    object_spans: BTreeMap<VarId, Span>,
+}
+
+pub(crate) fn analyze_in_context(
+    context: &mut ModuleAnalysisContext,
+    declaration: &CombDeclaration,
+    functions: &FunctionAnalysisCache,
+) -> Result<ProcedureAnalysis, ProcedureError> {
+    let mut builder = Builder::with_context_and_object_spans(
+        std::mem::take(&mut context.context),
+        std::mem::take(&mut context.object_spans),
+        functions.clone(),
+    );
+    let exit = builder
+        .lower_statements(&declaration.statements, 0, &[], None)
+        .unwrap_or(0);
+    builder.procedure.exit = exit;
+    let summary = match functions.procedures.analyze(&builder.procedure) {
+        Ok(summary) => summary,
+        Err(error) => {
+            (context.context, context.object_spans) = builder.into_reusable_context();
+            return Err(error);
+        }
+    };
+    let (analysis, restored_context, restored_spans) =
+        builder.finish_with_context((*summary).clone());
+    context.context = restored_context;
+    context.object_spans = restored_spans;
+    Ok(analysis)
+}
+
 pub(crate) fn analyze_observer_expression(
     module: &Module,
     expression: &Expression,
@@ -137,19 +175,53 @@ pub(crate) fn analyze_observer_expression(
     Ok(builder.finish((*summary).clone()))
 }
 
+pub(crate) fn analyze_observer_expression_in_context(
+    context: &mut ModuleAnalysisContext,
+    expression: &Expression,
+    functions: &FunctionAnalysisCache,
+) -> Result<ProcedureAnalysis, ProcedureError> {
+    let mut builder = Builder::with_context_and_object_spans(
+        std::mem::take(&mut context.context),
+        std::mem::take(&mut context.object_spans),
+        functions.clone(),
+    );
+    builder.lower_observer_expression(0, expression);
+    builder.procedure.exit = 0;
+    let summary = match functions.procedures.analyze(&builder.procedure) {
+        Ok(summary) => summary,
+        Err(error) => {
+            (context.context, context.object_spans) = builder.into_reusable_context();
+            return Err(error);
+        }
+    };
+    let (analysis, restored_context, restored_spans) =
+        builder.finish_with_context((*summary).clone());
+    context.context = restored_context;
+    context.object_spans = restored_spans;
+    Ok(analysis)
+}
+
 pub(crate) fn analyze_functions(
     module: &Module,
     functions: &FunctionAnalysisCache,
-) -> Vec<Arc<ProcedureAnalysis>> {
+) -> (Vec<Arc<ProcedureAnalysis>>, ModuleAnalysisContext) {
     let builder = Builder::new(module, functions.clone());
-    module
+    let analyses = module
         .functions
         .values()
         .flat_map(|function| {
             (0..function.functions.len())
                 .filter_map(|index| builder.cached_function((function.id, index)))
         })
-        .collect()
+        .collect();
+    let (context, object_spans) = builder.into_reusable_context();
+    (
+        analyses,
+        ModuleAnalysisContext {
+            context,
+            object_spans,
+        },
+    )
 }
 
 /// Observer procedures exist only to retain side effects and incomplete
@@ -464,6 +536,14 @@ impl Builder {
                     .map(|length| (id, Span { start: 0, length }))
             })
             .collect();
+        Self::with_context_and_object_spans(context, object_spans, function_cache)
+    }
+
+    fn with_context_and_object_spans(
+        context: Context,
+        object_spans: BTreeMap<VarId, Span>,
+        function_cache: FunctionAnalysisCache,
+    ) -> Self {
         Self {
             context,
             procedure: Procedure {
@@ -696,7 +776,21 @@ impl Builder {
         sites.into_iter().collect()
     }
 
-    fn finish(mut self, mut summary: ProcedureSummary<VarId>) -> ProcedureAnalysis {
+    fn finish(self, summary: ProcedureSummary<VarId>) -> ProcedureAnalysis {
+        self.finish_with_context(summary).0
+    }
+
+    fn into_reusable_context(mut self) -> (Context, BTreeMap<VarId, Span>) {
+        (
+            self.context,
+            std::mem::take(&mut self.procedure.object_spans),
+        )
+    }
+
+    fn finish_with_context(
+        mut self,
+        mut summary: ProcedureSummary<VarId>,
+    ) -> (ProcedureAnalysis, Context, BTreeMap<VarId, Span>) {
         for dependency in &mut summary.dependencies {
             if dependency
                 .origin
@@ -717,11 +811,16 @@ impl Builder {
             .extend(self.retained_coverage_sites(&summary));
         self.coverage_sites.sort_unstable();
         self.coverage_sites.dedup();
-        ProcedureAnalysis {
-            summary,
-            write_tokens: self.write_tokens,
-            coverage_sites: self.coverage_sites,
-        }
+        let object_spans = std::mem::take(&mut self.procedure.object_spans);
+        (
+            ProcedureAnalysis {
+                summary,
+                write_tokens: self.write_tokens,
+                coverage_sites: self.coverage_sites,
+            },
+            self.context,
+            object_spans,
+        )
     }
 
     fn record_write(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -8,7 +8,6 @@ use crate::ir::{
     ForBound, ForRange, FunctionCall, Module, Op, Statement, SystemFunctionCall,
     SystemFunctionKind, TypeKind, VarId, VarIndex, VarSelect,
 };
-use crate::value::Value;
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
     self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError, ProcedureSummary,
@@ -2192,9 +2191,6 @@ impl Builder {
         let Some(width) = variable.total_width() else {
             return vec![Region::UnknownObject(id)];
         };
-        if let Some(regions) = self.bounded_variable_regions(id, &variable, index, select, width) {
-            return regions;
-        }
         vec![self.variable_region_fallback(id, &variable, index, select, width)]
     }
 
@@ -2327,173 +2323,6 @@ impl Builder {
         }
     }
 
-    /// Exactly enumerate small two-state selector domains. This is deliberately
-    /// bounded: four-state selectors retain X/Z candidates, and large domains
-    /// fall back to the longest-static-prefix region below.
-    fn bounded_variable_regions(
-        &mut self,
-        id: VarId,
-        variable: &crate::ir::Variable,
-        index: &VarIndex,
-        select: &VarSelect,
-        width: usize,
-    ) -> Option<Vec<Region<VarId>>> {
-        let expressions = index
-            .0
-            .iter()
-            .chain(select.0.iter())
-            .chain(select.1.iter().map(|(_, bound)| bound))
-            .collect::<Vec<_>>();
-        if expressions
-            .iter()
-            .all(|expression| expression.comptime().is_const)
-        {
-            return None;
-        }
-
-        let mut ids = BTreeSet::new();
-        if !expressions
-            .iter()
-            .all(|expression| Self::collect_two_state_variables(expression, &mut ids))
-        {
-            return None;
-        }
-        let variables = ids
-            .into_iter()
-            .map(|id| {
-                let variable = self.context.variables.get(&id)?;
-                let bits = variable.total_width()?;
-                (matches!(variable.r#type.kind, TypeKind::Bit)
-                    && variable.r#type.total_array()? == 1
-                    && bits <= 8)
-                    .then_some((id, bits, variable.r#type.signed))
-            })
-            .collect::<Option<Vec<_>>>()?;
-        let total_bits = variables
-            .iter()
-            .try_fold(0usize, |total, (_, bits, _)| total.checked_add(*bits))?;
-        if total_bits > 8 {
-            return None;
-        }
-
-        let saved = variables
-            .iter()
-            .map(|&(id, _, _)| Some((id, self.context.variables.get(&id)?.value.clone())))
-            .collect::<Option<Vec<_>>>()?;
-        let assignments = 1usize.checked_shl(total_bits as u32)?;
-        let mut spans = Vec::new();
-        for assignment in 0..assignments {
-            let mut shift = 0usize;
-            for &(id, bits, signed) in &variables {
-                let mask = (1usize << bits).saturating_sub(1);
-                let payload = ((assignment >> shift) & mask) as u64;
-                let Some(variable) = self.context.variables.get_mut(&id) else {
-                    continue;
-                };
-                variable.value = vec![Value::new(payload, bits, signed)];
-                shift += bits;
-            }
-            let Some(index_path) = index.eval_value(&mut self.context) else {
-                continue;
-            };
-            let Some(array_index) = variable.r#type.array.calc_index(&index_path) else {
-                continue;
-            };
-            let Some((high, low)) = select.eval_value(&mut self.context, &variable.r#type, false)
-            else {
-                continue;
-            };
-            if high >= width || low > high {
-                continue;
-            }
-            let Some(start) = array_index
-                .checked_mul(width)
-                .and_then(|base| base.checked_add(low))
-            else {
-                continue;
-            };
-            spans.push(Span {
-                start,
-                length: high - low + 1,
-            });
-        }
-        for (id, value) in saved {
-            if let Some(variable) = self.context.variables.get_mut(&id) {
-                variable.value = value;
-            }
-        }
-
-        spans.sort_unstable();
-        spans.dedup();
-        let first = spans.first().copied()?;
-        let mut merged = Vec::new();
-        let mut start = first.start;
-        let mut end = first.end()?;
-        for span in spans.iter().copied().skip(1) {
-            if span.start > end {
-                merged.push(Region::UnknownRegion {
-                    object: id,
-                    span: Span {
-                        start,
-                        length: end.checked_sub(start)?,
-                    },
-                });
-                start = span.start;
-                end = span.end()?;
-            } else {
-                end = end.max(span.end()?);
-            }
-        }
-        merged.push(Region::UnknownRegion {
-            object: id,
-            span: Span {
-                start,
-                length: end.checked_sub(start)?,
-            },
-        });
-        Some(merged)
-    }
-
-    fn collect_two_state_variables(expression: &Expression, ids: &mut BTreeSet<VarId>) -> bool {
-        if expression.comptime().is_const {
-            return true;
-        }
-        match expression {
-            Expression::Term(factor) => match factor.as_ref() {
-                Factor::Variable(id, index, select, _)
-                    if index.0.is_empty() && select.is_empty() =>
-                {
-                    ids.insert(*id);
-                    true
-                }
-                Factor::SystemFunctionCall(call) => match &call.kind {
-                    SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
-                        Self::collect_two_state_variables(&input.0, ids)
-                    }
-                    _ => false,
-                },
-                Factor::Value(_) => true,
-                _ => false,
-            },
-            Expression::Unary(_, operand, _) => Self::collect_two_state_variables(operand, ids),
-            Expression::Binary(left, _, right, _) => {
-                Self::collect_two_state_variables(left, ids)
-                    && Self::collect_two_state_variables(right, ids)
-            }
-            Expression::Ternary(condition, left, right, _) => {
-                Self::collect_two_state_variables(condition, ids)
-                    && Self::collect_two_state_variables(left, ids)
-                    && Self::collect_two_state_variables(right, ids)
-            }
-            Expression::Concatenation(parts, _) => parts.iter().all(|(part, repeat)| {
-                Self::collect_two_state_variables(part, ids)
-                    && repeat
-                        .as_ref()
-                        .is_none_or(|repeat| Self::collect_two_state_variables(repeat, ids))
-            }),
-            Expression::ArrayLiteral(_, _) | Expression::StructConstructor(_, _, _) => false,
-        }
-    }
 }
 
 fn combine_edge_kinds(left: EdgeKind, right: EdgeKind) -> EdgeKind {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -10,7 +10,9 @@ use crate::ir::{
     SystemFunctionKind, TypeKind, VarId, VarIndex, VarKind, VarSelect,
 };
 use crate::value::Value;
-use veryl_causal::graph::{EdgeKind, IncompleteReason};
+use veryl_causal::graph::{
+    AnalysisFailure, AnalysisGap, EdgeKind, IncompleteReason, LoopAnalysisGap, OpaqueBoundary,
+};
 use veryl_causal::procedure::{
     self, AlignedDependency, Event, MustAliasCandidate, PeriodicAxis, Procedure, ProcedureError,
     ProcedureSummary, WriteId,
@@ -21,6 +23,7 @@ use veryl_parser::token_range::TokenRange;
 #[derive(Debug)]
 pub(crate) struct ProcedureAnalysis {
     pub summary: ProcedureSummary<VarId>,
+    pub failures: BTreeSet<AnalysisFailure>,
     pub write_tokens: BTreeMap<WriteId, TokenRange>,
     pub coverage_sites: Vec<(Region<VarId>, TokenRange)>,
 }
@@ -76,6 +79,7 @@ pub(crate) struct FunctionAnalysisCache {
     entries: Arc<Mutex<BTreeMap<FunctionKey, FunctionCacheEntry>>>,
     ready: Arc<OnceLock<Arc<FunctionSummaries>>>,
     procedures: ProcedureSummaryCache,
+    failures: Arc<Mutex<BTreeSet<AnalysisFailure>>>,
 }
 
 impl FunctionAnalysisCache {
@@ -84,7 +88,15 @@ impl FunctionAnalysisCache {
             entries: Arc::default(),
             ready: Arc::default(),
             procedures,
+            failures: Arc::default(),
         }
+    }
+
+    pub(crate) fn failures(&self) -> BTreeSet<AnalysisFailure> {
+        self.failures
+            .lock()
+            .expect("function analysis failure lock poisoned")
+            .clone()
     }
 
     pub(crate) fn freeze(&self) {
@@ -506,6 +518,7 @@ struct Builder {
     uncertain_writes: BTreeSet<WriteId>,
     coverage_writes: BTreeMap<VarId, BTreeSet<(Region<VarId>, TokenRange)>>,
     coverage_sites: Vec<(Region<VarId>, TokenRange)>,
+    failures: BTreeSet<AnalysisFailure>,
     function_cache: FunctionAnalysisCache,
 }
 
@@ -564,6 +577,7 @@ impl Builder {
             uncertain_writes: BTreeSet::new(),
             coverage_writes: BTreeMap::new(),
             coverage_sites: Vec::new(),
+            failures: BTreeSet::new(),
             function_cache,
         }
     }
@@ -594,6 +608,7 @@ impl Builder {
             uncertain_writes: BTreeSet::new(),
             coverage_writes: BTreeMap::new(),
             coverage_sites: Vec::new(),
+            failures: BTreeSet::new(),
             function_cache: self.function_cache.clone(),
         }
     }
@@ -645,11 +660,17 @@ impl Builder {
             .lower_statements(&body.statements, 0, &[], None)
             .unwrap_or(0);
         nested.procedure.exit = exit;
-        let summary = self
-            .function_cache
-            .procedures
-            .analyze(&nested.procedure)
-            .ok()?;
+        let summary = match self.function_cache.procedures.analyze(&nested.procedure) {
+            Ok(summary) => summary,
+            Err(_) => {
+                self.function_cache
+                    .failures
+                    .lock()
+                    .expect("function analysis failure lock poisoned")
+                    .insert(AnalysisFailure::MalformedModel);
+                return None;
+            }
+        };
         Some(Arc::new(nested.finish((*summary).clone())))
     }
 
@@ -664,10 +685,15 @@ impl Builder {
         self.procedure.successors[from].push(to);
     }
 
-    fn unknown_effect(&mut self, block: usize) -> usize {
+    fn malformed_effect(&mut self, block: usize) -> usize {
+        self.failures.insert(AnalysisFailure::MalformedModel);
+        self.unknown_clobber(block)
+    }
+
+    fn opaque_effect(&mut self, block: usize, boundary: OpaqueBoundary) -> usize {
         self.procedure
             .incomplete
-            .insert(IncompleteReason::MalformedModel);
+            .insert(IncompleteReason::Opaque(boundary));
         self.unknown_clobber(block)
     }
 
@@ -815,6 +841,7 @@ impl Builder {
         (
             ProcedureAnalysis {
                 summary,
+                failures: self.failures,
                 write_tokens: self.write_tokens,
                 coverage_sites: self.coverage_sites,
             },
@@ -1174,9 +1201,7 @@ impl Builder {
                                 None,
                             );
                         } else {
-                            self.procedure
-                                .incomplete
-                                .insert(IncompleteReason::MalformedModel);
+                            self.failures.insert(AnalysisFailure::MalformedModel);
                         }
                         let body = self.new_block();
                         self.edge(from, body);
@@ -1198,11 +1223,17 @@ impl Builder {
                 // hard dependency: their iterator values and trip paths are
                 // not represented by this compact CFG. Preserve uncertainty
                 // while keeping the graph declaration-width independent.
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::RuntimeLoop);
                 let suppress_hard_dependencies =
                     statement.range.is_over_size_limit(&mut self.context);
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::Analysis(AnalysisGap::Loop(
+                        if suppress_hard_dependencies {
+                            LoopAnalysisGap::ExpansionLimit
+                        } else {
+                            LoopAnalysisGap::DynamicTripCount
+                        },
+                    )));
                 let body = self.new_block();
                 let exit = self.new_block();
                 let header = self.new_block();
@@ -1248,7 +1279,7 @@ impl Builder {
             Statement::TbMethodCall(call) => {
                 self.procedure
                     .incomplete
-                    .insert(IncompleteReason::TimedOrEventEffect);
+                    .insert(IncompleteReason::Opaque(OpaqueBoundary::TimedOrEventEffect));
                 if let Some(destination) = &call.ret {
                     let unknown = self.unknown_read(block);
                     self.write_destination(
@@ -1261,21 +1292,19 @@ impl Builder {
                 Some(block)
             }
             Statement::IfReset(_) => {
-                self.unknown_effect(block);
+                self.opaque_effect(block, OpaqueBoundary::TimedOrEventEffect);
                 Some(block)
             }
             Statement::Break => {
                 if let Some(target) = break_target {
                     self.edge(block, target);
                 } else {
-                    self.procedure
-                        .incomplete
-                        .insert(IncompleteReason::MalformedModel);
+                    self.failures.insert(AnalysisFailure::MalformedModel);
                 }
                 None
             }
             Statement::Unsupported(_) => {
-                self.unknown_effect(block);
+                self.opaque_effect(block, OpaqueBoundary::UnsupportedConstruct);
                 Some(block)
             }
             Statement::Null => Some(block),
@@ -1440,7 +1469,7 @@ impl Builder {
             Factor::HierVariable(_) => {
                 self.procedure
                     .incomplete
-                    .insert(IncompleteReason::HierarchicalReference);
+                    .insert(IncompleteReason::Analysis(AnalysisGap::UnresolvedHierarchy));
                 reads.push((self.unknown_read(block), EdgeKind::Unknown));
             }
             Factor::SystemFunctionCall(call) => {
@@ -1464,14 +1493,14 @@ impl Builder {
     ) -> Vec<(usize, EdgeKind)> {
         let mut actual_inputs = BTreeMap::<VarId, (Expression, Vec<(usize, EdgeKind)>)>::new();
         let Some(function) = self.context.functions.get(&call.id) else {
-            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
+            return vec![(self.malformed_effect(block), EdgeKind::Unknown)];
         };
         let call_index = call.index.as_deref().unwrap_or(&[]);
         let Some(function_index) = function.array.calc_index(call_index) else {
-            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
+            return vec![(self.malformed_effect(block), EdgeKind::Unknown)];
         };
         let Some(function_body) = function.functions.get(function_index) else {
-            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
+            return vec![(self.malformed_effect(block), EdgeKind::Unknown)];
         };
         let function_args = function_body.arg_map.clone();
         let function_return = function_body.ret;
@@ -1486,13 +1515,14 @@ impl Builder {
         if self.call_stack.contains(&function_key) {
             self.procedure
                 .incomplete
-                .insert(IncompleteReason::RecursiveCall);
+                .insert(IncompleteReason::Analysis(AnalysisGap::RecursiveCall));
             return vec![(self.unknown_clobber(block), EdgeKind::Unknown)];
         }
 
         let Some(nested) = self.cached_function(function_key) else {
-            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
+            return vec![(self.malformed_effect(block), EdgeKind::Unknown)];
         };
+        self.failures.extend(nested.failures.iter().copied());
         let summary = &nested.summary;
         let mut captured_coverage = Vec::<(Region<VarId>, TokenRange)>::new();
         for &(region, token) in &nested.coverage_sites {
@@ -1575,14 +1605,10 @@ impl Builder {
                         && exact_regions_have_equal_length(dependency.input, dependency.output),
                 });
             } else if input_object.is_some_and(|object| formal_ids.contains(&object)) {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::MalformedModel);
+                self.failures.insert(AnalysisFailure::MalformedModel);
                 continue;
             } else {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::MalformedModel);
+                self.failures.insert(AnalysisFailure::MalformedModel);
                 mapped.push(MappedFunctionRead {
                     read: self.unknown_read(block),
                     kind: EdgeKind::Unknown,
@@ -1710,9 +1736,7 @@ impl Builder {
 
         for (path, outputs) in &call.outputs {
             let Some(&formal) = function_args.get(path) else {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::MalformedModel);
+                self.failures.insert(AnalysisFailure::MalformedModel);
                 continue;
             };
             let mapped_dependencies = dependencies_by_output
@@ -2636,7 +2660,7 @@ impl Builder {
             SystemFunctionKind::Readmemh(input, output) => {
                 self.procedure
                     .incomplete
-                    .insert(IncompleteReason::TimedOrEventEffect);
+                    .insert(IncompleteReason::Opaque(OpaqueBoundary::TimedOrEventEffect));
                 let dependencies = self.read_expression(block, &input.0, EdgeKind::Unknown);
                 for destination in &output.0 {
                     self.write_destination(block, destination, dependencies.clone(), Vec::new());
@@ -2687,7 +2711,7 @@ impl Builder {
                 Factor::HierVariable(_) => {
                     self.procedure
                         .incomplete
-                        .insert(IncompleteReason::HierarchicalReference);
+                        .insert(IncompleteReason::Analysis(AnalysisGap::UnresolvedHierarchy));
                 }
                 Factor::FunctionCall(call) => {
                     self.lower_function_call(block, call, &[]);
@@ -2696,9 +2720,9 @@ impl Builder {
                     self.lower_system_function(block, call, false);
                 }
                 Factor::Unknown(_) => {
-                    self.procedure
-                        .incomplete
-                        .insert(IncompleteReason::MalformedModel);
+                    self.procedure.incomplete.insert(IncompleteReason::Opaque(
+                        OpaqueBoundary::UnsupportedConstruct,
+                    ));
                 }
                 Factor::Value(_) | Factor::Anonymous(_) => {}
             },
@@ -3148,6 +3172,26 @@ fn combine_edge_kinds(left: EdgeKind, right: EdgeKind) -> EdgeKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn malformed_model_is_failure_not_incompleteness() {
+        // Why this case exists: malformed analyzer IR invalidates the analysis
+        // itself. It must not be presented to clients as another unsupported
+        // user-language boundary which a model or larger limit could resolve.
+        let mut builder = Builder::with_context(
+            Context::default(),
+            FunctionAnalysisCache::new(ProcedureSummaryCache::default()),
+        );
+        let exit = builder
+            .lower_statements(&[Statement::Break], 0, &[], None)
+            .unwrap_or(0);
+        builder.procedure.exit = exit;
+        let summary = procedure::analyze(&builder.procedure).unwrap();
+        let analysis = builder.finish(summary);
+
+        assert!(analysis.summary.incomplete.is_empty(), "{analysis:#?}");
+        assert_eq!(analysis.failures, [AnalysisFailure::MalformedModel].into());
+    }
 
     #[test]
     fn identical_procedures_share_their_ir_independent_summary() {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -10,14 +10,29 @@ use crate::ir::{
 };
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
-    self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError, ProcedureSummary,
+    self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError,
+    ProcedureSummary, WriteId,
 };
 use veryl_causal::region::{Region, Span};
+use veryl_parser::token_range::TokenRange;
+
+pub(crate) struct ProcedureAnalysis {
+    pub summary: ProcedureSummary<VarId>,
+    pub write_tokens: BTreeMap<WriteId, TokenRange>,
+}
+
+impl std::ops::Deref for ProcedureAnalysis {
+    type Target = ProcedureSummary<VarId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.summary
+    }
+}
 
 pub(crate) fn analyze(
     module: &Module,
     declaration: &CombDeclaration,
-) -> Result<ProcedureSummary<VarId>, ProcedureError> {
+) -> Result<ProcedureAnalysis, ProcedureError> {
     let mut builder = Builder::new(module);
     let exit = builder
         .lower_statements(&declaration.statements, 0, &[], None)
@@ -26,20 +41,28 @@ pub(crate) fn analyze(
     if let Some(message) = builder.model_error {
         return Err(ProcedureError::Model(message));
     }
-    procedure::analyze(&builder.procedure)
+    let summary = procedure::analyze(&builder.procedure)?;
+    Ok(ProcedureAnalysis {
+        summary,
+        write_tokens: builder.write_tokens,
+    })
 }
 
 pub(crate) fn analyze_observer_expression(
     module: &Module,
     expression: &Expression,
-) -> Result<ProcedureSummary<VarId>, ProcedureError> {
+) -> Result<ProcedureAnalysis, ProcedureError> {
     let mut builder = Builder::new(module);
     builder.lower_observer_expression(0, expression);
     builder.procedure.exit = 0;
     if let Some(message) = builder.model_error {
         return Err(ProcedureError::Model(message));
     }
-    procedure::analyze(&builder.procedure)
+    let summary = procedure::analyze(&builder.procedure)?;
+    Ok(ProcedureAnalysis {
+        summary,
+        write_tokens: builder.write_tokens,
+    })
 }
 
 /// Map a result-bit span to the module regions which structurally supply it.
@@ -115,6 +138,7 @@ struct Builder {
     next_write: usize,
     unresolved_writes: BTreeMap<String, Vec<(usize, Vec<usize>)>>,
     call_stack: Vec<VarId>,
+    write_tokens: BTreeMap<WriteId, TokenRange>,
     model_error: Option<&'static str>,
 }
 
@@ -160,6 +184,7 @@ impl Builder {
             next_write: 0,
             unresolved_writes: BTreeMap::new(),
             call_stack: Vec::new(),
+            write_tokens: BTreeMap::new(),
             model_error: None,
         }
     }
@@ -185,6 +210,7 @@ impl Builder {
             next_write: 0,
             unresolved_writes: BTreeMap::new(),
             call_stack,
+            write_tokens: BTreeMap::new(),
             model_error: None,
         }
     }
@@ -305,6 +331,7 @@ impl Builder {
         let read = self.push_read(block, source);
         let id = self.next_write;
         self.next_write += 1;
+        self.write_tokens.insert(id, first.dst[0].token);
         self.procedure.events[block].push(Event::Write {
             id,
             region: Region::Exact {
@@ -867,6 +894,7 @@ impl Builder {
             dependencies.extend_from_slice(controls);
             let id = self.next_write;
             self.next_write += 1;
+            self.write_tokens.insert(id, call.comptime.token);
             self.procedure.events[block].push(Event::Write {
                 id,
                 region: output,
@@ -1938,6 +1966,7 @@ impl Builder {
         {
             let id = self.next_write;
             self.next_write += 1;
+            self.write_tokens.insert(id, destination.token);
             if let Some(key) = Self::unresolved_access_key(
                 destination.id,
                 &destination.index,

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -144,23 +144,18 @@ impl Builder {
         match statement {
             Statement::Assign(assign) => {
                 let mut dependencies = self.read_expression(block, &assign.expr, EdgeKind::Value);
-                let aligned_dependencies = if assign.dst.len() == 1 {
-                    self.aligned_assignment_dependencies(
-                        &assign.expr,
-                        &assign.dst[0],
-                        &mut dependencies,
-                    )
-                    .unwrap_or_default()
-                } else {
-                    Vec::new()
-                };
+                let aligned_by_destination = self
+                    .aligned_assignment_dependencies(&assign.expr, &assign.dst, &mut dependencies)
+                    .unwrap_or_else(|| vec![Vec::new(); assign.dst.len()]);
                 dependencies.extend_from_slice(controls);
-                for destination in &assign.dst {
+                for (destination, aligned_dependencies) in
+                    assign.dst.iter().zip(aligned_by_destination)
+                {
                     self.write_destination(
                         block,
                         destination,
                         dependencies.clone(),
-                        aligned_dependencies.clone(),
+                        aligned_dependencies,
                     );
                 }
                 Some(block)
@@ -860,17 +855,27 @@ impl Builder {
     fn aligned_assignment_dependencies(
         &mut self,
         expression: &Expression,
-        destination: &AssignDestination,
+        destinations: &[AssignDestination],
         dependencies: &mut Vec<(usize, EdgeKind)>,
-    ) -> Option<Vec<AlignedDependency>> {
-        let Region::Exact {
-            span: destination_span,
-            ..
-        } = self.variable_region(destination.id, &destination.index, &destination.select)
-        else {
-            return None;
-        };
-        if expression.comptime().r#type.total_width()? != destination_span.length {
+    ) -> Option<Vec<Vec<AlignedDependency>>> {
+        let expression_width = expression.comptime().r#type.total_width()?;
+        let mut high = expression_width;
+        let mut destination_spans = Vec::with_capacity(destinations.len());
+        for destination in destinations {
+            let Region::Exact {
+                span: destination_span,
+                ..
+            } = self.variable_region(destination.id, &destination.index, &destination.select)
+            else {
+                return None;
+            };
+            high = high.checked_sub(destination_span.length)?;
+            destination_spans.push(Span {
+                start: high,
+                length: destination_span.length,
+            });
+        }
+        if high != 0 {
             return None;
         }
 
@@ -880,7 +885,7 @@ impl Builder {
             expression,
             Span {
                 start: 0,
-                length: destination_span.length,
+                length: expression_width,
             },
             dependencies,
             &mut dependency_cursor,
@@ -890,7 +895,29 @@ impl Builder {
             return None;
         }
         dependencies.clear();
-        Some(aligned)
+        let mut ret = vec![Vec::new(); destinations.len()];
+        for dependency in aligned {
+            for (index, destination) in destination_spans.iter().copied().enumerate() {
+                let Some(overlap) = dependency.destination.intersection(destination) else {
+                    continue;
+                };
+                let source_offset = overlap.start.checked_sub(dependency.destination.start)?;
+                let destination_offset = overlap.start.checked_sub(destination.start)?;
+                ret[index].push(AlignedDependency {
+                    read: dependency.read,
+                    kind: dependency.kind,
+                    source: Span {
+                        start: dependency.source.start.checked_add(source_offset)?,
+                        length: overlap.length,
+                    },
+                    destination: Span {
+                        start: destination_offset,
+                        length: overlap.length,
+                    },
+                });
+            }
+        }
+        Some(ret)
     }
 
     fn collect_aligned_expression_dependencies(
@@ -925,6 +952,10 @@ impl Builder {
                     aligned.push(AlignedDependency {
                         read,
                         kind,
+                        source: Span {
+                            start: 0,
+                            length: source_span.length,
+                        },
                         destination,
                     });
                     Some(())
@@ -983,6 +1014,53 @@ impl Builder {
                     dependency_cursor,
                     aligned,
                 )
+            }
+            Expression::Binary(left, op, right, _)
+                if matches!(op, Op::LogicShiftL | Op::ArithShiftL)
+                    && left.comptime().r#type.total_width()? == destination.length =>
+            {
+                let shift = right
+                    .clone()
+                    .eval_value(&mut self.context)?
+                    .to_usize()?
+                    .min(destination.length);
+                let mut shifted = Vec::new();
+                self.collect_aligned_expression_dependencies(
+                    left,
+                    Span {
+                        start: 0,
+                        length: destination.length,
+                    },
+                    dependencies,
+                    dependency_cursor,
+                    &mut shifted,
+                )?;
+                let live_source = Span {
+                    start: 0,
+                    length: destination.length.checked_sub(shift)?,
+                };
+                for dependency in shifted {
+                    let Some(overlap) = dependency.destination.intersection(live_source) else {
+                        continue;
+                    };
+                    let offset = overlap.start.checked_sub(dependency.destination.start)?;
+                    aligned.push(AlignedDependency {
+                        read: dependency.read,
+                        kind: dependency.kind,
+                        source: Span {
+                            start: dependency.source.start.checked_add(offset)?,
+                            length: overlap.length,
+                        },
+                        destination: Span {
+                            start: destination
+                                .start
+                                .checked_add(overlap.start)?
+                                .checked_add(shift)?,
+                            length: overlap.length,
+                        },
+                    });
+                }
+                Some(())
             }
             _ => None,
         }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -886,14 +886,6 @@ impl Builder {
         else {
             return None;
         };
-        let expression_length = expression
-            .comptime()
-            .r#type
-            .total_width()?
-            .checked_mul(expression.comptime().r#type.total_array().unwrap_or(1))?;
-        if formal_span.end()? > expression_length {
-            return None;
-        }
         self.map_expression_span_positioned_to_actual(expression, formal_span)
     }
 
@@ -920,6 +912,51 @@ impl Builder {
         expression: &Expression,
         requested: Span,
     ) -> Option<Vec<PositionedRegion>> {
+        let expression_type = &expression.comptime().r#type;
+        let packed_width = expression_type.total_width()?;
+        let expression_length =
+            packed_width.checked_mul(expression_type.total_array().unwrap_or(1))?;
+        if requested.end()? > expression_length {
+            // Context sizing extends only a packed value. Unpacked shape
+            // coercions are not bit extension and remain a conservative
+            // fallback when their flattened lengths disagree.
+            if expression_type.total_array().unwrap_or(1) != 1 {
+                return None;
+            }
+            let mut mapped = Vec::new();
+            if let Some(value_bits) = requested.intersection(Span {
+                start: 0,
+                length: packed_width,
+            }) {
+                mapped
+                    .extend(self.map_expression_span_positioned_to_actual(expression, value_bits)?);
+            }
+            let extension = requested.intersection(Span {
+                start: packed_width,
+                length: requested.end()?.checked_sub(packed_width)?,
+            });
+            if expression_type.signed
+                && packed_width != 0
+                && let Some(extension) = extension
+            {
+                mapped.extend(
+                    self.map_expression_span_positioned_to_actual(
+                        expression,
+                        Span {
+                            start: packed_width - 1,
+                            length: 1,
+                        },
+                    )?
+                    .into_iter()
+                    .map(|sign| PositionedRegion {
+                        region: sign.region,
+                        expression: extension,
+                        aligned: false,
+                    }),
+                );
+            }
+            return Some(mapped);
+        }
         match expression {
             Expression::Term(factor) => match factor.as_ref() {
                 Factor::Variable(id, index, select, _) => {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -1,0 +1,901 @@
+//! Veryl IR adapter for the IR-independent region MemorySSA engine.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::conv::Context;
+use crate::ir::{
+    ArrayLiteralItem, AssignDestination, CasePattern, CombDeclaration, Expression, Factor,
+    ForBound, ForRange, FunctionCall, Module, Op, Statement, SystemFunctionCall,
+    SystemFunctionKind, VarId, VarIndex, VarSelect,
+};
+use veryl_causal::graph::{EdgeKind, IncompleteReason};
+use veryl_causal::procedure::{
+    self, AlignedDependency, Dependency, Event, Procedure, ProcedureError, ProcedureSummary,
+};
+use veryl_causal::region::{Region, Span};
+
+pub(crate) fn analyze(
+    module: &Module,
+    declaration: &CombDeclaration,
+) -> Result<ProcedureSummary<VarId>, ProcedureError> {
+    let mut builder = Builder::new(module);
+    let exit = builder.lower_statements(&declaration.statements, 0, &[]);
+    builder.procedure.exit = exit;
+    procedure::analyze(&builder.procedure)
+}
+
+struct Builder {
+    context: Context,
+    procedure: Procedure<VarId>,
+    next_read: usize,
+    next_write: usize,
+    call_stack: Vec<VarId>,
+}
+
+impl Builder {
+    fn new(module: &Module) -> Self {
+        let mut context = Context::default();
+        context.variables = module.variables.clone();
+        context.functions = module.functions.clone();
+        let object_spans = context
+            .variables
+            .iter()
+            .filter_map(|(&id, variable)| {
+                variable
+                    .total_width()?
+                    .checked_mul(variable.r#type.total_array().unwrap_or(1))
+                    .map(|length| (id, Span { start: 0, length }))
+            })
+            .collect();
+        Self {
+            context,
+            procedure: Procedure {
+                entry: 0,
+                exit: 0,
+                successors: vec![Vec::new()],
+                events: vec![Vec::new()],
+                object_spans,
+                incomplete: BTreeSet::new(),
+            },
+            next_read: 0,
+            next_write: 0,
+            call_stack: Vec::new(),
+        }
+    }
+
+    fn nested(&self, callee: VarId) -> Self {
+        let mut context = Context::default();
+        context.variables = self.context.variables.clone();
+        context.functions = self.context.functions.clone();
+        let mut call_stack = self.call_stack.clone();
+        call_stack.push(callee);
+        Self {
+            context,
+            procedure: Procedure {
+                entry: 0,
+                exit: 0,
+                successors: vec![Vec::new()],
+                events: vec![Vec::new()],
+                object_spans: self.procedure.object_spans.clone(),
+                incomplete: BTreeSet::new(),
+            },
+            next_read: 0,
+            next_write: 0,
+            call_stack,
+        }
+    }
+
+    fn new_block(&mut self) -> usize {
+        let block = self.procedure.events.len();
+        self.procedure.events.push(Vec::new());
+        self.procedure.successors.push(Vec::new());
+        block
+    }
+
+    fn edge(&mut self, from: usize, to: usize) {
+        self.procedure.successors[from].push(to);
+    }
+
+    fn lower_statements(
+        &mut self,
+        statements: &[Statement],
+        mut block: usize,
+        controls: &[(usize, EdgeKind)],
+    ) -> usize {
+        for statement in statements {
+            block = self.lower_statement(statement, block, controls);
+        }
+        block
+    }
+
+    fn lower_statement(
+        &mut self,
+        statement: &Statement,
+        block: usize,
+        controls: &[(usize, EdgeKind)],
+    ) -> usize {
+        match statement {
+            Statement::Assign(assign) => {
+                let mut dependencies = self.read_expression(block, &assign.expr, EdgeKind::Value);
+                let aligned_dependencies = if assign.dst.len() == 1 {
+                    self.aligned_assignment_dependencies(
+                        &assign.expr,
+                        &assign.dst[0],
+                        &mut dependencies,
+                    )
+                    .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+                dependencies.extend_from_slice(controls);
+                for destination in &assign.dst {
+                    self.write_destination(
+                        block,
+                        destination,
+                        dependencies.clone(),
+                        aligned_dependencies.clone(),
+                    );
+                }
+                block
+            }
+            Statement::If(statement) => {
+                let condition = self.read_expression(block, &statement.cond, EdgeKind::Control);
+                let mut nested_controls = controls.to_vec();
+                nested_controls.extend(condition);
+                let true_block = self.new_block();
+                let false_block = self.new_block();
+                let join = self.new_block();
+                self.edge(block, true_block);
+                self.edge(block, false_block);
+                let true_exit =
+                    self.lower_statements(&statement.true_side, true_block, &nested_controls);
+                let false_exit =
+                    self.lower_statements(&statement.false_side, false_block, &nested_controls);
+                self.edge(true_exit, join);
+                self.edge(false_exit, join);
+                join
+            }
+            Statement::Case(statement) => {
+                let mut condition =
+                    self.read_expression(block, &statement.case_target, EdgeKind::Control);
+                for arm in &statement.arms {
+                    for pattern in &arm.patterns {
+                        match pattern {
+                            CasePattern::Eq(expression) => condition.extend(self.read_expression(
+                                block,
+                                expression,
+                                EdgeKind::Control,
+                            )),
+                            CasePattern::Range { lo, hi, .. } => {
+                                condition.extend(self.read_expression(
+                                    block,
+                                    lo,
+                                    EdgeKind::Control,
+                                ));
+                                condition.extend(self.read_expression(
+                                    block,
+                                    hi,
+                                    EdgeKind::Control,
+                                ));
+                            }
+                        }
+                    }
+                }
+                let mut nested_controls = controls.to_vec();
+                nested_controls.extend(condition);
+                let join = self.new_block();
+                for arm in &statement.arms {
+                    let arm_block = self.new_block();
+                    self.edge(block, arm_block);
+                    let exit = self.lower_statements(&arm.body, arm_block, &nested_controls);
+                    self.edge(exit, join);
+                }
+                let default_block = self.new_block();
+                self.edge(block, default_block);
+                let default_exit =
+                    self.lower_statements(&statement.default, default_block, &nested_controls);
+                self.edge(default_exit, join);
+                join
+            }
+            Statement::For(statement) => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::RuntimeLoop);
+                let header = self.new_block();
+                let body = self.new_block();
+                let exit = self.new_block();
+                self.edge(block, header);
+                let mut condition = Vec::new();
+                let bounds = match &statement.range {
+                    ForRange::Forward { start, end, .. }
+                    | ForRange::Reverse { start, end, .. }
+                    | ForRange::Stepped { start, end, .. } => [start, end],
+                };
+                for bound in bounds {
+                    if let ForBound::Expression(expression) = bound {
+                        condition.extend(self.read_expression(
+                            header,
+                            expression,
+                            EdgeKind::Control,
+                        ));
+                    }
+                }
+                let mut nested_controls = controls.to_vec();
+                nested_controls.extend(condition);
+                self.edge(header, body);
+                self.edge(header, exit);
+                let body_exit = self.lower_statements(&statement.body, body, &nested_controls);
+                self.edge(body_exit, header);
+                exit
+            }
+            Statement::FunctionCall(call) => {
+                self.lower_function_call(block, call, controls);
+                block
+            }
+            Statement::SystemFunctionCall(call) => {
+                self.lower_system_function(block, call, false);
+                block
+            }
+            Statement::TbMethodCall(call) => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::TimedOrEventEffect);
+                if let Some(destination) = &call.ret {
+                    let unknown = self.unknown_read(block);
+                    self.write_destination(
+                        block,
+                        destination,
+                        vec![(unknown, EdgeKind::Unknown)],
+                        Vec::new(),
+                    );
+                }
+                block
+            }
+            Statement::IfReset(_) => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::UnsupportedSyntax);
+                block
+            }
+            Statement::Break => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::RuntimeLoop);
+                block
+            }
+            Statement::Unsupported(_) => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::UnsupportedSyntax);
+                block
+            }
+            Statement::Null => block,
+        }
+    }
+
+    fn read_expression(
+        &mut self,
+        block: usize,
+        expression: &Expression,
+        kind: EdgeKind,
+    ) -> Vec<(usize, EdgeKind)> {
+        let mut reads = Vec::new();
+        match expression {
+            Expression::Term(factor) => self.read_factor(block, factor, kind, &mut reads),
+            Expression::Unary(_, expression, _) => {
+                reads.extend(self.read_expression(block, expression, kind));
+            }
+            Expression::Binary(left, _, right, _) => {
+                reads.extend(self.read_expression(block, left, kind));
+                reads.extend(self.read_expression(block, right, kind));
+            }
+            Expression::Ternary(condition, left, right, _) => {
+                reads.extend(self.read_expression(block, condition, EdgeKind::Control));
+                reads.extend(self.read_expression(block, left, kind));
+                reads.extend(self.read_expression(block, right, kind));
+            }
+            Expression::Concatenation(parts, _) => {
+                for (expression, repeat) in parts {
+                    reads.extend(self.read_expression(block, expression, kind));
+                    if let Some(repeat) = repeat {
+                        reads.extend(self.read_expression(block, repeat, EdgeKind::Address));
+                    }
+                }
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(expression, repeat) => {
+                            reads.extend(self.read_expression(block, expression, kind));
+                            if let Some(repeat) = repeat {
+                                reads.extend(self.read_expression(
+                                    block,
+                                    repeat,
+                                    EdgeKind::Address,
+                                ));
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(expression) => {
+                            reads.extend(self.read_expression(block, expression, kind));
+                        }
+                    }
+                }
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, expression) in fields {
+                    reads.extend(self.read_expression(block, expression, kind));
+                }
+            }
+        }
+        reads
+    }
+
+    fn read_factor(
+        &mut self,
+        block: usize,
+        factor: &Factor,
+        kind: EdgeKind,
+        reads: &mut Vec<(usize, EdgeKind)>,
+    ) {
+        match factor {
+            Factor::Variable(id, index, select, _) => {
+                for expression in index.0.iter().chain(select.0.iter()) {
+                    reads.extend(self.read_expression(block, expression, EdgeKind::Address));
+                }
+                if let Some((_, expression)) = &select.1 {
+                    reads.extend(self.read_expression(block, expression, EdgeKind::Address));
+                }
+                let region = self.variable_region(*id, index, select);
+                reads.push((self.push_read(block, region), kind));
+            }
+            Factor::HierVariable(_) => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::HierarchicalReference);
+                reads.push((self.unknown_read(block), EdgeKind::Unknown));
+            }
+            Factor::SystemFunctionCall(call) => {
+                reads.extend(self.lower_system_function(block, call, true));
+            }
+            Factor::FunctionCall(call) => {
+                reads.extend(self.lower_function_call(block, call, &[]));
+            }
+            Factor::Unknown(_) => {
+                reads.push((self.unknown_read(block), EdgeKind::Unknown));
+            }
+            Factor::Value(_) | Factor::Anonymous(_) => {}
+        }
+    }
+
+    fn lower_function_call(
+        &mut self,
+        block: usize,
+        call: &FunctionCall,
+        controls: &[(usize, EdgeKind)],
+    ) -> Vec<(usize, EdgeKind)> {
+        let mut actual_inputs = BTreeMap::<VarId, (Expression, Vec<(usize, EdgeKind)>)>::new();
+        let function_body = self.context.functions.get(&call.id).and_then(|function| {
+            if let Some(index) = &call.index {
+                function.get_function(index)
+            } else {
+                function.get_function(&[])
+            }
+        });
+
+        let Some(function_body) = function_body else {
+            self.procedure
+                .incomplete
+                .insert(IncompleteReason::UnsupportedSyntax);
+            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        };
+        for (path, input) in &call.inputs {
+            let reads = self.read_expression(block, input, EdgeKind::Value);
+            if let Some(&formal) = function_body.arg_map.get(path) {
+                actual_inputs.insert(formal, (input.clone(), reads));
+            }
+        }
+
+        if self.call_stack.contains(&call.id) {
+            self.procedure
+                .incomplete
+                .insert(IncompleteReason::RecursiveCall);
+            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        }
+
+        let mut nested = self.nested(call.id);
+        let exit = nested.lower_statements(&function_body.statements, 0, &[]);
+        nested.procedure.exit = exit;
+        let Ok(summary) = procedure::analyze(&nested.procedure) else {
+            self.procedure
+                .incomplete
+                .insert(IncompleteReason::UnsupportedSyntax);
+            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        };
+        if !summary.incomplete.is_empty() {
+            self.procedure
+                .incomplete
+                .extend(summary.incomplete.iter().copied());
+            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        }
+
+        let mut sources_by_output = BTreeMap::<VarId, Vec<Dependency<VarId>>>::new();
+        for dependency in &summary.dependencies {
+            let Region::Exact { object: output, .. } = dependency.output else {
+                continue;
+            };
+            sources_by_output
+                .entry(output)
+                .or_default()
+                .push(*dependency);
+        }
+
+        let mut dependencies_by_output = BTreeMap::<VarId, Vec<(usize, EdgeKind)>>::new();
+        for (&output, dependencies) in &sources_by_output {
+            let mut mapped = Vec::new();
+            for dependency in dependencies {
+                let Region::Exact { object: formal, .. } = dependency.input else {
+                    continue;
+                };
+                let Some((actual_expression, fallback_reads)) = actual_inputs.get(&formal) else {
+                    self.procedure
+                        .incomplete
+                        .insert(IncompleteReason::UnsupportedSyntax);
+                    continue;
+                };
+                if let Some(actual_regions) =
+                    self.map_formal_region_to_actual(actual_expression, dependency.input)
+                {
+                    mapped.extend(actual_regions.into_iter().map(|actual_region| {
+                        (self.push_read(block, actual_region), dependency.kind)
+                    }));
+                } else {
+                    mapped.extend(fallback_reads.iter().map(|&(read, actual_kind)| {
+                        (read, combine_edge_kinds(dependency.kind, actual_kind))
+                    }));
+                }
+            }
+            mapped.sort_unstable();
+            mapped.dedup();
+            dependencies_by_output.insert(output, mapped);
+        }
+
+        for (path, outputs) in &call.outputs {
+            let Some(&formal) = function_body.arg_map.get(path) else {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::UnsupportedSyntax);
+                continue;
+            };
+            let mut dependencies = dependencies_by_output
+                .get(&formal)
+                .cloned()
+                .unwrap_or_default();
+            dependencies.extend_from_slice(controls);
+            for destination in outputs {
+                self.write_destination(block, destination, dependencies.clone(), Vec::new());
+            }
+        }
+
+        if let Some(ret) = function_body.ret {
+            dependencies_by_output.remove(&ret).unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn map_formal_region_to_actual(
+        &mut self,
+        expression: &Expression,
+        formal_region: Region<VarId>,
+    ) -> Option<Vec<Region<VarId>>> {
+        let Region::Exact {
+            span: formal_span, ..
+        } = formal_region
+        else {
+            return None;
+        };
+        if formal_span.end()? > expression.comptime().r#type.total_width()? {
+            return None;
+        }
+        self.map_expression_span_to_actual(expression, formal_span)
+    }
+
+    /// Maps a low-bit-based span of an expression to the source variable
+    /// regions which supply those bits. `None` means that this expression
+    /// form is not modeled precisely and the caller must conservatively use
+    /// all reads. `Some([])` means the requested bits are constant.
+    fn map_expression_span_to_actual(
+        &mut self,
+        expression: &Expression,
+        requested: Span,
+    ) -> Option<Vec<Region<VarId>>> {
+        match expression {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(id, index, select, _) => {
+                    let Region::Exact {
+                        object,
+                        span: actual_span,
+                    } = self.variable_region(*id, index, select)
+                    else {
+                        return None;
+                    };
+                    if requested.end()? > actual_span.length {
+                        return None;
+                    }
+                    Some(vec![Region::Exact {
+                        object,
+                        span: Span {
+                            start: actual_span.start.checked_add(requested.start)?,
+                            length: requested.length,
+                        },
+                    }])
+                }
+                Factor::Value(_) => Some(Vec::new()),
+                _ => None,
+            },
+            Expression::Concatenation(parts, _) => {
+                let mut low = 0usize;
+                let mut mapped = Vec::new();
+                // Veryl and SystemVerilog list concatenation operands from
+                // most to least significant. Walk in reverse so `low` stays
+                // in the same LSB-based coordinate system as Region::Span.
+                for (part, repeat) in parts.iter().rev() {
+                    if repeat.is_some() {
+                        return None;
+                    }
+                    let width = part.comptime().r#type.total_width()?;
+                    let part_span = Span {
+                        start: low,
+                        length: width,
+                    };
+                    if let Some(overlap) = requested.intersection(part_span) {
+                        let local = Span {
+                            start: overlap.start.checked_sub(low)?,
+                            length: overlap.length,
+                        };
+                        mapped.extend(self.map_expression_span_to_actual(part, local)?);
+                    }
+                    low = low.checked_add(width)?;
+                }
+                Some(mapped)
+            }
+            _ => None,
+        }
+    }
+
+    fn lower_system_function(
+        &mut self,
+        block: usize,
+        call: &SystemFunctionCall,
+        value_position: bool,
+    ) -> Vec<(usize, EdgeKind)> {
+        match &call.kind {
+            SystemFunctionKind::Bits(_)
+            | SystemFunctionKind::Size(_)
+            | SystemFunctionKind::Clog2(_) => Vec::new(),
+            SystemFunctionKind::Onehot(input)
+            | SystemFunctionKind::Signed(input)
+            | SystemFunctionKind::Unsigned(input) => {
+                self.read_expression(block, &input.0, EdgeKind::Value)
+            }
+            SystemFunctionKind::Readmemh(input, output) => {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::TimedOrEventEffect);
+                let dependencies = self.read_expression(block, &input.0, EdgeKind::Unknown);
+                for destination in &output.0 {
+                    self.write_destination(block, destination, dependencies.clone(), Vec::new());
+                }
+                Vec::new()
+            }
+            SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
+                // Observer reads affect process sensitivity, but never a
+                // signal definition. Only preserve nested function output
+                // side effects; recording ordinary reads here would let a
+                // dynamic observer unnecessarily taint the whole procedure.
+                for input in inputs {
+                    self.lower_observer_expression(block, &input.0);
+                }
+                Vec::new()
+            }
+            SystemFunctionKind::Assert { cond, args, .. } => {
+                self.lower_observer_expression(block, &cond.0);
+                for input in args {
+                    self.lower_observer_expression(block, &input.0);
+                }
+                Vec::new()
+            }
+            SystemFunctionKind::Finish => Vec::new(),
+        }
+        .into_iter()
+        .map(|(read, kind)| {
+            if value_position {
+                (read, kind)
+            } else {
+                (read, EdgeKind::Value)
+            }
+        })
+        .collect()
+    }
+
+    fn lower_observer_expression(&mut self, block: usize, expression: &Expression) {
+        match expression {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::FunctionCall(call) if !call.outputs.is_empty() => {
+                    self.lower_function_call(block, call, &[]);
+                }
+                Factor::SystemFunctionCall(call) => {
+                    self.lower_system_function(block, call, false);
+                }
+                _ => {}
+            },
+            Expression::Unary(_, expression, _) => {
+                self.lower_observer_expression(block, expression);
+            }
+            Expression::Binary(left, _, right, _) => {
+                self.lower_observer_expression(block, left);
+                self.lower_observer_expression(block, right);
+            }
+            Expression::Ternary(condition, left, right, _) => {
+                self.lower_observer_expression(block, condition);
+                self.lower_observer_expression(block, left);
+                self.lower_observer_expression(block, right);
+            }
+            Expression::Concatenation(parts, _) => {
+                for (expression, repeat) in parts {
+                    self.lower_observer_expression(block, expression);
+                    if let Some(repeat) = repeat {
+                        self.lower_observer_expression(block, repeat);
+                    }
+                }
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(expression, repeat) => {
+                            self.lower_observer_expression(block, expression);
+                            if let Some(repeat) = repeat {
+                                self.lower_observer_expression(block, repeat);
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(expression) => {
+                            self.lower_observer_expression(block, expression);
+                        }
+                    }
+                }
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, expression) in fields {
+                    self.lower_observer_expression(block, expression);
+                }
+            }
+        }
+    }
+
+    fn write_destination(
+        &mut self,
+        block: usize,
+        destination: &AssignDestination,
+        mut dependencies: Vec<(usize, EdgeKind)>,
+        aligned_dependencies: Vec<AlignedDependency>,
+    ) {
+        for expression in destination
+            .index
+            .0
+            .iter()
+            .chain(destination.select.0.iter())
+        {
+            dependencies.extend(self.read_expression(block, expression, EdgeKind::Address));
+        }
+        if let Some((_, expression)) = &destination.select.1 {
+            dependencies.extend(self.read_expression(block, expression, EdgeKind::Address));
+        }
+        let region = self.variable_region(destination.id, &destination.index, &destination.select);
+        let id = self.next_write;
+        self.next_write += 1;
+        self.procedure.events[block].push(Event::Write {
+            id,
+            region,
+            dependencies,
+            aligned_dependencies,
+        });
+    }
+
+    fn aligned_assignment_dependencies(
+        &mut self,
+        expression: &Expression,
+        destination: &AssignDestination,
+        dependencies: &mut Vec<(usize, EdgeKind)>,
+    ) -> Option<Vec<AlignedDependency>> {
+        let Region::Exact {
+            span: destination_span,
+            ..
+        } = self.variable_region(destination.id, &destination.index, &destination.select)
+        else {
+            return None;
+        };
+        if expression.comptime().r#type.total_width()? != destination_span.length {
+            return None;
+        }
+
+        let mut dependency_cursor = 0usize;
+        let mut aligned = Vec::new();
+        self.collect_aligned_expression_dependencies(
+            expression,
+            Span {
+                start: 0,
+                length: destination_span.length,
+            },
+            dependencies,
+            &mut dependency_cursor,
+            &mut aligned,
+        )?;
+        if dependency_cursor != dependencies.len() {
+            return None;
+        }
+        dependencies.clear();
+        Some(aligned)
+    }
+
+    fn collect_aligned_expression_dependencies(
+        &mut self,
+        expression: &Expression,
+        destination: Span,
+        dependencies: &[(usize, EdgeKind)],
+        dependency_cursor: &mut usize,
+        aligned: &mut Vec<AlignedDependency>,
+    ) -> Option<()> {
+        if expression.comptime().r#type.total_width()? != destination.length {
+            return None;
+        }
+        match expression {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Value(_) => Some(()),
+                Factor::Variable(id, index, select, _) => {
+                    let Region::Exact {
+                        span: source_span, ..
+                    } = self.variable_region(*id, index, select)
+                    else {
+                        return None;
+                    };
+                    if source_span.length != destination.length {
+                        return None;
+                    }
+                    let &(read, kind) = dependencies.get(*dependency_cursor)?;
+                    if kind != EdgeKind::Value {
+                        return None;
+                    }
+                    *dependency_cursor += 1;
+                    aligned.push(AlignedDependency {
+                        read,
+                        kind,
+                        destination,
+                    });
+                    Some(())
+                }
+                _ => None,
+            },
+            Expression::Concatenation(parts, _) => {
+                let mut low = destination.end()?;
+                for (part, repeat) in parts {
+                    if repeat.is_some() {
+                        return None;
+                    }
+                    let width = part.comptime().r#type.total_width()?;
+                    low = low.checked_sub(width)?;
+                    self.collect_aligned_expression_dependencies(
+                        part,
+                        Span {
+                            start: low,
+                            length: width,
+                        },
+                        dependencies,
+                        dependency_cursor,
+                        aligned,
+                    )?;
+                }
+                (low == destination.start).then_some(())
+            }
+            Expression::Unary(op, operand, _)
+                if matches!(op, Op::BitNot | Op::Add)
+                    && operand.comptime().r#type.total_width()? == destination.length =>
+            {
+                self.collect_aligned_expression_dependencies(
+                    operand,
+                    destination,
+                    dependencies,
+                    dependency_cursor,
+                    aligned,
+                )
+            }
+            Expression::Binary(left, op, right, _)
+                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
+                    && left.comptime().r#type.total_width()? == destination.length
+                    && right.comptime().r#type.total_width()? == destination.length =>
+            {
+                self.collect_aligned_expression_dependencies(
+                    left,
+                    destination,
+                    dependencies,
+                    dependency_cursor,
+                    aligned,
+                )?;
+                self.collect_aligned_expression_dependencies(
+                    right,
+                    destination,
+                    dependencies,
+                    dependency_cursor,
+                    aligned,
+                )
+            }
+            _ => None,
+        }
+    }
+
+    fn push_read(&mut self, block: usize, region: Region<VarId>) -> usize {
+        let id = self.next_read;
+        self.next_read += 1;
+        self.procedure.events[block].push(Event::Read { id, region });
+        id
+    }
+
+    fn unknown_read(&mut self, block: usize) -> usize {
+        self.push_read(block, Region::UnknownAll)
+    }
+
+    fn variable_region(
+        &mut self,
+        id: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+    ) -> Region<VarId> {
+        let Some(variable) = self.context.variables.get(&id).cloned() else {
+            return Region::UnknownObject(id);
+        };
+        let Some(width) = variable.total_width() else {
+            return Region::UnknownObject(id);
+        };
+        // `eval_value` maps an X/Z numeric index to zero for simulation
+        // convenience. Alias analysis must not mistake that fallback for a
+        // statically resolved address.
+        if !index.is_const() || !select.is_const_with_range() {
+            return Region::UnknownObject(id);
+        }
+        let Some(index_path) = index.eval_value(&mut self.context) else {
+            return Region::UnknownObject(id);
+        };
+        let Some(array_index) = variable.r#type.array.calc_index(&index_path) else {
+            return Region::UnknownObject(id);
+        };
+        let Some((high, low)) = select.eval_value(&mut self.context, &variable.r#type, false)
+        else {
+            return Region::UnknownObject(id);
+        };
+        let start = match array_index
+            .checked_mul(width)
+            .and_then(|base| base.checked_add(low))
+        {
+            Some(start) => start,
+            None => return Region::UnknownObject(id),
+        };
+        let Some(length) = high.checked_sub(low).and_then(|delta| delta.checked_add(1)) else {
+            return Region::UnknownObject(id);
+        };
+        Region::Exact {
+            object: id,
+            span: Span { start, length },
+        }
+    }
+}
+
+fn combine_edge_kinds(left: EdgeKind, right: EdgeKind) -> EdgeKind {
+    if left == EdgeKind::Unknown || right == EdgeKind::Unknown {
+        EdgeKind::Unknown
+    } else if left == EdgeKind::Control || right == EdgeKind::Control {
+        EdgeKind::Control
+    } else if left == EdgeKind::Address || right == EdgeKind::Address {
+        EdgeKind::Address
+    } else {
+        EdgeKind::Value
+    }
+}

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -1703,10 +1703,11 @@ impl Builder {
     }
 
     fn binary_rhs_is_reachable(&mut self, left: &Expression, op: Op) -> bool {
-        !matches!(
-            (op, self.constant_condition(left)),
-            (Op::LogicAnd, Some(false)) | (Op::LogicOr, Some(true))
-        )
+        match op {
+            Op::LogicAnd => self.constant_condition(left) != Some(false),
+            Op::LogicOr => self.constant_condition(left) != Some(true),
+            _ => true,
+        }
     }
 
     fn write_destination(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -29,6 +29,19 @@ pub(crate) fn analyze(
     procedure::analyze(&builder.procedure)
 }
 
+pub(crate) fn analyze_observer_expression(
+    module: &Module,
+    expression: &Expression,
+) -> Result<ProcedureSummary<VarId>, ProcedureError> {
+    let mut builder = Builder::new(module);
+    builder.lower_observer_expression(0, expression);
+    builder.procedure.exit = 0;
+    if let Some(message) = builder.model_error {
+        return Err(ProcedureError::Model(message));
+    }
+    procedure::analyze(&builder.procedure)
+}
+
 /// Map a result-bit span to the module regions which structurally supply it.
 /// `None` requests the caller's conservative, all-operands fallback.
 pub(crate) fn map_expression_span(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -410,8 +410,14 @@ impl Builder {
             }
             Expression::Ternary(condition, left, right, _) => {
                 reads.extend(self.read_expression(block, condition, EdgeKind::Control));
-                reads.extend(self.read_expression(block, left, kind));
-                reads.extend(self.read_expression(block, right, kind));
+                match self.constant_condition(condition) {
+                    Some(true) => reads.extend(self.read_expression(block, left, kind)),
+                    Some(false) => reads.extend(self.read_expression(block, right, kind)),
+                    None => {
+                        reads.extend(self.read_expression(block, left, kind));
+                        reads.extend(self.read_expression(block, right, kind));
+                    }
+                }
             }
             Expression::Concatenation(parts, _) => {
                 for (expression, repeat) in parts {
@@ -1272,8 +1278,14 @@ impl Builder {
             }
             Expression::Ternary(condition, left, right, _) => {
                 self.lower_observer_expression(block, condition);
-                self.lower_observer_expression(block, left);
-                self.lower_observer_expression(block, right);
+                match self.constant_condition(condition) {
+                    Some(true) => self.lower_observer_expression(block, left),
+                    Some(false) => self.lower_observer_expression(block, right),
+                    None => {
+                        self.lower_observer_expression(block, left);
+                        self.lower_observer_expression(block, right);
+                    }
+                }
             }
             Expression::Concatenation(parts, _) => {
                 for (expression, repeat) in parts {
@@ -1304,6 +1316,11 @@ impl Builder {
                 }
             }
         }
+    }
+
+    fn constant_condition(&mut self, expression: &Expression) -> Option<bool> {
+        let value = expression.clone().eval_value(&mut self.context)?;
+        (!value.is_xz()).then(|| value.is_positive())
     }
 
     fn write_destination(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -10,7 +10,7 @@ use crate::ir::{
 };
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
-    self, AlignedDependency, Event, Procedure, ProcedureError, ProcedureSummary,
+    self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError, ProcedureSummary,
 };
 use veryl_causal::region::{Region, Span};
 
@@ -47,6 +47,7 @@ struct Builder {
     procedure: Procedure<VarId>,
     next_read: usize,
     next_write: usize,
+    unresolved_writes: BTreeMap<String, Vec<(usize, Vec<usize>)>>,
     call_stack: Vec<VarId>,
     model_error: Option<&'static str>,
 }
@@ -78,10 +79,12 @@ impl Builder {
                 successors: vec![Vec::new()],
                 events: vec![Vec::new()],
                 object_spans,
+                must_alias: BTreeSet::new(),
                 incomplete: BTreeSet::new(),
             },
             next_read: 0,
             next_write: 0,
+            unresolved_writes: BTreeMap::new(),
             call_stack: Vec::new(),
             model_error: None,
         }
@@ -101,10 +104,12 @@ impl Builder {
                 successors: vec![Vec::new()],
                 events: vec![Vec::new()],
                 object_spans: self.procedure.object_spans.clone(),
+                must_alias: BTreeSet::new(),
                 incomplete: BTreeSet::new(),
             },
             next_read: 0,
             next_write: 0,
+            unresolved_writes: BTreeMap::new(),
             call_stack,
             model_error: None,
         }
@@ -403,14 +408,27 @@ impl Builder {
     ) {
         match factor {
             Factor::Variable(id, index, select, _) => {
+                let mut selector_reads = Vec::new();
                 for expression in index.0.iter().chain(select.0.iter()) {
-                    reads.extend(self.read_expression(block, expression, EdgeKind::Address));
+                    selector_reads.extend(self.read_expression(
+                        block,
+                        expression,
+                        EdgeKind::Address,
+                    ));
                 }
                 if let Some((_, expression)) = &select.1 {
-                    reads.extend(self.read_expression(block, expression, EdgeKind::Address));
+                    selector_reads.extend(self.read_expression(
+                        block,
+                        expression,
+                        EdgeKind::Address,
+                    ));
                 }
+                reads.extend(selector_reads.iter().copied());
                 let region = self.variable_region(*id, index, select);
-                reads.push((self.push_read(block, region), kind));
+                reads.push((
+                    self.push_variable_read(block, *id, index, select, region, &selector_reads),
+                    kind,
+                ));
             }
             Factor::HierVariable(_) => {
                 self.procedure
@@ -924,20 +942,33 @@ impl Builder {
         mut dependencies: Vec<(usize, EdgeKind)>,
         aligned_dependencies: Vec<AlignedDependency>,
     ) {
+        let mut selector_reads = Vec::new();
         for expression in destination
             .index
             .0
             .iter()
             .chain(destination.select.0.iter())
         {
-            dependencies.extend(self.read_expression(block, expression, EdgeKind::Address));
+            selector_reads.extend(self.read_expression(block, expression, EdgeKind::Address));
         }
         if let Some((_, expression)) = &destination.select.1 {
-            dependencies.extend(self.read_expression(block, expression, EdgeKind::Address));
+            selector_reads.extend(self.read_expression(block, expression, EdgeKind::Address));
         }
+        dependencies.extend(selector_reads.iter().copied());
         let region = self.variable_region(destination.id, &destination.index, &destination.select);
         let id = self.next_write;
         self.next_write += 1;
+        if let Some(key) = Self::unresolved_access_key(
+            destination.id,
+            &destination.index,
+            &destination.select,
+            region,
+        ) {
+            self.unresolved_writes
+                .entry(key)
+                .or_default()
+                .push((id, selector_reads.iter().map(|&(read, _)| read).collect()));
+        }
         self.procedure.events[block].push(Event::Write {
             id,
             region,
@@ -1208,6 +1239,49 @@ impl Builder {
         self.next_read += 1;
         self.procedure.events[block].push(Event::Read { id, region });
         id
+    }
+
+    fn push_variable_read(
+        &mut self,
+        block: usize,
+        object: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+        region: Region<VarId>,
+        selector_reads: &[(usize, EdgeKind)],
+    ) -> usize {
+        let read = self.push_read(block, region);
+        if let Some(key) = Self::unresolved_access_key(object, index, select, region) {
+            let read_selectors = selector_reads
+                .iter()
+                .map(|&(selector, _)| selector)
+                .collect::<Vec<_>>();
+            if let Some(writes) = self.unresolved_writes.get(&key) {
+                for (write, write_selectors) in writes {
+                    if write_selectors.len() == read_selectors.len() {
+                        self.procedure.must_alias.insert(MustAliasCandidate {
+                            read,
+                            write: *write,
+                            selector_reads: write_selectors
+                                .iter()
+                                .copied()
+                                .zip(read_selectors.iter().copied())
+                                .collect(),
+                        });
+                    }
+                }
+            }
+        }
+        read
+    }
+
+    fn unresolved_access_key(
+        object: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+        region: Region<VarId>,
+    ) -> Option<String> {
+        (!region.is_exact()).then(|| format!("{object:?}{index}{select}"))
     }
 
     fn unknown_read(&mut self, block: usize) -> usize {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -194,7 +194,7 @@ fn positioned_extent(length: usize, axes: &[PeriodicAxis]) -> Option<usize> {
     })
 }
 
-fn clip_aligned_dependency(
+pub(crate) fn clip_aligned_dependency(
     dependency: &AlignedDependency,
     destination: Span,
 ) -> Option<Vec<AlignedDependency>> {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -6,8 +6,9 @@ use crate::conv::Context;
 use crate::ir::{
     ArrayLiteralItem, AssignDestination, CasePattern, CombDeclaration, Expression, Factor,
     ForBound, ForRange, FunctionCall, Module, Op, Statement, SystemFunctionCall,
-    SystemFunctionKind, VarId, VarIndex, VarSelect,
+    SystemFunctionKind, TypeKind, VarId, VarIndex, VarSelect,
 };
+use crate::value::Value;
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
     self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError, ProcedureSummary,
@@ -1657,6 +1658,9 @@ impl Builder {
                 span: Span { start: 0, length },
             };
         }
+        if let Some(region) = self.bounded_variable_region(id, &variable, index, select, width) {
+            return region;
+        }
         // Preserve the longest statically known prefix. `eval_value` maps an
         // X/Z numeric index to zero for simulation convenience, so alias
         // analysis must inspect every constant before accepting its value.
@@ -1762,6 +1766,162 @@ impl Builder {
         Region::UnknownRegion {
             object: id,
             span: Span { start, length },
+        }
+    }
+
+    /// Exactly enumerate small two-state selector domains. This is deliberately
+    /// bounded: four-state selectors retain X/Z candidates, and large domains
+    /// fall back to the longest-static-prefix region below.
+    fn bounded_variable_region(
+        &mut self,
+        id: VarId,
+        variable: &crate::ir::Variable,
+        index: &VarIndex,
+        select: &VarSelect,
+        width: usize,
+    ) -> Option<Region<VarId>> {
+        let expressions = index
+            .0
+            .iter()
+            .chain(select.0.iter())
+            .chain(select.1.iter().map(|(_, bound)| bound))
+            .collect::<Vec<_>>();
+        if expressions
+            .iter()
+            .all(|expression| expression.comptime().is_const)
+        {
+            return None;
+        }
+
+        let mut ids = BTreeSet::new();
+        if !expressions
+            .iter()
+            .all(|expression| Self::collect_two_state_variables(expression, &mut ids))
+        {
+            return None;
+        }
+        let variables = ids
+            .into_iter()
+            .map(|id| {
+                let variable = self.context.variables.get(&id)?;
+                let bits = variable.total_width()?;
+                (matches!(variable.r#type.kind, TypeKind::Bit)
+                    && variable.r#type.total_array()? == 1
+                    && bits <= 8)
+                    .then_some((id, bits, variable.r#type.signed))
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let total_bits = variables
+            .iter()
+            .try_fold(0usize, |total, (_, bits, _)| total.checked_add(*bits))?;
+        if total_bits > 8 {
+            return None;
+        }
+
+        let saved = variables
+            .iter()
+            .map(|&(id, _, _)| Some((id, self.context.variables.get(&id)?.value.clone())))
+            .collect::<Option<Vec<_>>>()?;
+        let assignments = 1usize.checked_shl(total_bits as u32)?;
+        let mut spans = Vec::new();
+        for assignment in 0..assignments {
+            let mut shift = 0usize;
+            for &(id, bits, signed) in &variables {
+                let mask = (1usize << bits).saturating_sub(1);
+                let payload = ((assignment >> shift) & mask) as u64;
+                let Some(variable) = self.context.variables.get_mut(&id) else {
+                    continue;
+                };
+                variable.value = vec![Value::new(payload, bits, signed)];
+                shift += bits;
+            }
+            let Some(index_path) = index.eval_value(&mut self.context) else {
+                continue;
+            };
+            let Some(array_index) = variable.r#type.array.calc_index(&index_path) else {
+                continue;
+            };
+            let Some((high, low)) = select.eval_value(&mut self.context, &variable.r#type, false)
+            else {
+                continue;
+            };
+            if high >= width || low > high {
+                continue;
+            }
+            let Some(start) = array_index
+                .checked_mul(width)
+                .and_then(|base| base.checked_add(low))
+            else {
+                continue;
+            };
+            spans.push(Span {
+                start,
+                length: high - low + 1,
+            });
+        }
+        for (id, value) in saved {
+            if let Some(variable) = self.context.variables.get_mut(&id) {
+                variable.value = value;
+            }
+        }
+
+        spans.sort_unstable();
+        spans.dedup();
+        let first = spans.first().copied()?;
+        let mut end = first.end()?;
+        for span in spans.iter().copied().skip(1) {
+            if span.start > end {
+                return None;
+            }
+            end = end.max(span.end()?);
+        }
+        Some(Region::UnknownRegion {
+            object: id,
+            span: Span {
+                start: first.start,
+                length: end.checked_sub(first.start)?,
+            },
+        })
+    }
+
+    fn collect_two_state_variables(expression: &Expression, ids: &mut BTreeSet<VarId>) -> bool {
+        if expression.comptime().is_const {
+            return true;
+        }
+        match expression {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(id, index, select, _)
+                    if index.0.is_empty() && select.is_empty() =>
+                {
+                    ids.insert(*id);
+                    true
+                }
+                Factor::SystemFunctionCall(call) => match &call.kind {
+                    SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
+                        Self::collect_two_state_variables(&input.0, ids)
+                    }
+                    _ => false,
+                },
+                Factor::Value(_) => true,
+                _ => false,
+            },
+            Expression::Unary(_, operand, _) => Self::collect_two_state_variables(operand, ids),
+            Expression::Binary(left, _, right, _) => {
+                Self::collect_two_state_variables(left, ids)
+                    && Self::collect_two_state_variables(right, ids)
+            }
+            Expression::Ternary(condition, left, right, _) => {
+                Self::collect_two_state_variables(condition, ids)
+                    && Self::collect_two_state_variables(left, ids)
+                    && Self::collect_two_state_variables(right, ids)
+            }
+            Expression::Concatenation(parts, _) => parts.iter().all(|(part, repeat)| {
+                Self::collect_two_state_variables(part, ids)
+                    && repeat
+                        .as_ref()
+                        .is_none_or(|repeat| Self::collect_two_state_variables(repeat, ids))
+            }),
+            Expression::ArrayLiteral(_, _) | Expression::StructConstructor(_, _, _) => false,
         }
     }
 }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -21,7 +21,23 @@ pub(crate) fn analyze(
     let mut builder = Builder::new(module);
     let exit = builder.lower_statements(&declaration.statements, 0, &[]);
     builder.procedure.exit = exit;
+    if let Some(message) = builder.model_error {
+        return Err(ProcedureError::Model(message));
+    }
     procedure::analyze(&builder.procedure)
+}
+
+/// Map a result-bit span to the module regions which structurally supply it.
+/// `None` requests the caller's conservative, all-operands fallback.
+pub(crate) fn map_expression_span(
+    context: &Context,
+    expression: &Expression,
+    requested: Span,
+) -> Option<Vec<Region<VarId>>> {
+    let mut nested_context = Context::default();
+    nested_context.variables = context.variables.clone();
+    nested_context.functions = context.functions.clone();
+    Builder::with_context(nested_context).map_expression_span_to_actual(expression, requested)
 }
 
 struct Builder {
@@ -30,6 +46,7 @@ struct Builder {
     next_read: usize,
     next_write: usize,
     call_stack: Vec<VarId>,
+    model_error: Option<&'static str>,
 }
 
 impl Builder {
@@ -37,6 +54,10 @@ impl Builder {
         let mut context = Context::default();
         context.variables = module.variables.clone();
         context.functions = module.functions.clone();
+        Self::with_context(context)
+    }
+
+    fn with_context(context: Context) -> Self {
         let object_spans = context
             .variables
             .iter()
@@ -60,6 +81,7 @@ impl Builder {
             next_read: 0,
             next_write: 0,
             call_stack: Vec::new(),
+            model_error: None,
         }
     }
 
@@ -82,6 +104,7 @@ impl Builder {
             next_read: 0,
             next_write: 0,
             call_stack,
+            model_error: None,
         }
     }
 
@@ -252,9 +275,8 @@ impl Builder {
                 block
             }
             Statement::IfReset(_) => {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::UnsupportedSyntax);
+                self.model_error
+                    .get_or_insert("always_comb contains an always_ff-only if_reset statement");
                 block
             }
             Statement::Break => {
@@ -264,9 +286,9 @@ impl Builder {
                 block
             }
             Statement::Unsupported(_) => {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::UnsupportedSyntax);
+                self.model_error.get_or_insert(
+                    "always_comb contains a statement rejected during IR conversion",
+                );
                 block
             }
             Statement::Null => block,
@@ -383,9 +405,8 @@ impl Builder {
         });
 
         let Some(function_body) = function_body else {
-            self.procedure
-                .incomplete
-                .insert(IncompleteReason::UnsupportedSyntax);
+            self.model_error
+                .get_or_insert("resolved function call has no instantiated function body");
             return vec![(self.unknown_read(block), EdgeKind::Unknown)];
         };
         for (path, input) in &call.inputs {
@@ -405,17 +426,21 @@ impl Builder {
         let mut nested = self.nested(call.id);
         let exit = nested.lower_statements(&function_body.statements, 0, &[]);
         nested.procedure.exit = exit;
+        if self.model_error.is_none() {
+            self.model_error = nested.model_error;
+        }
+        if self.model_error.is_some() {
+            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        }
         let Ok(summary) = procedure::analyze(&nested.procedure) else {
-            self.procedure
-                .incomplete
-                .insert(IncompleteReason::UnsupportedSyntax);
+            self.model_error
+                .get_or_insert("function body produced an invalid causal model");
             return vec![(self.unknown_read(block), EdgeKind::Unknown)];
         };
         if !summary.incomplete.is_empty() {
             self.procedure
                 .incomplete
                 .extend(summary.incomplete.iter().copied());
-            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
         }
 
         let mut sources_by_output = BTreeMap::<VarId, Vec<Dependency<VarId>>>::new();
@@ -437,9 +462,8 @@ impl Builder {
                     continue;
                 };
                 let Some((actual_expression, fallback_reads)) = actual_inputs.get(&formal) else {
-                    self.procedure
-                        .incomplete
-                        .insert(IncompleteReason::UnsupportedSyntax);
+                    self.model_error
+                        .get_or_insert("function dependency refers to an unmapped input argument");
                     continue;
                 };
                 if let Some(actual_regions) =
@@ -461,9 +485,8 @@ impl Builder {
 
         for (path, outputs) in &call.outputs {
             let Some(&formal) = function_body.arg_map.get(path) else {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::UnsupportedSyntax);
+                self.model_error
+                    .get_or_insert("function call output has no formal argument mapping");
                 continue;
             };
             let mut dependencies = dependencies_by_output
@@ -531,6 +554,18 @@ impl Builder {
                     }])
                 }
                 Factor::Value(_) => Some(Vec::new()),
+                Factor::SystemFunctionCall(call) => match &call.kind {
+                    SystemFunctionKind::Bits(_)
+                    | SystemFunctionKind::Size(_)
+                    | SystemFunctionKind::Clog2(_) => Some(Vec::new()),
+                    SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
+                        self.map_expression_span_to_actual(&input.0, requested)
+                    }
+                    _ => None,
+                },
+                Factor::FunctionCall(call) => {
+                    self.map_function_return_span_to_actual(call, requested)
+                }
                 _ => None,
             },
             Expression::Concatenation(parts, _) => {
@@ -559,8 +594,83 @@ impl Builder {
                 }
                 Some(mapped)
             }
+            Expression::Unary(op, operand, _)
+                if matches!(op, Op::BitNot | Op::Add)
+                    && operand.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()? =>
+            {
+                self.map_expression_span_to_actual(operand, requested)
+            }
+            Expression::Binary(left, op, right, _)
+                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
+                    && left.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()?
+                    && right.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()? =>
+            {
+                let mut mapped = self.map_expression_span_to_actual(left, requested)?;
+                mapped.extend(self.map_expression_span_to_actual(right, requested)?);
+                Some(mapped)
+            }
             _ => None,
         }
+    }
+
+    fn map_function_return_span_to_actual(
+        &mut self,
+        call: &FunctionCall,
+        requested: Span,
+    ) -> Option<Vec<Region<VarId>>> {
+        if self.call_stack.contains(&call.id) {
+            return None;
+        }
+        let function_body = self.context.functions.get(&call.id).and_then(|function| {
+            if let Some(index) = &call.index {
+                function.get_function(index)
+            } else {
+                function.get_function(&[])
+            }
+        })?;
+        let ret = function_body.ret?;
+
+        let mut actual_inputs = BTreeMap::<VarId, &Expression>::new();
+        for (path, input) in &call.inputs {
+            if let Some(&formal) = function_body.arg_map.get(path) {
+                actual_inputs.insert(formal, input);
+            }
+        }
+
+        let mut nested = self.nested(call.id);
+        let exit = nested.lower_statements(&function_body.statements, 0, &[]);
+        nested.procedure.exit = exit;
+        if nested.model_error.is_some() {
+            return None;
+        }
+        let summary = procedure::analyze(&nested.procedure).ok()?;
+        let mut mapped = Vec::new();
+        for dependency in summary.dependencies {
+            let Region::Exact {
+                object: output,
+                span: output_span,
+            } = dependency.output
+            else {
+                continue;
+            };
+            if output != ret || output_span.intersection(requested).is_none() {
+                continue;
+            }
+            if dependency.kind == EdgeKind::Unknown {
+                continue;
+            }
+            let Region::Exact { object: input, .. } = dependency.input else {
+                continue;
+            };
+            let actual = actual_inputs.get(&input)?;
+            mapped.extend(self.map_formal_region_to_actual(actual, dependency.input)?);
+        }
+        mapped.sort_unstable();
+        mapped.dedup();
+        Some(mapped)
     }
 
     fn lower_system_function(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -19,7 +19,9 @@ pub(crate) fn analyze(
     declaration: &CombDeclaration,
 ) -> Result<ProcedureSummary<VarId>, ProcedureError> {
     let mut builder = Builder::new(module);
-    let exit = builder.lower_statements(&declaration.statements, 0, &[]);
+    let exit = builder
+        .lower_statements(&declaration.statements, 0, &[], None)
+        .unwrap_or(0);
     builder.procedure.exit = exit;
     if let Some(message) = builder.model_error {
         return Err(ProcedureError::Model(message));
@@ -124,11 +126,12 @@ impl Builder {
         statements: &[Statement],
         mut block: usize,
         controls: &[(usize, EdgeKind)],
-    ) -> usize {
+        break_target: Option<usize>,
+    ) -> Option<usize> {
         for statement in statements {
-            block = self.lower_statement(statement, block, controls);
+            block = self.lower_statement(statement, block, controls, break_target)?;
         }
-        block
+        Some(block)
     }
 
     fn lower_statement(
@@ -136,7 +139,8 @@ impl Builder {
         statement: &Statement,
         block: usize,
         controls: &[(usize, EdgeKind)],
-    ) -> usize {
+        break_target: Option<usize>,
+    ) -> Option<usize> {
         match statement {
             Statement::Assign(assign) => {
                 let mut dependencies = self.read_expression(block, &assign.expr, EdgeKind::Value);
@@ -159,7 +163,7 @@ impl Builder {
                         aligned_dependencies.clone(),
                     );
                 }
-                block
+                Some(block)
             }
             Statement::If(statement) => {
                 let condition = self.read_expression(block, &statement.cond, EdgeKind::Control);
@@ -167,16 +171,30 @@ impl Builder {
                 nested_controls.extend(condition);
                 let true_block = self.new_block();
                 let false_block = self.new_block();
-                let join = self.new_block();
                 self.edge(block, true_block);
                 self.edge(block, false_block);
-                let true_exit =
-                    self.lower_statements(&statement.true_side, true_block, &nested_controls);
-                let false_exit =
-                    self.lower_statements(&statement.false_side, false_block, &nested_controls);
-                self.edge(true_exit, join);
-                self.edge(false_exit, join);
-                join
+                let true_exit = self.lower_statements(
+                    &statement.true_side,
+                    true_block,
+                    &nested_controls,
+                    break_target,
+                );
+                let false_exit = self.lower_statements(
+                    &statement.false_side,
+                    false_block,
+                    &nested_controls,
+                    break_target,
+                );
+                let exits = true_exit.into_iter().chain(false_exit).collect::<Vec<_>>();
+                if exits.is_empty() {
+                    None
+                } else {
+                    let join = self.new_block();
+                    for exit in exits {
+                        self.edge(exit, join);
+                    }
+                    Some(join)
+                }
             }
             Statement::Case(statement) => {
                 let mut condition =
@@ -206,19 +224,34 @@ impl Builder {
                 }
                 let mut nested_controls = controls.to_vec();
                 nested_controls.extend(condition);
-                let join = self.new_block();
+                let mut exits = Vec::new();
                 for arm in &statement.arms {
                     let arm_block = self.new_block();
                     self.edge(block, arm_block);
-                    let exit = self.lower_statements(&arm.body, arm_block, &nested_controls);
-                    self.edge(exit, join);
+                    exits.extend(self.lower_statements(
+                        &arm.body,
+                        arm_block,
+                        &nested_controls,
+                        break_target,
+                    ));
                 }
                 let default_block = self.new_block();
                 self.edge(block, default_block);
-                let default_exit =
-                    self.lower_statements(&statement.default, default_block, &nested_controls);
-                self.edge(default_exit, join);
-                join
+                exits.extend(self.lower_statements(
+                    &statement.default,
+                    default_block,
+                    &nested_controls,
+                    break_target,
+                ));
+                if exits.is_empty() {
+                    None
+                } else {
+                    let join = self.new_block();
+                    for exit in exits {
+                        self.edge(exit, join);
+                    }
+                    Some(join)
+                }
             }
             Statement::For(statement) => {
                 self.procedure
@@ -247,17 +280,20 @@ impl Builder {
                 nested_controls.extend(condition);
                 self.edge(header, body);
                 self.edge(header, exit);
-                let body_exit = self.lower_statements(&statement.body, body, &nested_controls);
-                self.edge(body_exit, header);
-                exit
+                if let Some(body_exit) =
+                    self.lower_statements(&statement.body, body, &nested_controls, Some(exit))
+                {
+                    self.edge(body_exit, header);
+                }
+                Some(exit)
             }
             Statement::FunctionCall(call) => {
                 self.lower_function_call(block, call, controls);
-                block
+                Some(block)
             }
             Statement::SystemFunctionCall(call) => {
                 self.lower_system_function(block, call, false);
-                block
+                Some(block)
             }
             Statement::TbMethodCall(call) => {
                 self.procedure
@@ -272,26 +308,32 @@ impl Builder {
                         Vec::new(),
                     );
                 }
-                block
+                Some(block)
             }
             Statement::IfReset(_) => {
                 self.model_error
                     .get_or_insert("always_comb contains an always_ff-only if_reset statement");
-                block
+                Some(block)
             }
             Statement::Break => {
                 self.procedure
                     .incomplete
                     .insert(IncompleteReason::RuntimeLoop);
-                block
+                if let Some(target) = break_target {
+                    self.edge(block, target);
+                } else {
+                    self.model_error
+                        .get_or_insert("break appears outside a lowered loop");
+                }
+                None
             }
             Statement::Unsupported(_) => {
                 self.model_error.get_or_insert(
                     "always_comb contains a statement rejected during IR conversion",
                 );
-                block
+                Some(block)
             }
-            Statement::Null => block,
+            Statement::Null => Some(block),
         }
     }
 
@@ -424,7 +466,9 @@ impl Builder {
         }
 
         let mut nested = self.nested(call.id);
-        let exit = nested.lower_statements(&function_body.statements, 0, &[]);
+        let exit = nested
+            .lower_statements(&function_body.statements, 0, &[], None)
+            .unwrap_or(0);
         nested.procedure.exit = exit;
         if self.model_error.is_none() {
             self.model_error = nested.model_error;
@@ -641,7 +685,9 @@ impl Builder {
         }
 
         let mut nested = self.nested(call.id);
-        let exit = nested.lower_statements(&function_body.statements, 0, &[]);
+        let exit = nested
+            .lower_statements(&function_body.statements, 0, &[], None)
+            .unwrap_or(0);
         nested.procedure.exit = exit;
         if nested.model_error.is_some() {
             return None;

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -33,6 +33,11 @@ enum FunctionCacheEntry {
     Ready(Option<Arc<ProcedureAnalysis>>),
 }
 
+enum PeriodicAssignmentRun {
+    Lowered(usize),
+    Rejected(usize),
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct FunctionAnalysisCache {
     entries: Arc<Mutex<BTreeMap<FunctionKey, FunctionCacheEntry>>>,
@@ -706,10 +711,19 @@ impl Builder {
     ) -> Option<usize> {
         let mut index = 0usize;
         while index < statements.len() {
-            if let Some(consumed) =
+            if let Some(run) =
                 self.lower_periodic_variable_assignments(&statements[index..], block, controls)
             {
-                index += consumed;
+                match run {
+                    PeriodicAssignmentRun::Lowered(consumed) => index += consumed,
+                    PeriodicAssignmentRun::Rejected(consumed) => {
+                        for statement in &statements[index..index + consumed] {
+                            block =
+                                self.lower_statement(statement, block, controls, break_target)?;
+                        }
+                        index += consumed;
+                    }
+                }
                 continue;
             }
             block = self.lower_statement(&statements[index], block, controls, break_target)?;
@@ -727,7 +741,7 @@ impl Builder {
         statements: &[Statement],
         block: usize,
         controls: &[(usize, EdgeKind)],
-    ) -> Option<usize> {
+    ) -> Option<PeriodicAssignmentRun> {
         let Statement::Assign(first) = statements.first()? else {
             return None;
         };
@@ -786,18 +800,21 @@ impl Builder {
             .iter()
             .any(|(candidate, _)| *candidate != object)
         {
-            return None;
+            return Some(PeriodicAssignmentRun::Rejected(destinations.len()));
         }
         destinations.sort_unstable_by_key(|(_, span)| span.start);
         if destinations
             .windows(2)
             .any(|pair| pair[0].1.end().is_none_or(|end| end != pair[1].1.start))
         {
-            return None;
+            return Some(PeriodicAssignmentRun::Rejected(destinations.len()));
         }
+        let Some(length) = source_span.length.checked_mul(destinations.len()) else {
+            return Some(PeriodicAssignmentRun::Rejected(destinations.len()));
+        };
         let output = Span {
             start: destinations[0].1.start,
-            length: source_span.length.checked_mul(destinations.len())?,
+            length,
         };
         let read = self.push_read(block, source);
         let id = self.next_write;
@@ -831,7 +848,7 @@ impl Builder {
                     .collect(),
             }],
         });
-        Some(destinations.len())
+        Some(PeriodicAssignmentRun::Lowered(destinations.len()))
     }
 
     fn lower_statement(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -27,6 +27,39 @@ pub(crate) struct ProcedureAnalysis {
 
 type FunctionKey = (VarId, usize);
 type FunctionSummaries = BTreeMap<FunctionKey, Option<Arc<ProcedureAnalysis>>>;
+type ProcedureSummaries = BTreeMap<Procedure<VarId>, Arc<ProcedureSummary<VarId>>>;
+
+#[derive(Clone, Default)]
+pub(crate) struct ProcedureSummaryCache {
+    entries: Arc<Mutex<ProcedureSummaries>>,
+}
+
+impl ProcedureSummaryCache {
+    fn analyze(
+        &self,
+        procedure: &Procedure<VarId>,
+    ) -> Result<Arc<ProcedureSummary<VarId>>, ProcedureError> {
+        if let Some(summary) = self
+            .entries
+            .lock()
+            .expect("procedure summary cache lock poisoned")
+            .get(procedure)
+            .cloned()
+        {
+            return Ok(summary);
+        }
+
+        let summary = Arc::new(procedure::analyze(procedure)?);
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("procedure summary cache lock poisoned");
+        Ok(entries
+            .entry(procedure.clone())
+            .or_insert_with(|| summary.clone())
+            .clone())
+    }
+}
 
 enum FunctionCacheEntry {
     Building,
@@ -42,9 +75,18 @@ enum PeriodicAssignmentRun {
 pub(crate) struct FunctionAnalysisCache {
     entries: Arc<Mutex<BTreeMap<FunctionKey, FunctionCacheEntry>>>,
     ready: Arc<OnceLock<Arc<FunctionSummaries>>>,
+    procedures: ProcedureSummaryCache,
 }
 
 impl FunctionAnalysisCache {
+    pub(crate) fn new(procedures: ProcedureSummaryCache) -> Self {
+        Self {
+            entries: Arc::default(),
+            ready: Arc::default(),
+            procedures,
+        }
+    }
+
     pub(crate) fn freeze(&self) {
         let entries = self
             .entries
@@ -79,8 +121,8 @@ pub(crate) fn analyze(
         .lower_statements(&declaration.statements, 0, &[], None)
         .unwrap_or(0);
     builder.procedure.exit = exit;
-    let summary = procedure::analyze(&builder.procedure)?;
-    Ok(builder.finish(summary))
+    let summary = functions.procedures.analyze(&builder.procedure)?;
+    Ok(builder.finish((*summary).clone()))
 }
 
 pub(crate) fn analyze_observer_expression(
@@ -91,8 +133,8 @@ pub(crate) fn analyze_observer_expression(
     let mut builder = Builder::new(module, functions.clone());
     builder.lower_observer_expression(0, expression);
     builder.procedure.exit = 0;
-    let summary = procedure::analyze(&builder.procedure)?;
-    Ok(builder.finish(summary))
+    let summary = functions.procedures.analyze(&builder.procedure)?;
+    Ok(builder.finish((*summary).clone()))
 }
 
 pub(crate) fn analyze_functions(
@@ -523,8 +565,12 @@ impl Builder {
             .lower_statements(&body.statements, 0, &[], None)
             .unwrap_or(0);
         nested.procedure.exit = exit;
-        let summary = procedure::analyze(&nested.procedure).ok()?;
-        Some(Arc::new(nested.finish(summary)))
+        let summary = self
+            .function_cache
+            .procedures
+            .analyze(&nested.procedure)
+            .ok()?;
+        Some(Arc::new(nested.finish((*summary).clone())))
     }
 
     fn new_block(&mut self) -> usize {
@@ -2997,5 +3043,43 @@ fn combine_edge_kinds(left: EdgeKind, right: EdgeKind) -> EdgeKind {
         EdgeKind::Address
     } else {
         EdgeKind::Value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_procedures_share_their_ir_independent_summary() {
+        // Why this case exists: the same elaborated procedure can appear as a
+        // declaration and again behind an instance boundary. Re-running the
+        // pure causal analysis made large unrolled procedures dominate whole
+        // project analysis even though source diagnostics remain module-local.
+        let object = VarId::default();
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![Event::Read {
+                id: 0,
+                region: Region::Exact {
+                    object,
+                    span: Span {
+                        start: 0,
+                        length: 1,
+                    },
+                },
+            }]],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+        let cache = ProcedureSummaryCache::default();
+
+        let first = cache.analyze(&procedure).unwrap();
+        let second = cache.analyze(&procedure).unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -198,15 +198,8 @@ impl Builder {
     ) -> Option<usize> {
         match statement {
             Statement::Assign(assign) => {
-                let mut dependencies = self.read_expression(block, &assign.expr, EdgeKind::Value);
-                let aligned_by_destination = self
-                    .aligned_assignment_dependencies(
-                        block,
-                        &assign.expr,
-                        &assign.dst,
-                        &mut dependencies,
-                    )
-                    .unwrap_or_else(|| vec![Vec::new(); assign.dst.len()]);
+                let (mut dependencies, aligned_by_destination) =
+                    self.assignment_dependencies(block, &assign.expr, &assign.dst);
                 dependencies.extend_from_slice(controls);
                 for (destination, aligned_dependencies) in
                     assign.dst.iter().zip(aligned_by_destination)
@@ -389,6 +382,55 @@ impl Builder {
                 Some(block)
             }
             Statement::Null => Some(block),
+        }
+    }
+
+    fn assignment_dependencies(
+        &mut self,
+        block: usize,
+        expression: &Expression,
+        destinations: &[AssignDestination],
+    ) -> (Vec<(usize, EdgeKind)>, Vec<Vec<AlignedDependency>>) {
+        if let Expression::Ternary(condition, left, right, _) = expression {
+            let condition_dependencies = self.read_expression(block, condition, EdgeKind::Control);
+            let branches = match self.constant_condition(condition) {
+                Some(true) => [Some(left.as_ref()), None],
+                Some(false) => [Some(right.as_ref()), None],
+                None => [Some(left.as_ref()), Some(right.as_ref())],
+            };
+            let mut all_dependencies = condition_dependencies.clone();
+            let mut aligned = vec![Vec::new(); destinations.len()];
+            let mut precise = true;
+            for branch in branches.into_iter().flatten() {
+                let mut branch_dependencies = self.read_expression(block, branch, EdgeKind::Value);
+                all_dependencies.extend_from_slice(&branch_dependencies);
+                if branch_dependencies.is_empty() {
+                    continue;
+                }
+                let Some(branch_aligned) = self.aligned_assignment_dependencies(
+                    block,
+                    branch,
+                    destinations,
+                    &mut branch_dependencies,
+                ) else {
+                    precise = false;
+                    continue;
+                };
+                for (combined, branch) in aligned.iter_mut().zip(branch_aligned) {
+                    combined.extend(branch);
+                }
+            }
+            if precise {
+                (condition_dependencies, aligned)
+            } else {
+                (all_dependencies, vec![Vec::new(); destinations.len()])
+            }
+        } else {
+            let mut dependencies = self.read_expression(block, expression, EdgeKind::Value);
+            let aligned = self
+                .aligned_assignment_dependencies(block, expression, destinations, &mut dependencies)
+                .unwrap_or_else(|| vec![Vec::new(); destinations.len()]);
+            (dependencies, aligned)
         }
     }
 

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -832,93 +832,13 @@ impl Builder {
         expression: &Expression,
         requested: Span,
     ) -> Option<Vec<Region<VarId>>> {
-        match expression {
-            Expression::Term(factor) => match factor.as_ref() {
-                Factor::Variable(id, index, select, _) => {
-                    let Region::Exact {
-                        object,
-                        span: actual_span,
-                    } = self.variable_region(*id, index, select)
-                    else {
-                        return None;
-                    };
-                    if requested.end()? > actual_span.length {
-                        return None;
-                    }
-                    Some(vec![Region::Exact {
-                        object,
-                        span: Span {
-                            start: actual_span.start.checked_add(requested.start)?,
-                            length: requested.length,
-                        },
-                    }])
-                }
-                Factor::Value(_) => Some(Vec::new()),
-                Factor::SystemFunctionCall(call) => match &call.kind {
-                    SystemFunctionKind::Bits(_)
-                    | SystemFunctionKind::Size(_)
-                    | SystemFunctionKind::Clog2(_) => Some(Vec::new()),
-                    SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
-                        self.map_expression_span_to_actual(&input.0, requested)
-                    }
-                    _ => None,
-                },
-                Factor::FunctionCall(call) => self
-                    .map_function_return_spans_to_actual(call, requested)
-                    .map(|mapped| mapped.into_iter().map(|(region, _)| region).collect()),
-                _ => None,
-            },
-            Expression::Concatenation(parts, _) => {
-                let mut low = 0usize;
-                let mut mapped = Vec::new();
-                // Veryl and SystemVerilog list concatenation operands from
-                // most to least significant. Walk in reverse so `low` stays
-                // in the same LSB-based coordinate system as Region::Span.
-                for (part, repeat) in parts.iter().rev() {
-                    let width = part.comptime().r#type.total_width()?;
-                    let repeat = if let Some(repeat) = repeat {
-                        repeat.clone().eval_value(&mut self.context)?.to_usize()?
-                    } else {
-                        1
-                    };
-                    for copy in 0..repeat {
-                        let copy_start = low.checked_add(copy.checked_mul(width)?)?;
-                        let part_span = Span {
-                            start: copy_start,
-                            length: width,
-                        };
-                        if let Some(overlap) = requested.intersection(part_span) {
-                            let local = Span {
-                                start: overlap.start.checked_sub(copy_start)?,
-                                length: overlap.length,
-                            };
-                            mapped.extend(self.map_expression_span_to_actual(part, local)?);
-                        }
-                    }
-                    low = low.checked_add(width.checked_mul(repeat)?)?;
-                }
-                Some(mapped)
-            }
-            Expression::Unary(op, operand, _)
-                if matches!(op, Op::BitNot | Op::Add)
-                    && operand.comptime().r#type.total_width()?
-                        == expression.comptime().r#type.total_width()? =>
-            {
-                self.map_expression_span_to_actual(operand, requested)
-            }
-            Expression::Binary(left, op, right, _)
-                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
-                    && left.comptime().r#type.total_width()?
-                        == expression.comptime().r#type.total_width()?
-                    && right.comptime().r#type.total_width()?
-                        == expression.comptime().r#type.total_width()? =>
-            {
-                let mut mapped = self.map_expression_span_to_actual(left, requested)?;
-                mapped.extend(self.map_expression_span_to_actual(right, requested)?);
-                Some(mapped)
-            }
-            _ => None,
-        }
+        self.map_expression_span_positioned_to_actual(expression, requested)
+            .map(|mapped| {
+                mapped
+                    .into_iter()
+                    .map(|positioned| positioned.region)
+                    .collect()
+            })
     }
 
     fn map_expression_span_positioned_to_actual(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -555,11 +555,12 @@ impl Builder {
                     ));
                 }
                 reads.extend(selector_reads.iter().copied());
-                let region = self.variable_region(*id, index, select);
-                reads.push((
-                    self.push_variable_read(block, *id, index, select, region, &selector_reads),
-                    kind,
-                ));
+                for region in self.variable_regions(*id, index, select) {
+                    reads.push((
+                        self.push_variable_read(block, *id, index, select, region, &selector_reads),
+                        kind,
+                    ));
+                }
             }
             Factor::HierVariable(_) => {
                 self.procedure
@@ -1728,26 +1729,28 @@ impl Builder {
             selector_reads.extend(self.read_expression(block, expression, EdgeKind::Address));
         }
         dependencies.extend(selector_reads.iter().copied());
-        let region = self.variable_region(destination.id, &destination.index, &destination.select);
-        let id = self.next_write;
-        self.next_write += 1;
-        if let Some(key) = Self::unresolved_access_key(
-            destination.id,
-            &destination.index,
-            &destination.select,
-            region,
-        ) {
-            self.unresolved_writes
-                .entry(key)
-                .or_default()
-                .push((id, selector_reads.iter().map(|&(read, _)| read).collect()));
+        for region in self.variable_regions(destination.id, &destination.index, &destination.select)
+        {
+            let id = self.next_write;
+            self.next_write += 1;
+            if let Some(key) = Self::unresolved_access_key(
+                destination.id,
+                &destination.index,
+                &destination.select,
+                region,
+            ) {
+                self.unresolved_writes
+                    .entry(key)
+                    .or_default()
+                    .push((id, selector_reads.iter().map(|&(read, _)| read).collect()));
+            }
+            self.procedure.events[block].push(Event::Write {
+                id,
+                region,
+                dependencies: dependencies.clone(),
+                aligned_dependencies: aligned_dependencies.clone(),
+            });
         }
-        self.procedure.events[block].push(Event::Write {
-            id,
-            region,
-            dependencies,
-            aligned_dependencies,
-        });
     }
 
     fn aligned_assignment_dependencies(
@@ -1899,12 +1902,60 @@ impl Builder {
         index: &VarIndex,
         select: &VarSelect,
     ) -> Region<VarId> {
-        let Some(variable) = self.context.variables.get(&id).cloned() else {
+        let regions = self.variable_regions(id, index, select);
+        if regions.len() == 1 {
+            return regions[0];
+        }
+        let mut start = usize::MAX;
+        let mut end = 0usize;
+        for region in regions {
+            let Region::UnknownRegion { object, span } = region else {
+                return Region::UnknownObject(id);
+            };
+            if object != id {
+                return Region::UnknownObject(id);
+            }
+            start = start.min(span.start);
+            let Some(span_end) = span.end() else {
+                return Region::UnknownObject(id);
+            };
+            end = end.max(span_end);
+        }
+        let Some(length) = end.checked_sub(start) else {
             return Region::UnknownObject(id);
+        };
+        Region::UnknownRegion {
+            object: id,
+            span: Span { start, length },
+        }
+    }
+
+    fn variable_regions(
+        &mut self,
+        id: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+    ) -> Vec<Region<VarId>> {
+        let Some(variable) = self.context.variables.get(&id).cloned() else {
+            return vec![Region::UnknownObject(id)];
         };
         let Some(width) = variable.total_width() else {
-            return Region::UnknownObject(id);
+            return vec![Region::UnknownObject(id)];
         };
+        if let Some(regions) = self.bounded_variable_regions(id, &variable, index, select, width) {
+            return regions;
+        }
+        vec![self.variable_region_fallback(id, &variable, index, select, width)]
+    }
+
+    fn variable_region_fallback(
+        &mut self,
+        id: VarId,
+        variable: &crate::ir::Variable,
+        index: &VarIndex,
+        select: &VarSelect,
+        width: usize,
+    ) -> Region<VarId> {
         if index.0.is_empty() && select.0.is_empty() && select.1.is_none() {
             let Some(length) = variable
                 .r#type
@@ -1917,9 +1968,6 @@ impl Builder {
                 object: id,
                 span: Span { start: 0, length },
             };
-        }
-        if let Some(region) = self.bounded_variable_region(id, &variable, index, select, width) {
-            return region;
         }
         // Preserve the longest statically known prefix. `eval_value` maps an
         // X/Z numeric index to zero for simulation convenience, so alias
@@ -2032,14 +2080,14 @@ impl Builder {
     /// Exactly enumerate small two-state selector domains. This is deliberately
     /// bounded: four-state selectors retain X/Z candidates, and large domains
     /// fall back to the longest-static-prefix region below.
-    fn bounded_variable_region(
+    fn bounded_variable_regions(
         &mut self,
         id: VarId,
         variable: &crate::ir::Variable,
         index: &VarIndex,
         select: &VarSelect,
         width: usize,
-    ) -> Option<Region<VarId>> {
+    ) -> Option<Vec<Region<VarId>>> {
         let expressions = index
             .0
             .iter()
@@ -2128,20 +2176,32 @@ impl Builder {
         spans.sort_unstable();
         spans.dedup();
         let first = spans.first().copied()?;
+        let mut merged = Vec::new();
+        let mut start = first.start;
         let mut end = first.end()?;
         for span in spans.iter().copied().skip(1) {
             if span.start > end {
-                return None;
+                merged.push(Region::UnknownRegion {
+                    object: id,
+                    span: Span {
+                        start,
+                        length: end.checked_sub(start)?,
+                    },
+                });
+                start = span.start;
+                end = span.end()?;
+            } else {
+                end = end.max(span.end()?);
             }
-            end = end.max(span.end()?);
         }
-        Some(Region::UnknownRegion {
+        merged.push(Region::UnknownRegion {
             object: id,
             span: Span {
-                start: first.start,
-                length: end.checked_sub(first.start)?,
+                start,
+                length: end.checked_sub(start)?,
             },
-        })
+        });
+        Some(merged)
     }
 
     fn collect_two_state_variables(expression: &Expression, ids: &mut BTreeSet<VarId>) -> bool {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -850,22 +850,27 @@ impl Builder {
                 // most to least significant. Walk in reverse so `low` stays
                 // in the same LSB-based coordinate system as Region::Span.
                 for (part, repeat) in parts.iter().rev() {
-                    if repeat.is_some() {
-                        return None;
-                    }
                     let width = part.comptime().r#type.total_width()?;
-                    let part_span = Span {
-                        start: low,
-                        length: width,
+                    let repeat = if let Some(repeat) = repeat {
+                        repeat.clone().eval_value(&mut self.context)?.to_usize()?
+                    } else {
+                        1
                     };
-                    if let Some(overlap) = requested.intersection(part_span) {
-                        let local = Span {
-                            start: overlap.start.checked_sub(low)?,
-                            length: overlap.length,
+                    for copy in 0..repeat {
+                        let copy_start = low.checked_add(copy.checked_mul(width)?)?;
+                        let part_span = Span {
+                            start: copy_start,
+                            length: width,
                         };
-                        mapped.extend(self.map_expression_span_to_actual(part, local)?);
+                        if let Some(overlap) = requested.intersection(part_span) {
+                            let local = Span {
+                                start: overlap.start.checked_sub(copy_start)?,
+                                length: overlap.length,
+                            };
+                            mapped.extend(self.map_expression_span_to_actual(part, local)?);
+                        }
                     }
-                    low = low.checked_add(width)?;
+                    low = low.checked_add(width.checked_mul(repeat)?)?;
                 }
                 Some(mapped)
             }
@@ -1294,22 +1299,40 @@ impl Builder {
             Expression::Concatenation(parts, _) => {
                 let mut low = destination.end()?;
                 for (part, repeat) in parts {
-                    if repeat.is_some() {
-                        return None;
-                    }
                     let width = part.comptime().r#type.total_width()?;
-                    low = low.checked_sub(width)?;
+                    let repeat = if let Some(repeat) = repeat {
+                        repeat.clone().eval_value(&mut self.context)?.to_usize()?
+                    } else {
+                        1
+                    };
+                    let group_width = width.checked_mul(repeat)?;
+                    low = low.checked_sub(group_width)?;
+                    let mut part_dependencies = Vec::new();
                     self.collect_aligned_expression_dependencies(
                         block,
                         part,
                         Span {
-                            start: low,
+                            start: 0,
                             length: width,
                         },
                         dependencies,
                         dependency_cursor,
-                        aligned,
+                        &mut part_dependencies,
                     )?;
+                    for copy in 0..repeat {
+                        let copy_start = low.checked_add(copy.checked_mul(width)?)?;
+                        aligned.extend(part_dependencies.iter().map(|dependency| {
+                            AlignedDependency {
+                                read: dependency.read,
+                                kind: dependency.kind,
+                                source: dependency.source,
+                                destination: Span {
+                                    start: copy_start + dependency.destination.start,
+                                    length: dependency.destination.length,
+                                },
+                            }
+                        }));
+                    }
                 }
                 (low == destination.start).then_some(())
             }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -446,9 +446,11 @@ impl Builder {
             Expression::Unary(_, expression, _) => {
                 reads.extend(self.read_expression(block, expression, kind));
             }
-            Expression::Binary(left, _, right, _) => {
+            Expression::Binary(left, op, right, _) => {
                 reads.extend(self.read_expression(block, left, kind));
-                reads.extend(self.read_expression(block, right, kind));
+                if self.binary_rhs_is_reachable(left, *op) {
+                    reads.extend(self.read_expression(block, right, kind));
+                }
             }
             Expression::Ternary(condition, left, right, _) => {
                 reads.extend(self.read_expression(block, condition, EdgeKind::Control));
@@ -1251,9 +1253,11 @@ impl Builder {
             Expression::Unary(_, expression, _) => {
                 self.lower_observer_expression(block, expression);
             }
-            Expression::Binary(left, _, right, _) => {
+            Expression::Binary(left, op, right, _) => {
                 self.lower_observer_expression(block, left);
-                self.lower_observer_expression(block, right);
+                if self.binary_rhs_is_reachable(left, *op) {
+                    self.lower_observer_expression(block, right);
+                }
             }
             Expression::Ternary(condition, left, right, _) => {
                 self.lower_observer_expression(block, condition);
@@ -1300,6 +1304,13 @@ impl Builder {
     fn constant_condition(&mut self, expression: &Expression) -> Option<bool> {
         let value = expression.clone().eval_value(&mut self.context)?;
         (!value.is_xz()).then(|| value.is_positive())
+    }
+
+    fn binary_rhs_is_reachable(&mut self, left: &Expression, op: Op) -> bool {
+        match (op, self.constant_condition(left)) {
+            (Op::LogicAnd, Some(false)) | (Op::LogicOr, Some(true)) => false,
+            _ => true,
+        }
     }
 
     fn write_destination(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -10,7 +10,7 @@ use crate::ir::{
 };
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
-    self, AlignedDependency, Dependency, Event, Procedure, ProcedureError, ProcedureSummary,
+    self, AlignedDependency, Event, Procedure, ProcedureError, ProcedureSummary,
 };
 use veryl_causal::region::{Region, Span};
 
@@ -145,7 +145,12 @@ impl Builder {
             Statement::Assign(assign) => {
                 let mut dependencies = self.read_expression(block, &assign.expr, EdgeKind::Value);
                 let aligned_by_destination = self
-                    .aligned_assignment_dependencies(&assign.expr, &assign.dst, &mut dependencies)
+                    .aligned_assignment_dependencies(
+                        block,
+                        &assign.expr,
+                        &assign.dst,
+                        &mut dependencies,
+                    )
                     .unwrap_or_else(|| vec![Vec::new(); assign.dst.len()]);
                 dependencies.extend_from_slice(controls);
                 for (destination, aligned_dependencies) in
@@ -482,29 +487,22 @@ impl Builder {
                 .extend(summary.incomplete.iter().copied());
         }
 
-        let mut sources_by_output = BTreeMap::<VarId, Vec<Dependency<VarId>>>::new();
+        let formal_ids = function_body
+            .arg_map
+            .values()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let mut dependencies_by_output = BTreeMap::<Region<VarId>, Vec<(usize, EdgeKind)>>::new();
         for dependency in &summary.dependencies {
-            let Region::Exact { object: output, .. } = dependency.output else {
-                continue;
-            };
-            sources_by_output
-                .entry(output)
-                .or_default()
-                .push(*dependency);
-        }
-
-        let mut dependencies_by_output = BTreeMap::<VarId, Vec<(usize, EdgeKind)>>::new();
-        for (&output, dependencies) in &sources_by_output {
             let mut mapped = Vec::new();
-            for dependency in dependencies {
-                let Region::Exact { object: formal, .. } = dependency.input else {
-                    continue;
-                };
-                let Some((actual_expression, fallback_reads)) = actual_inputs.get(&formal) else {
-                    self.model_error
-                        .get_or_insert("function dependency refers to an unmapped input argument");
-                    continue;
-                };
+            let input_object = match dependency.input {
+                Region::Exact { object, .. } | Region::UnknownObject(object) => Some(object),
+                Region::UnknownAll => None,
+            };
+            if let Some(formal) =
+                input_object.and_then(|object| actual_inputs.get_key_value(&object))
+            {
+                let (_, (actual_expression, fallback_reads)) = formal;
                 if let Some(actual_regions) =
                     self.map_formal_region_to_actual(actual_expression, dependency.input)
                 {
@@ -516,10 +514,57 @@ impl Builder {
                         (read, combine_edge_kinds(dependency.kind, actual_kind))
                     }));
                 }
+            } else if input_object.is_some_and(|object| {
+                self.context.variables.get(&object).is_some_and(|variable| {
+                    variable.affiliation == crate::symbol::Affiliation::Module
+                })
+            }) {
+                mapped.push((self.push_read(block, dependency.input), dependency.kind));
+            } else if input_object.is_some_and(|object| formal_ids.contains(&object)) {
+                self.model_error
+                    .get_or_insert("function dependency refers to an unmapped input argument");
+                continue;
+            } else {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::MalformedModel);
+                mapped.push((self.unknown_read(block), EdgeKind::Unknown));
             }
             mapped.sort_unstable();
             mapped.dedup();
-            dependencies_by_output.insert(output, mapped);
+            dependencies_by_output
+                .entry(dependency.output)
+                .or_default()
+                .extend(mapped);
+        }
+        for dependencies in dependencies_by_output.values_mut() {
+            dependencies.sort_unstable();
+            dependencies.dedup();
+        }
+
+        for (&output, dependencies) in &dependencies_by_output {
+            let output_object = match output {
+                Region::Exact { object, .. } | Region::UnknownObject(object) => object,
+                Region::UnknownAll => continue,
+            };
+            let is_module_capture = self
+                .context
+                .variables
+                .get(&output_object)
+                .is_some_and(|variable| variable.affiliation == crate::symbol::Affiliation::Module);
+            if !is_module_capture {
+                continue;
+            }
+            let mut dependencies = dependencies.clone();
+            dependencies.extend_from_slice(controls);
+            let id = self.next_write;
+            self.next_write += 1;
+            self.procedure.events[block].push(Event::Write {
+                id,
+                region: output,
+                dependencies,
+                aligned_dependencies: Vec::new(),
+            });
         }
 
         for (path, outputs) in &call.outputs {
@@ -529,9 +574,19 @@ impl Builder {
                 continue;
             };
             let mut dependencies = dependencies_by_output
-                .get(&formal)
-                .cloned()
-                .unwrap_or_default();
+                .iter()
+                .filter_map(|(output, dependencies)| match output {
+                    Region::Exact { object, .. } | Region::UnknownObject(object)
+                        if *object == formal =>
+                    {
+                        Some(dependencies.iter().copied())
+                    }
+                    _ => None,
+                })
+                .flatten()
+                .collect::<Vec<_>>();
+            dependencies.sort_unstable();
+            dependencies.dedup();
             dependencies.extend_from_slice(controls);
             for destination in outputs {
                 self.write_destination(block, destination, dependencies.clone(), Vec::new());
@@ -539,7 +594,21 @@ impl Builder {
         }
 
         if let Some(ret) = function_body.ret {
-            dependencies_by_output.remove(&ret).unwrap_or_default()
+            let mut dependencies = dependencies_by_output
+                .into_iter()
+                .filter_map(|(output, dependencies)| match output {
+                    Region::Exact { object, .. } | Region::UnknownObject(object)
+                        if object == ret =>
+                    {
+                        Some(dependencies)
+                    }
+                    _ => None,
+                })
+                .flatten()
+                .collect::<Vec<_>>();
+            dependencies.sort_unstable();
+            dependencies.dedup();
+            dependencies
         } else {
             Vec::new()
         }
@@ -697,17 +766,38 @@ impl Builder {
             else {
                 continue;
             };
-            if output != ret || output_span.intersection(requested).is_none() {
+            let Some(output_overlap) = output_span.intersection(requested) else {
+                continue;
+            };
+            if output != ret {
                 continue;
             }
             if dependency.kind == EdgeKind::Unknown {
                 continue;
             }
-            let Region::Exact { object: input, .. } = dependency.input else {
+            if !dependency.aligned {
+                return None;
+            }
+            let Region::Exact {
+                object: input,
+                span: input_span,
+            } = dependency.input
+            else {
                 continue;
             };
             let actual = actual_inputs.get(&input)?;
-            mapped.extend(self.map_formal_region_to_actual(actual, dependency.input)?);
+            if input_span.length != output_span.length {
+                return None;
+            }
+            let relative_start = output_overlap.start.checked_sub(output_span.start)?;
+            let formal_region = Region::Exact {
+                object: input,
+                span: Span {
+                    start: input_span.start.checked_add(relative_start)?,
+                    length: output_overlap.length,
+                },
+            };
+            mapped.extend(self.map_formal_region_to_actual(actual, formal_region)?);
         }
         mapped.sort_unstable();
         mapped.dedup();
@@ -854,6 +944,7 @@ impl Builder {
 
     fn aligned_assignment_dependencies(
         &mut self,
+        block: usize,
         expression: &Expression,
         destinations: &[AssignDestination],
         dependencies: &mut Vec<(usize, EdgeKind)>,
@@ -882,6 +973,7 @@ impl Builder {
         let mut dependency_cursor = 0usize;
         let mut aligned = Vec::new();
         self.collect_aligned_expression_dependencies(
+            block,
             expression,
             Span {
                 start: 0,
@@ -922,6 +1014,7 @@ impl Builder {
 
     fn collect_aligned_expression_dependencies(
         &mut self,
+        block: usize,
         expression: &Expression,
         destination: Span,
         dependencies: &[(usize, EdgeKind)],
@@ -960,6 +1053,41 @@ impl Builder {
                     });
                     Some(())
                 }
+                Factor::FunctionCall(call) => {
+                    let regions = self.map_function_return_span_to_actual(
+                        call,
+                        Span {
+                            start: 0,
+                            length: destination.length,
+                        },
+                    )?;
+                    let dependency_count = regions.len();
+                    for region in regions {
+                        let Region::Exact { span, .. } = region else {
+                            return None;
+                        };
+                        if span.length != destination.length {
+                            return None;
+                        }
+                        aligned.push(AlignedDependency {
+                            read: self.push_read(block, region),
+                            kind: EdgeKind::Value,
+                            source: Span {
+                                start: 0,
+                                length: span.length,
+                            },
+                            destination,
+                        });
+                    }
+                    for _ in 0..dependency_count {
+                        let (_, kind) = *dependencies.get(*dependency_cursor)?;
+                        if kind != EdgeKind::Value {
+                            return None;
+                        }
+                        *dependency_cursor += 1;
+                    }
+                    Some(())
+                }
                 _ => None,
             },
             Expression::Concatenation(parts, _) => {
@@ -971,6 +1099,7 @@ impl Builder {
                     let width = part.comptime().r#type.total_width()?;
                     low = low.checked_sub(width)?;
                     self.collect_aligned_expression_dependencies(
+                        block,
                         part,
                         Span {
                             start: low,
@@ -988,6 +1117,7 @@ impl Builder {
                     && operand.comptime().r#type.total_width()? == destination.length =>
             {
                 self.collect_aligned_expression_dependencies(
+                    block,
                     operand,
                     destination,
                     dependencies,
@@ -1001,6 +1131,7 @@ impl Builder {
                     && right.comptime().r#type.total_width()? == destination.length =>
             {
                 self.collect_aligned_expression_dependencies(
+                    block,
                     left,
                     destination,
                     dependencies,
@@ -1008,6 +1139,7 @@ impl Builder {
                     aligned,
                 )?;
                 self.collect_aligned_expression_dependencies(
+                    block,
                     right,
                     destination,
                     dependencies,
@@ -1026,6 +1158,7 @@ impl Builder {
                     .min(destination.length);
                 let mut shifted = Vec::new();
                 self.collect_aligned_expression_dependencies(
+                    block,
                     left,
                     Span {
                         start: 0,

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -1,13 +1,15 @@
 //! Veryl IR adapter for the IR-independent region MemorySSA engine.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::conv::Context;
 use crate::ir::{
     ArrayLiteralItem, AssignDestination, CasePattern, CombDeclaration, Expression, Factor,
     ForBound, ForRange, FunctionCall, Module, Op, Statement, SystemFunctionCall,
-    SystemFunctionKind, TypeKind, VarId, VarIndex, VarSelect,
+    SystemFunctionKind, TypeKind, VarId, VarIndex, VarKind, VarSelect,
 };
+use crate::value::Value;
 use veryl_causal::graph::{EdgeKind, IncompleteReason};
 use veryl_causal::procedure::{
     self, AlignedDependency, Event, MustAliasCandidate, Procedure, ProcedureError,
@@ -16,9 +18,42 @@ use veryl_causal::procedure::{
 use veryl_causal::region::{Region, Span};
 use veryl_parser::token_range::TokenRange;
 
+#[derive(Debug)]
 pub(crate) struct ProcedureAnalysis {
     pub summary: ProcedureSummary<VarId>,
     pub write_tokens: BTreeMap<WriteId, TokenRange>,
+    pub coverage_sites: Vec<(Region<VarId>, TokenRange)>,
+}
+
+type FunctionKey = (VarId, usize);
+type FunctionSummaries = BTreeMap<FunctionKey, Option<Arc<ProcedureAnalysis>>>;
+
+enum FunctionCacheEntry {
+    Building,
+    Ready(Option<Arc<ProcedureAnalysis>>),
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct FunctionAnalysisCache {
+    entries: Arc<Mutex<BTreeMap<FunctionKey, FunctionCacheEntry>>>,
+    ready: Arc<OnceLock<Arc<FunctionSummaries>>>,
+}
+
+impl FunctionAnalysisCache {
+    pub(crate) fn freeze(&self) {
+        let entries = self
+            .entries
+            .lock()
+            .expect("function analysis cache lock poisoned");
+        let ready = entries
+            .iter()
+            .filter_map(|(&key, entry)| match entry {
+                FunctionCacheEntry::Ready(value) => Some((key, value.clone())),
+                FunctionCacheEntry::Building => None,
+            })
+            .collect::<BTreeMap<_, _>>();
+        let _ = self.ready.set(Arc::new(ready));
+    }
 }
 
 impl std::ops::Deref for ProcedureAnalysis {
@@ -32,37 +67,92 @@ impl std::ops::Deref for ProcedureAnalysis {
 pub(crate) fn analyze(
     module: &Module,
     declaration: &CombDeclaration,
+    functions: &FunctionAnalysisCache,
 ) -> Result<ProcedureAnalysis, ProcedureError> {
-    let mut builder = Builder::new(module);
+    let mut builder = Builder::new(module, functions.clone());
     let exit = builder
         .lower_statements(&declaration.statements, 0, &[], None)
         .unwrap_or(0);
     builder.procedure.exit = exit;
-    if let Some(message) = builder.model_error {
-        return Err(ProcedureError::Model(message));
-    }
     let summary = procedure::analyze(&builder.procedure)?;
-    Ok(ProcedureAnalysis {
-        summary,
-        write_tokens: builder.write_tokens,
-    })
+    Ok(builder.finish(summary))
 }
 
 pub(crate) fn analyze_observer_expression(
     module: &Module,
     expression: &Expression,
+    functions: &FunctionAnalysisCache,
 ) -> Result<ProcedureAnalysis, ProcedureError> {
-    let mut builder = Builder::new(module);
+    let mut builder = Builder::new(module, functions.clone());
     builder.lower_observer_expression(0, expression);
     builder.procedure.exit = 0;
-    if let Some(message) = builder.model_error {
-        return Err(ProcedureError::Model(message));
-    }
     let summary = procedure::analyze(&builder.procedure)?;
-    Ok(ProcedureAnalysis {
-        summary,
-        write_tokens: builder.write_tokens,
-    })
+    Ok(builder.finish(summary))
+}
+
+pub(crate) fn analyze_functions(
+    module: &Module,
+    functions: &FunctionAnalysisCache,
+) -> Vec<Arc<ProcedureAnalysis>> {
+    let builder = Builder::new(module, functions.clone());
+    module
+        .functions
+        .values()
+        .flat_map(|function| {
+            (0..function.functions.len())
+                .filter_map(|index| builder.cached_function((function.id, index)))
+        })
+        .collect()
+}
+
+/// Observer procedures exist only to retain side effects and incomplete
+/// boundaries in instance actuals. Plain values and variable reads are already
+/// represented by the instance connection graph and need no empty MemorySSA.
+pub(crate) fn expression_needs_observer(expression: &Expression) -> bool {
+    fn factor_needs_observer(factor: &Factor) -> bool {
+        match factor {
+            Factor::Variable(_, index, select, _) => index
+                .0
+                .iter()
+                .chain(select.0.iter())
+                .chain(select.1.iter().map(|(_, expression)| expression))
+                .any(expression_needs_observer),
+            Factor::FunctionCall(_)
+            | Factor::SystemFunctionCall(_)
+            | Factor::HierVariable(_)
+            | Factor::Unknown(_) => true,
+            Factor::Value(_) | Factor::Anonymous(_) => false,
+        }
+    }
+
+    match expression {
+        Expression::Term(factor) => factor_needs_observer(factor),
+        Expression::Unary(_, expression, _) => expression_needs_observer(expression),
+        Expression::Binary(left, _, right, _) => {
+            expression_needs_observer(left) || expression_needs_observer(right)
+        }
+        Expression::Ternary(condition, left, right, _) => {
+            expression_needs_observer(condition)
+                || expression_needs_observer(left)
+                || expression_needs_observer(right)
+        }
+        Expression::Concatenation(parts, _) => parts.iter().any(|(expression, repeat)| {
+            expression_needs_observer(expression)
+                || repeat.as_ref().is_some_and(expression_needs_observer)
+        }),
+        Expression::ArrayLiteral(items, _) => items.iter().any(|item| match item {
+            ArrayLiteralItem::Value(expression, repeat) => {
+                expression_needs_observer(expression)
+                    || repeat
+                        .as_ref()
+                        .is_some_and(|repeat| expression_needs_observer(repeat))
+            }
+            ArrayLiteralItem::Defaul(expression) => expression_needs_observer(expression),
+        }),
+        Expression::StructConstructor(_, fields, _) => fields
+            .iter()
+            .any(|(_, expression)| expression_needs_observer(expression)),
+    }
 }
 
 /// Map a result-bit span to the module regions which structurally supply it.
@@ -71,11 +161,13 @@ pub(crate) fn map_expression_span(
     context: &Context,
     expression: &Expression,
     requested: Span,
+    functions: &FunctionAnalysisCache,
 ) -> Option<Vec<Region<VarId>>> {
     let mut nested_context = Context::default();
     nested_context.variables = context.variables.clone();
     nested_context.functions = context.functions.clone();
-    Builder::with_context(nested_context).map_expression_span_to_actual(expression, requested)
+    Builder::with_context(nested_context, functions.clone())
+        .map_expression_span_to_actual(expression, requested)
 }
 
 #[derive(Clone, Copy)]
@@ -96,11 +188,12 @@ pub(crate) fn map_expression_span_positioned(
     context: &Context,
     expression: &Expression,
     requested: Span,
+    functions: &FunctionAnalysisCache,
 ) -> Option<Vec<PositionedRegion>> {
     let mut nested_context = Context::default();
     nested_context.variables = context.variables.clone();
     nested_context.functions = context.functions.clone();
-    Builder::with_context(nested_context)
+    Builder::with_context(nested_context, functions.clone())
         .map_expression_span_positioned_to_actual(expression, requested)
 }
 
@@ -113,12 +206,13 @@ pub(crate) fn map_expression_span_positioned_as(
     expression: &Expression,
     expected: &crate::ir::Type,
     requested: Span,
+    functions: &FunctionAnalysisCache,
 ) -> Option<Vec<PositionedRegion>> {
     let mut expression = expression.clone();
     if matches!(expression, Expression::ArrayLiteral(_, _)) {
         expression.comptime_mut().r#type = expected.clone();
     }
-    map_expression_span_positioned(context, &expression, requested)
+    map_expression_span_positioned(context, &expression, requested, functions)
 }
 
 fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) -> bool {
@@ -131,15 +225,26 @@ fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) ->
     )
 }
 
+fn weak_region(region: Region<VarId>) -> Region<VarId> {
+    match region {
+        Region::Exact { object, span } => Region::UnknownRegion { object, span },
+        region => region,
+    }
+}
+
 struct Builder {
     context: Context,
     procedure: Procedure<VarId>,
     next_read: usize,
     next_write: usize,
     unresolved_writes: BTreeMap<String, Vec<(usize, Vec<usize>)>>,
-    call_stack: Vec<VarId>,
+    call_stack: Vec<FunctionKey>,
     write_tokens: BTreeMap<WriteId, TokenRange>,
-    model_error: Option<&'static str>,
+    uncertain_loop_depth: usize,
+    uncertain_writes: BTreeSet<WriteId>,
+    coverage_writes: BTreeMap<VarId, BTreeSet<(Region<VarId>, TokenRange)>>,
+    coverage_sites: Vec<(Region<VarId>, TokenRange)>,
+    function_cache: FunctionAnalysisCache,
 }
 
 #[derive(Clone, Copy)]
@@ -151,14 +256,14 @@ struct MappedFunctionRead {
 }
 
 impl Builder {
-    fn new(module: &Module) -> Self {
+    fn new(module: &Module, function_cache: FunctionAnalysisCache) -> Self {
         let mut context = Context::default();
         context.variables = module.variables.clone();
         context.functions = module.functions.clone();
-        Self::with_context(context)
+        Self::with_context(context, function_cache)
     }
 
-    fn with_context(context: Context) -> Self {
+    fn with_context(context: Context, function_cache: FunctionAnalysisCache) -> Self {
         let object_spans = context
             .variables
             .iter()
@@ -185,11 +290,15 @@ impl Builder {
             unresolved_writes: BTreeMap::new(),
             call_stack: Vec::new(),
             write_tokens: BTreeMap::new(),
-            model_error: None,
+            uncertain_loop_depth: 0,
+            uncertain_writes: BTreeSet::new(),
+            coverage_writes: BTreeMap::new(),
+            coverage_sites: Vec::new(),
+            function_cache,
         }
     }
 
-    fn nested(&self, callee: VarId) -> Self {
+    fn nested(&self, callee: FunctionKey) -> Self {
         let mut context = Context::default();
         context.variables = self.context.variables.clone();
         context.functions = self.context.functions.clone();
@@ -211,8 +320,63 @@ impl Builder {
             unresolved_writes: BTreeMap::new(),
             call_stack,
             write_tokens: BTreeMap::new(),
-            model_error: None,
+            uncertain_loop_depth: 0,
+            uncertain_writes: BTreeSet::new(),
+            coverage_writes: BTreeMap::new(),
+            coverage_sites: Vec::new(),
+            function_cache: self.function_cache.clone(),
         }
+    }
+
+    fn cached_function(&self, key: FunctionKey) -> Option<Arc<ProcedureAnalysis>> {
+        if let Some(ready) = self.function_cache.ready.get() {
+            return ready.get(&key).cloned().flatten();
+        }
+        let owner = {
+            let mut entries = self
+                .function_cache
+                .entries
+                .lock()
+                .expect("function analysis cache lock poisoned");
+            match entries.get(&key) {
+                Some(FunctionCacheEntry::Ready(result)) => return result.clone(),
+                Some(FunctionCacheEntry::Building) => false,
+                None => {
+                    entries.insert(key, FunctionCacheEntry::Building);
+                    true
+                }
+            }
+        };
+
+        // Never wait for another in-progress root: mutually recursive roots
+        // can be initialized concurrently by Rayon. A racing thread computes
+        // a local copy, while only the reserving owner publishes its result.
+        let result = self.build_function(key);
+        if owner {
+            self.function_cache
+                .entries
+                .lock()
+                .expect("function analysis cache lock poisoned")
+                .insert(key, FunctionCacheEntry::Ready(result.clone()));
+        }
+        result
+    }
+
+    fn build_function(&self, key: FunctionKey) -> Option<Arc<ProcedureAnalysis>> {
+        let body = self
+            .context
+            .functions
+            .get(&key.0)?
+            .functions
+            .get(key.1)?
+            .clone();
+        let mut nested = self.nested(key);
+        let exit = nested
+            .lower_statements(&body.statements, 0, &[], None)
+            .unwrap_or(0);
+        nested.procedure.exit = exit;
+        let summary = procedure::analyze(&nested.procedure).ok()?;
+        Some(Arc::new(nested.finish(summary)))
     }
 
     fn new_block(&mut self) -> usize {
@@ -224,6 +388,170 @@ impl Builder {
 
     fn edge(&mut self, from: usize, to: usize) {
         self.procedure.successors[from].push(to);
+    }
+
+    fn unknown_effect(&mut self, block: usize) -> usize {
+        self.procedure
+            .incomplete
+            .insert(IncompleteReason::MalformedModel);
+        self.unknown_clobber(block)
+    }
+
+    fn unknown_clobber(&mut self, block: usize) -> usize {
+        let dependency = self.unknown_read(block);
+        for (&object, &span) in &self.procedure.object_spans {
+            let id = self.next_write;
+            self.next_write += 1;
+            self.procedure.events[block].push(Event::Write {
+                id,
+                region: Region::Exact { object, span },
+                dependencies: vec![(dependency, EdgeKind::Unknown)],
+                aligned_dependencies: Vec::new(),
+            });
+        }
+        dependency
+    }
+
+    fn retained_coverage_sites(
+        &self,
+        summary: &ProcedureSummary<VarId>,
+    ) -> Vec<(Region<VarId>, TokenRange)> {
+        let mut sites = BTreeSet::new();
+        let mut retained_spans = BTreeMap::<VarId, Vec<Span>>::new();
+        for retained in &summary.retained_outputs {
+            let object = match retained.output {
+                Region::Exact { object, .. }
+                | Region::UnknownRegion { object, .. }
+                | Region::UnknownObject(object) => object,
+                Region::UnknownAll => continue,
+            };
+            let externally_visible = self.context.variables.get(&object).is_some_and(|variable| {
+                variable.affiliation == crate::symbol::Affiliation::Module
+                    || variable.kind == VarKind::Output
+            });
+            let supplies_live_read = summary
+                .dependencies
+                .iter()
+                .any(|dependency| dependency.input.may_alias(retained.output))
+                || summary
+                    .periodic_dependencies
+                    .iter()
+                    .any(|dependency| dependency.input.may_alias(retained.output));
+            if !externally_visible && !supplies_live_read {
+                continue;
+            }
+            match retained.output {
+                Region::Exact { object, span } | Region::UnknownRegion { object, span } => {
+                    retained_spans.entry(object).or_default().push(span);
+                }
+                Region::UnknownObject(object) => {
+                    if let Some(span) = self.procedure.object_spans.get(&object) {
+                        retained_spans.entry(object).or_default().push(*span);
+                    }
+                }
+                Region::UnknownAll => continue,
+            }
+        }
+
+        for spans in retained_spans.values_mut() {
+            spans.sort_unstable_by_key(|span| (span.start, span.length));
+            let mut merged = Vec::<Span>::with_capacity(spans.len());
+            for span in spans.drain(..) {
+                if let Some(previous) = merged.last_mut()
+                    && previous.end().is_some_and(|end| span.start <= end)
+                {
+                    if let (Some(previous_end), Some(span_end)) = (previous.end(), span.end()) {
+                        previous.length = previous_end.max(span_end) - previous.start;
+                    }
+                    continue;
+                }
+                merged.push(span);
+            }
+            *spans = merged;
+        }
+
+        for (&object, writes) in &self.coverage_writes {
+            let Some(retained) = retained_spans.get(&object) else {
+                continue;
+            };
+            for &(write, token) in writes {
+                let write_span = match write {
+                    Region::Exact { span, .. } | Region::UnknownRegion { span, .. } => Some(span),
+                    Region::UnknownObject(_) => self.procedure.object_spans.get(&object).copied(),
+                    Region::UnknownAll => None,
+                };
+                let Some(write_span) = write_span else {
+                    continue;
+                };
+                let Some(write_end) = write_span.end() else {
+                    continue;
+                };
+                let low = retained
+                    .partition_point(|span| span.end().is_some_and(|end| end <= write_span.start));
+                let high = retained.partition_point(|span| span.start < write_end);
+                for &retained_span in &retained[low..high] {
+                    if let Some(span) = retained_span.intersection(write_span) {
+                        sites.insert((Region::Exact { object, span }, token));
+                    }
+                }
+            }
+        }
+        sites.into_iter().collect()
+    }
+
+    fn finish(mut self, mut summary: ProcedureSummary<VarId>) -> ProcedureAnalysis {
+        for dependency in &mut summary.dependencies {
+            if dependency
+                .origin
+                .is_some_and(|write| self.uncertain_writes.contains(&write))
+            {
+                dependency.kind = EdgeKind::Unknown;
+            }
+        }
+        for dependency in &mut summary.periodic_dependencies {
+            if dependency
+                .origin
+                .is_some_and(|write| self.uncertain_writes.contains(&write))
+            {
+                dependency.kind = EdgeKind::Unknown;
+            }
+        }
+        self.coverage_sites
+            .extend(self.retained_coverage_sites(&summary));
+        self.coverage_sites.sort_unstable();
+        self.coverage_sites.dedup();
+        ProcedureAnalysis {
+            summary,
+            write_tokens: self.write_tokens,
+            coverage_sites: self.coverage_sites,
+        }
+    }
+
+    fn record_write(
+        &mut self,
+        id: WriteId,
+        region: Region<VarId>,
+        token: TokenRange,
+        diagnostic: bool,
+    ) {
+        self.write_tokens.insert(id, token);
+        if self.uncertain_loop_depth != 0 {
+            self.uncertain_writes.insert(id);
+        }
+        if diagnostic && self.uncertain_loop_depth == 0 {
+            let object = match region {
+                Region::Exact { object, .. }
+                | Region::UnknownRegion { object, .. }
+                | Region::UnknownObject(object) => Some(object),
+                Region::UnknownAll => None,
+            };
+            if let Some(object) = object {
+                self.coverage_writes
+                    .entry(object)
+                    .or_default()
+                    .insert((region, token));
+            }
+        }
     }
 
     fn lower_statements(
@@ -331,13 +659,14 @@ impl Builder {
         let read = self.push_read(block, source);
         let id = self.next_write;
         self.next_write += 1;
-        self.write_tokens.insert(id, first.dst[0].token);
+        let region = Region::Exact {
+            object,
+            span: output,
+        };
+        self.record_write(id, region, first.dst[0].token, true);
         self.procedure.events[block].push(Event::Write {
             id,
-            region: Region::Exact {
-                object,
-                span: output,
-            },
+            region,
             dependencies: controls.to_vec(),
             aligned_dependencies: vec![AlignedDependency {
                 read,
@@ -385,6 +714,14 @@ impl Builder {
                 let condition = self.read_expression(block, &statement.cond, EdgeKind::Control);
                 let mut nested_controls = controls.to_vec();
                 nested_controls.extend(condition);
+                if let Some(value) = self.constant_condition(&statement.cond) {
+                    let selected = if value {
+                        &statement.true_side
+                    } else {
+                        &statement.false_side
+                    };
+                    return self.lower_statements(selected, block, &nested_controls, break_target);
+                }
                 let true_block = self.new_block();
                 let false_block = self.new_block();
                 self.edge(block, true_block);
@@ -440,6 +777,34 @@ impl Builder {
                 }
                 let mut nested_controls = controls.to_vec();
                 nested_controls.extend(condition);
+                let selected = statement
+                    .case_target
+                    .clone()
+                    .eval_value(&mut self.context)
+                    .and_then(|target| {
+                        let mut selected = Some(statement.default.as_slice());
+                        'arms: for arm in &statement.arms {
+                            let mut undecided = false;
+                            for pattern in &arm.patterns {
+                                match pattern.matches(&target, &mut self.context) {
+                                    Some(true) => {
+                                        selected = Some(arm.body.as_slice());
+                                        break 'arms;
+                                    }
+                                    Some(false) => {}
+                                    None => undecided = true,
+                                }
+                            }
+                            if undecided {
+                                selected = None;
+                                break;
+                            }
+                        }
+                        selected
+                    });
+                if let Some(selected) = selected {
+                    return self.lower_statements(selected, block, &nested_controls, break_target);
+                }
                 let mut exits = Vec::new();
                 for arm in &statement.arms {
                     let arm_block = self.new_block();
@@ -470,14 +835,60 @@ impl Builder {
                 }
             }
             Statement::For(statement) => {
+                if let Some(iterations) = statement.range.eval_iter(&mut self.context) {
+                    if iterations.is_empty() {
+                        return Some(block);
+                    }
+                    let saved_iterator = self.context.variables.get(&statement.var_id).cloned();
+                    let exit = self.new_block();
+                    let mut continuation = Some(block);
+                    for value in iterations {
+                        let Some(from) = continuation else {
+                            break;
+                        };
+                        if let Some(variable) = self.context.variables.get_mut(&statement.var_id)
+                            && let Some(width) = statement.var_type.total_width()
+                        {
+                            variable.set_value(
+                                &[],
+                                Value::new(value as u64, width, statement.var_type.signed),
+                                None,
+                            );
+                        } else {
+                            self.procedure
+                                .incomplete
+                                .insert(IncompleteReason::MalformedModel);
+                        }
+                        let body = self.new_block();
+                        self.edge(from, body);
+                        continuation =
+                            self.lower_statements(&statement.body, body, controls, Some(exit));
+                    }
+                    if let Some(saved_iterator) = saved_iterator {
+                        self.context
+                            .variables
+                            .insert(statement.var_id, saved_iterator);
+                    }
+                    if let Some(continuation) = continuation {
+                        self.edge(continuation, exit);
+                    }
+                    return Some(exit);
+                }
+
+                // Dynamic or deliberately non-expanded loops cannot supply a
+                // hard dependency: their iterator values and trip paths are
+                // not represented by this compact CFG. Preserve uncertainty
+                // while keeping the graph declaration-width independent.
                 self.procedure
                     .incomplete
                     .insert(IncompleteReason::RuntimeLoop);
-                let header = self.new_block();
+                let suppress_hard_dependencies =
+                    statement.range.is_over_size_limit(&mut self.context);
                 let body = self.new_block();
                 let exit = self.new_block();
+                let header = self.new_block();
+                let mut nested_controls = controls.to_vec();
                 self.edge(block, header);
-                let mut condition = Vec::new();
                 let bounds = match &statement.range {
                     ForRange::Forward { start, end, .. }
                     | ForRange::Reverse { start, end, .. }
@@ -485,20 +896,24 @@ impl Builder {
                 };
                 for bound in bounds {
                     if let ForBound::Expression(expression) = bound {
-                        condition.extend(self.read_expression(
+                        nested_controls.extend(self.read_expression(
                             header,
                             expression,
                             EdgeKind::Control,
                         ));
                     }
                 }
-                let mut nested_controls = controls.to_vec();
-                nested_controls.extend(condition);
                 self.edge(header, body);
                 self.edge(header, exit);
-                if let Some(body_exit) =
-                    self.lower_statements(&statement.body, body, &nested_controls, Some(exit))
-                {
+                if suppress_hard_dependencies {
+                    self.uncertain_loop_depth += 1;
+                }
+                let body_exit =
+                    self.lower_statements(&statement.body, body, &nested_controls, Some(exit));
+                if suppress_hard_dependencies {
+                    self.uncertain_loop_depth -= 1;
+                }
+                if let Some(body_exit) = body_exit {
                     self.edge(body_exit, header);
                 }
                 Some(exit)
@@ -527,26 +942,21 @@ impl Builder {
                 Some(block)
             }
             Statement::IfReset(_) => {
-                self.model_error
-                    .get_or_insert("always_comb contains an always_ff-only if_reset statement");
+                self.unknown_effect(block);
                 Some(block)
             }
             Statement::Break => {
-                self.procedure
-                    .incomplete
-                    .insert(IncompleteReason::RuntimeLoop);
                 if let Some(target) = break_target {
                     self.edge(block, target);
                 } else {
-                    self.model_error
-                        .get_or_insert("break appears outside a lowered loop");
+                    self.procedure
+                        .incomplete
+                        .insert(IncompleteReason::MalformedModel);
                 }
                 None
             }
             Statement::Unsupported(_) => {
-                self.model_error.get_or_insert(
-                    "always_comb contains a statement rejected during IR conversion",
-                );
+                self.unknown_effect(block);
                 Some(block)
             }
             Statement::Null => Some(block),
@@ -734,60 +1144,63 @@ impl Builder {
         controls: &[(usize, EdgeKind)],
     ) -> Vec<(usize, EdgeKind)> {
         let mut actual_inputs = BTreeMap::<VarId, (Expression, Vec<(usize, EdgeKind)>)>::new();
-        let function_body = self.context.functions.get(&call.id).and_then(|function| {
-            if let Some(index) = &call.index {
-                function.get_function(index)
-            } else {
-                function.get_function(&[])
-            }
-        });
-
-        let Some(function_body) = function_body else {
-            self.model_error
-                .get_or_insert("resolved function call has no instantiated function body");
-            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        let Some(function) = self.context.functions.get(&call.id) else {
+            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
         };
+        let call_index = call.index.as_deref().unwrap_or(&[]);
+        let Some(function_index) = function.array.calc_index(call_index) else {
+            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
+        };
+        let Some(function_body) = function.functions.get(function_index) else {
+            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
+        };
+        let function_args = function_body.arg_map.clone();
+        let function_return = function_body.ret;
         for (path, input) in &call.inputs {
             let reads = self.read_expression(block, input, EdgeKind::Value);
-            if let Some(&formal) = function_body.arg_map.get(path) {
+            if let Some(&formal) = function_args.get(path) {
                 actual_inputs.insert(formal, (input.clone(), reads));
             }
         }
 
-        if self.call_stack.contains(&call.id) {
+        let function_key = (call.id, function_index);
+        if self.call_stack.contains(&function_key) {
             self.procedure
                 .incomplete
                 .insert(IncompleteReason::RecursiveCall);
-            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+            return vec![(self.unknown_clobber(block), EdgeKind::Unknown)];
         }
 
-        let mut nested = self.nested(call.id);
-        let exit = nested
-            .lower_statements(&function_body.statements, 0, &[], None)
-            .unwrap_or(0);
-        nested.procedure.exit = exit;
-        if self.model_error.is_none() {
-            self.model_error = nested.model_error;
-        }
-        if self.model_error.is_some() {
-            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
-        }
-        let Ok(summary) = procedure::analyze(&nested.procedure) else {
-            self.model_error
-                .get_or_insert("function body produced an invalid causal model");
-            return vec![(self.unknown_read(block), EdgeKind::Unknown)];
+        let Some(nested) = self.cached_function(function_key) else {
+            return vec![(self.unknown_effect(block), EdgeKind::Unknown)];
         };
+        let summary = &nested.summary;
+        let mut captured_coverage = Vec::<(Region<VarId>, TokenRange)>::new();
+        for &(region, token) in &nested.coverage_sites {
+            let object = match region {
+                Region::Exact { object, .. }
+                | Region::UnknownRegion { object, .. }
+                | Region::UnknownObject(object) => object,
+                Region::UnknownAll => continue,
+            };
+            if self
+                .context
+                .variables
+                .get(&object)
+                .is_some_and(|variable| variable.affiliation == crate::symbol::Affiliation::Module)
+            {
+                captured_coverage.push((region, token));
+            } else {
+                self.coverage_sites.push((region, token));
+            }
+        }
         if !summary.incomplete.is_empty() {
             self.procedure
                 .incomplete
                 .extend(summary.incomplete.iter().copied());
         }
 
-        let formal_ids = function_body
-            .arg_map
-            .values()
-            .copied()
-            .collect::<BTreeSet<_>>();
+        let formal_ids = function_args.values().copied().collect::<BTreeSet<_>>();
         let mut dependencies_by_output = BTreeMap::<Region<VarId>, Vec<MappedFunctionRead>>::new();
         for dependency in &summary.dependencies {
             let mut mapped = Vec::new();
@@ -843,8 +1256,9 @@ impl Builder {
                         && exact_regions_have_equal_length(dependency.input, dependency.output),
                 });
             } else if input_object.is_some_and(|object| formal_ids.contains(&object)) {
-                self.model_error
-                    .get_or_insert("function dependency refers to an unmapped input argument");
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::MalformedModel);
                 continue;
             } else {
                 self.procedure
@@ -872,6 +1286,61 @@ impl Builder {
             dependencies_by_output.entry(output).or_default();
         }
 
+        let retained_outputs = summary
+            .retained_outputs
+            .iter()
+            .map(|retained| retained.output)
+            .collect::<BTreeSet<_>>();
+        let mut outputs_by_object = BTreeMap::<VarId, Vec<(Span, Region<VarId>)>>::new();
+        for &output in dependencies_by_output.keys() {
+            if let Region::Exact { object, span } = output {
+                outputs_by_object
+                    .entry(object)
+                    .or_default()
+                    .push((span, output));
+            }
+        }
+        for outputs in outputs_by_object.values_mut() {
+            outputs.sort_unstable_by_key(|(span, _)| (span.start, span.length));
+        }
+        let mut captured_coverage_by_output =
+            BTreeMap::<Region<VarId>, BTreeSet<TokenRange>>::new();
+        for (region, token) in captured_coverage {
+            let (object, span) = match region {
+                Region::Exact { object, span } | Region::UnknownRegion { object, span } => {
+                    (object, Some(span))
+                }
+                Region::UnknownObject(object) => (object, None),
+                Region::UnknownAll => continue,
+            };
+            let Some(outputs) = outputs_by_object.get(&object) else {
+                continue;
+            };
+            let (low, high) = if let Some(span) = span {
+                let Some(end) = span.end() else {
+                    continue;
+                };
+                (
+                    outputs.partition_point(|(output, _)| {
+                        output
+                            .end()
+                            .is_some_and(|output_end| output_end <= span.start)
+                    }),
+                    outputs.partition_point(|(output, _)| output.start < end),
+                )
+            } else {
+                (0, outputs.len())
+            };
+            for &(output_span, output) in &outputs[low..high] {
+                if span.is_none_or(|span| span.intersection(output_span).is_some()) {
+                    captured_coverage_by_output
+                        .entry(output)
+                        .or_default()
+                        .insert(token);
+                }
+            }
+        }
+
         for (&output, dependencies) in &dependencies_by_output {
             let output_object = match output {
                 Region::Exact { object, .. }
@@ -892,21 +1361,39 @@ impl Builder {
                 .map(|dependency| (dependency.read, dependency.kind))
                 .collect::<Vec<_>>();
             dependencies.extend_from_slice(controls);
+            let retained = retained_outputs.contains(&output);
+            let caller_output = if retained {
+                weak_region(output)
+            } else {
+                output
+            };
             let id = self.next_write;
             self.next_write += 1;
-            self.write_tokens.insert(id, call.comptime.token);
+            self.record_write(id, caller_output, call.comptime.token, false);
+            if retained
+                && self.uncertain_loop_depth == 0
+                && let Some(tokens) = captured_coverage_by_output.get(&output)
+            {
+                for &token in tokens {
+                    self.coverage_writes
+                        .entry(output_object)
+                        .or_default()
+                        .insert((output, token));
+                }
+            }
             self.procedure.events[block].push(Event::Write {
                 id,
-                region: output,
+                region: caller_output,
                 dependencies,
                 aligned_dependencies: Vec::new(),
             });
         }
 
         for (path, outputs) in &call.outputs {
-            let Some(&formal) = function_body.arg_map.get(path) else {
-                self.model_error
-                    .get_or_insert("function call output has no formal argument mapping");
+            let Some(&formal) = function_args.get(path) else {
+                self.procedure
+                    .incomplete
+                    .insert(IncompleteReason::MalformedModel);
                 continue;
             };
             let mapped_dependencies = dependencies_by_output
@@ -946,7 +1433,7 @@ impl Builder {
             }
         }
 
-        if let Some(ret) = function_body.ret {
+        if let Some(ret) = function_return {
             let mut dependencies = dependencies_by_output
                 .into_iter()
                 .filter_map(|(output, dependencies)| match output {
@@ -1416,9 +1903,12 @@ impl Builder {
                     requested,
                     expression.comptime().r#type.signed,
                 ),
-            Expression::Binary(left, op, right, _)
-                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor) =>
-            {
+            Expression::Binary(
+                left,
+                Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor,
+                right,
+                _,
+            ) => {
                 let result_signed = expression.comptime().r#type.signed;
                 let mut mapped = self.map_expression_span_positioned_with_signed(
                     left,
@@ -1707,36 +2197,28 @@ impl Builder {
         call: &FunctionCall,
         requested: Span,
     ) -> Option<Vec<(Region<VarId>, Span, bool)>> {
-        if self.call_stack.contains(&call.id) {
+        let function = self.context.functions.get(&call.id)?;
+        let function_index = function
+            .array
+            .calc_index(call.index.as_deref().unwrap_or(&[]))?;
+        let function_key = (call.id, function_index);
+        if self.call_stack.contains(&function_key) {
             return None;
         }
-        let function_body = self.context.functions.get(&call.id).and_then(|function| {
-            if let Some(index) = &call.index {
-                function.get_function(index)
-            } else {
-                function.get_function(&[])
-            }
-        })?;
+        let function_body = function.functions.get(function_index)?;
         let ret = function_body.ret?;
+        let function_args = function_body.arg_map.clone();
 
         let mut actual_inputs = BTreeMap::<VarId, &Expression>::new();
         for (path, input) in &call.inputs {
-            if let Some(&formal) = function_body.arg_map.get(path) {
+            if let Some(&formal) = function_args.get(path) {
                 actual_inputs.insert(formal, input);
             }
         }
 
-        let mut nested = self.nested(call.id);
-        let exit = nested
-            .lower_statements(&function_body.statements, 0, &[], None)
-            .unwrap_or(0);
-        nested.procedure.exit = exit;
-        if nested.model_error.is_some() {
-            return None;
-        }
-        let summary = procedure::analyze(&nested.procedure).ok()?;
+        let summary = self.cached_function(function_key)?;
         let mut mapped = Vec::new();
-        for dependency in summary.dependencies {
+        for dependency in summary.dependencies.iter().copied() {
             let Region::Exact {
                 object: output,
                 span: output_span,
@@ -1870,13 +2352,31 @@ impl Builder {
     fn lower_observer_expression(&mut self, block: usize, expression: &Expression) {
         match expression {
             Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(_, index, select, _) => {
+                    for selector in index.0.iter().chain(select.0.iter()) {
+                        self.lower_observer_expression(block, selector);
+                    }
+                    if let Some((_, width)) = &select.1 {
+                        self.lower_observer_expression(block, width);
+                    }
+                }
+                Factor::HierVariable(_) => {
+                    self.procedure
+                        .incomplete
+                        .insert(IncompleteReason::HierarchicalReference);
+                }
                 Factor::FunctionCall(call) => {
                     self.lower_function_call(block, call, &[]);
                 }
                 Factor::SystemFunctionCall(call) => {
                     self.lower_system_function(block, call, false);
                 }
-                _ => {}
+                Factor::Unknown(_) => {
+                    self.procedure
+                        .incomplete
+                        .insert(IncompleteReason::MalformedModel);
+                }
+                Factor::Value(_) | Factor::Anonymous(_) => {}
             },
             Expression::Unary(_, expression, _) => {
                 self.lower_observer_expression(block, expression);
@@ -1930,6 +2430,21 @@ impl Builder {
     }
 
     fn constant_condition(&mut self, expression: &Expression) -> Option<bool> {
+        if let Expression::Binary(left, op, right, _) = expression {
+            match op {
+                Op::LogicAnd => match self.constant_condition(left) {
+                    Some(false) => return Some(false),
+                    Some(true) => return self.constant_condition(right),
+                    None => {}
+                },
+                Op::LogicOr => match self.constant_condition(left) {
+                    Some(true) => return Some(true),
+                    Some(false) => return self.constant_condition(right),
+                    None => {}
+                },
+                _ => {}
+            }
+        }
         let value = expression.clone().eval_value(&mut self.context)?;
         (!value.is_xz()).then(|| value.is_positive())
     }
@@ -1966,7 +2481,7 @@ impl Builder {
         {
             let id = self.next_write;
             self.next_write += 1;
-            self.write_tokens.insert(id, destination.token);
+            self.record_write(id, region, destination.token, true);
             if let Some(key) = Self::unresolved_access_key(
                 destination.id,
                 &destination.index,

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -65,6 +65,9 @@ pub(crate) struct PositionedRegion {
     pub aligned: bool,
     /// Value for data (including replicated fill); Control for selectors.
     pub kind: EdgeKind,
+    /// Regular copies of this source-to-expression mapping.
+    pub repetitions: usize,
+    pub expression_stride: usize,
 }
 
 pub(crate) fn map_expression_span_positioned(
@@ -205,10 +208,127 @@ impl Builder {
         controls: &[(usize, EdgeKind)],
         break_target: Option<usize>,
     ) -> Option<usize> {
-        for statement in statements {
-            block = self.lower_statement(statement, block, controls, break_target)?;
+        let mut index = 0usize;
+        while index < statements.len() {
+            if let Some(consumed) =
+                self.lower_periodic_variable_assignments(&statements[index..], block, controls)
+            {
+                index += consumed;
+                continue;
+            }
+            block = self.lower_statement(&statements[index], block, controls, break_target)?;
+            index += 1;
         }
         Some(block)
+    }
+
+    /// Collapse an elaborated run such as `b[i] = a` into one periodic
+    /// transfer. The front-end expands array assignment patterns for codegen;
+    /// rebuilding their regular structure here prevents causal analysis from
+    /// inheriting a declaration-width-sized event list.
+    fn lower_periodic_variable_assignments(
+        &mut self,
+        statements: &[Statement],
+        block: usize,
+        controls: &[(usize, EdgeKind)],
+    ) -> Option<usize> {
+        let Statement::Assign(first) = statements.first()? else {
+            return None;
+        };
+        if first.dst.len() != 1 {
+            return None;
+        }
+        let Expression::Term(first_factor) = &first.expr else {
+            return None;
+        };
+        let Factor::Variable(source_id, source_index, source_select, _) = first_factor.as_ref()
+        else {
+            return None;
+        };
+        let source = self.variable_region(*source_id, source_index, source_select);
+        let Region::Exact {
+            span: source_span, ..
+        } = source
+        else {
+            return None;
+        };
+
+        let mut destinations = Vec::new();
+        for statement in statements {
+            let Statement::Assign(assign) = statement else {
+                break;
+            };
+            if assign.dst.len() != 1 {
+                break;
+            }
+            let Expression::Term(factor) = &assign.expr else {
+                break;
+            };
+            let Factor::Variable(id, index, select, _) = factor.as_ref() else {
+                break;
+            };
+            if self.variable_region(*id, index, select) != source {
+                break;
+            }
+            let Region::Exact { object, span } = self.variable_region(
+                assign.dst[0].id,
+                &assign.dst[0].index,
+                &assign.dst[0].select,
+            ) else {
+                break;
+            };
+            if span.length != source_span.length {
+                break;
+            }
+            destinations.push((object, span));
+        }
+        if destinations.len() < 2 {
+            return None;
+        }
+        let object = destinations[0].0;
+        if destinations
+            .iter()
+            .any(|(candidate, _)| *candidate != object)
+        {
+            return None;
+        }
+        destinations.sort_unstable_by_key(|(_, span)| span.start);
+        if destinations
+            .windows(2)
+            .any(|pair| pair[0].1.end().is_none_or(|end| end != pair[1].1.start))
+        {
+            return None;
+        }
+        let output = Span {
+            start: destinations[0].1.start,
+            length: source_span.length.checked_mul(destinations.len())?,
+        };
+        let read = self.push_read(block, source);
+        let id = self.next_write;
+        self.next_write += 1;
+        self.procedure.events[block].push(Event::Write {
+            id,
+            region: Region::Exact {
+                object,
+                span: output,
+            },
+            dependencies: controls.to_vec(),
+            aligned_dependencies: vec![AlignedDependency {
+                read,
+                kind: EdgeKind::Value,
+                source: Span {
+                    start: 0,
+                    length: source_span.length,
+                },
+                destination: Span {
+                    start: 0,
+                    length: source_span.length,
+                },
+                repetitions: destinations.len(),
+                destination_stride: source_span.length,
+            }],
+        });
+        Some(destinations.len())
     }
 
     fn lower_statement(
@@ -897,6 +1017,8 @@ impl Builder {
                             start: overlap.start.checked_sub(destination_span.start)?,
                             length: overlap.length,
                         },
+                        repetitions: 1,
+                        destination_stride: 0,
                     });
                 }
             }
@@ -995,6 +1117,8 @@ impl Builder {
                         expression: extension,
                         aligned: false,
                         kind: EdgeKind::Value,
+                        repetitions: 1,
+                        expression_stride: 0,
                     }),
                 );
             }
@@ -1024,6 +1148,8 @@ impl Builder {
                         expression: requested,
                         aligned: true,
                         kind: EdgeKind::Value,
+                        repetitions: 1,
+                        expression_stride: 0,
                     }])
                 }
                 Factor::Value(_) => Some(Vec::new()),
@@ -1049,6 +1175,8 @@ impl Builder {
                                 },
                                 aligned,
                                 kind: EdgeKind::Value,
+                                repetitions: 1,
+                                expression_stride: 0,
                             })
                             .collect()
                     }),
@@ -1087,6 +1215,8 @@ impl Builder {
                         expression: requested,
                         aligned: false,
                         kind: EdgeKind::Control,
+                        repetitions: 1,
+                        expression_stride: 0,
                     }),
                 );
                 Some(mapped)
@@ -1125,6 +1255,8 @@ impl Builder {
                                     },
                                     aligned: positioned.aligned,
                                     kind: positioned.kind,
+                                    repetitions: positioned.repetitions,
+                                    expression_stride: positioned.expression_stride,
                                 }),
                         );
                     }
@@ -1179,6 +1311,8 @@ impl Builder {
                             },
                             aligned: positioned.aligned,
                             kind: positioned.kind,
+                            repetitions: positioned.repetitions,
+                            expression_stride: positioned.expression_stride,
                         });
                     }
                 }
@@ -1304,6 +1438,8 @@ impl Builder {
                             },
                             aligned: positioned.aligned,
                             kind: positioned.kind,
+                            repetitions: positioned.repetitions,
+                            expression_stride: positioned.expression_stride,
                         })
                         .collect(),
                 )
@@ -1339,6 +1475,8 @@ impl Builder {
                             },
                             aligned: positioned.aligned,
                             kind: positioned.kind,
+                            repetitions: positioned.repetitions,
+                            expression_stride: positioned.expression_stride,
                         })
                         .collect(),
                 )
@@ -1375,6 +1513,8 @@ impl Builder {
                                 },
                                 aligned: positioned.aligned,
                                 kind: positioned.kind,
+                                repetitions: positioned.repetitions,
+                                expression_stride: positioned.expression_stride,
                             }),
                     );
                 }
@@ -1396,6 +1536,8 @@ impl Builder {
                             expression: fill,
                             aligned: false,
                             kind: EdgeKind::Value,
+                            repetitions: 1,
+                            expression_stride: 0,
                         }),
                     );
                 }
@@ -1440,7 +1582,23 @@ impl Builder {
         let value = contextual_value.as_ref().unwrap_or(value);
         let first_copy = overlap.start / element_length;
         let last_copy = overlap.end()?.checked_sub(1)?.checked_div(element_length)?;
-        for copy in first_copy..=last_copy {
+        let first_full = overlap
+            .start
+            .checked_add(element_length - 1)?
+            .checked_div(element_length)?
+            .max(first_copy);
+        let end_full = overlap
+            .end()?
+            .checked_div(element_length)?
+            .min(last_copy.saturating_add(1));
+
+        for copy in [
+            Some(first_copy),
+            (last_copy != first_copy).then_some(last_copy),
+        ]
+        .into_iter()
+        .flatten()
+        {
             let copy_start = copy.checked_mul(element_length)?;
             let copy_span = Span {
                 start: copy_start,
@@ -1449,6 +1607,9 @@ impl Builder {
             let Some(copy_overlap) = requested.intersection(copy_span) else {
                 continue;
             };
+            if copy_overlap == copy_span {
+                continue;
+            }
             let local = Span {
                 start: copy_overlap.start.checked_sub(copy_start)?,
                 length: copy_overlap.length,
@@ -1464,7 +1625,51 @@ impl Builder {
                     },
                     aligned: positioned.aligned,
                     kind: positioned.kind,
+                    repetitions: positioned.repetitions,
+                    expression_stride: positioned.expression_stride,
                 });
+            }
+        }
+
+        if first_full < end_full {
+            let copies = end_full - first_full;
+            let copy_start = first_full.checked_mul(element_length)?;
+            for mut positioned in self.map_expression_span_positioned_with_signed(
+                value,
+                Span {
+                    start: 0,
+                    length: element_length,
+                },
+                element_type.signed,
+            )? {
+                positioned.expression.start =
+                    positioned.expression.start.checked_add(copy_start)?;
+                if copies > 1 {
+                    if positioned.repetitions == 1 {
+                        positioned.repetitions = copies;
+                        positioned.expression_stride = element_length;
+                    } else if positioned
+                        .expression_stride
+                        .checked_mul(positioned.repetitions)
+                        == Some(element_length)
+                    {
+                        positioned.repetitions = positioned.repetitions.checked_mul(copies)?;
+                    } else {
+                        // A non-flattenable nested pattern retains one compact
+                        // inner pattern per outer copy. The number of explicit
+                        // items then reflects source structure, not bit width.
+                        for copy in 0..copies {
+                            let mut positioned = positioned;
+                            positioned.expression.start = positioned
+                                .expression
+                                .start
+                                .checked_add(copy.checked_mul(element_length)?)?;
+                            mapped.push(positioned);
+                        }
+                        continue;
+                    }
+                }
+                mapped.push(positioned);
             }
         }
         Some(())
@@ -1812,6 +2017,8 @@ impl Builder {
                         length: span.length,
                     },
                     destination: positioned.expression,
+                    repetitions: positioned.repetitions,
+                    destination_stride: positioned.expression_stride,
                 });
             } else {
                 retained.push((read, positioned.kind));
@@ -1820,24 +2027,66 @@ impl Builder {
         *dependencies = retained;
         let mut ret = vec![Vec::new(); destinations.len()];
         for dependency in aligned {
-            for (index, destination) in destination_spans.iter().copied().enumerate() {
-                let Some(overlap) = dependency.destination.intersection(destination) else {
-                    continue;
-                };
-                let source_offset = overlap.start.checked_sub(dependency.destination.start)?;
-                let destination_offset = overlap.start.checked_sub(destination.start)?;
+            let pattern_end = dependency
+                .destination_stride
+                .checked_mul(dependency.repetitions.saturating_sub(1))?
+                .checked_add(dependency.destination.end()?)?;
+            if dependency.repetitions > 1
+                && let Some((index, destination)) = destination_spans
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .find(|(_, destination)| {
+                        dependency.destination.start >= destination.start
+                            && pattern_end <= destination.end().unwrap_or(0)
+                    })
+            {
                 ret[index].push(AlignedDependency {
                     read: dependency.read,
                     kind: dependency.kind,
-                    source: Span {
-                        start: dependency.source.start.checked_add(source_offset)?,
-                        length: overlap.length,
-                    },
+                    source: dependency.source,
                     destination: Span {
-                        start: destination_offset,
-                        length: overlap.length,
+                        start: dependency
+                            .destination
+                            .start
+                            .checked_sub(destination.start)?,
+                        length: dependency.destination.length,
                     },
+                    repetitions: dependency.repetitions,
+                    destination_stride: dependency.destination_stride,
                 });
+                continue;
+            }
+            for (index, destination) in destination_spans.iter().copied().enumerate() {
+                for copy in 0..dependency.repetitions {
+                    let copy_start = dependency
+                        .destination
+                        .start
+                        .checked_add(copy.checked_mul(dependency.destination_stride)?)?;
+                    let copy_span = Span {
+                        start: copy_start,
+                        length: dependency.destination.length,
+                    };
+                    let Some(overlap) = copy_span.intersection(destination) else {
+                        continue;
+                    };
+                    let source_offset = overlap.start.checked_sub(copy_span.start)?;
+                    let destination_offset = overlap.start.checked_sub(destination.start)?;
+                    ret[index].push(AlignedDependency {
+                        read: dependency.read,
+                        kind: dependency.kind,
+                        source: Span {
+                            start: dependency.source.start.checked_add(source_offset)?,
+                            length: overlap.length,
+                        },
+                        destination: Span {
+                            start: destination_offset,
+                            length: overlap.length,
+                        },
+                        repetitions: 1,
+                        destination_stride: 0,
+                    });
+                }
             }
         }
         Some(ret)

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -61,9 +61,10 @@ pub(crate) struct PositionedRegion {
     pub region: Region<VarId>,
     /// Bit coordinates in the mapped expression which this region supplies.
     pub expression: Span,
-    /// False when this region controls the mapped expression span instead of
-    /// supplying corresponding data bits.
+    /// Whether source and result bits correspond one-to-one.
     pub aligned: bool,
+    /// Value for data (including replicated fill); Control for selectors.
+    pub kind: EdgeKind,
 }
 
 pub(crate) fn map_expression_span_positioned(
@@ -403,6 +404,7 @@ impl Builder {
                 None => [Some(left.as_ref()), Some(right.as_ref())],
             };
             let mut all_dependencies = condition_dependencies.clone();
+            let mut precise_dependencies = condition_dependencies.clone();
             let mut aligned = vec![Vec::new(); destinations.len()];
             let mut precise = true;
             for branch in branches.into_iter().flatten() {
@@ -416,23 +418,31 @@ impl Builder {
                     branch,
                     destinations,
                     &mut branch_dependencies,
+                    Some(left.comptime().r#type.signed && right.comptime().r#type.signed),
                 ) else {
                     precise = false;
                     continue;
                 };
+                precise_dependencies.extend(branch_dependencies);
                 for (combined, branch) in aligned.iter_mut().zip(branch_aligned) {
                     combined.extend(branch);
                 }
             }
             if precise {
-                (condition_dependencies, aligned)
+                (precise_dependencies, aligned)
             } else {
                 (all_dependencies, vec![Vec::new(); destinations.len()])
             }
         } else {
             let mut dependencies = self.read_expression(block, expression, EdgeKind::Value);
             let aligned = self
-                .aligned_assignment_dependencies(block, expression, destinations, &mut dependencies)
+                .aligned_assignment_dependencies(
+                    block,
+                    expression,
+                    destinations,
+                    &mut dependencies,
+                    None,
+                )
                 .unwrap_or_else(|| vec![Vec::new(); destinations.len()]);
             (dependencies, aligned)
         }
@@ -913,6 +923,19 @@ impl Builder {
         expression: &Expression,
         requested: Span,
     ) -> Option<Vec<PositionedRegion>> {
+        self.map_expression_span_positioned_with_signed(
+            expression,
+            requested,
+            expression.comptime().r#type.signed,
+        )
+    }
+
+    fn map_expression_span_positioned_with_signed(
+        &mut self,
+        expression: &Expression,
+        requested: Span,
+        extension_signed: bool,
+    ) -> Option<Vec<PositionedRegion>> {
         let expression_type = &expression.comptime().r#type;
         let packed_width = expression_type.total_width()?;
         let expression_length =
@@ -936,7 +959,7 @@ impl Builder {
                 start: packed_width,
                 length: requested.end()?.checked_sub(packed_width)?,
             });
-            if expression_type.signed
+            if extension_signed
                 && packed_width != 0
                 && let Some(extension) = extension
             {
@@ -953,6 +976,7 @@ impl Builder {
                         region: sign.region,
                         expression: extension,
                         aligned: false,
+                        kind: EdgeKind::Value,
                     }),
                 );
             }
@@ -981,6 +1005,7 @@ impl Builder {
                         },
                         expression: requested,
                         aligned: true,
+                        kind: EdgeKind::Value,
                     }])
                 }
                 Factor::Value(_) => Some(Vec::new()),
@@ -1005,6 +1030,7 @@ impl Builder {
                                     length: relative.length,
                                 },
                                 aligned,
+                                kind: EdgeKind::Value,
                             })
                             .collect()
                     }),
@@ -1017,8 +1043,17 @@ impl Builder {
                         requested,
                     );
                 }
-                let mut mapped = self.map_expression_span_positioned_to_actual(left, requested)?;
-                mapped.extend(self.map_expression_span_positioned_to_actual(right, requested)?);
+                let result_signed = expression.comptime().r#type.signed;
+                let mut mapped = self.map_expression_span_positioned_with_signed(
+                    left,
+                    requested,
+                    result_signed,
+                )?;
+                mapped.extend(self.map_expression_span_positioned_with_signed(
+                    right,
+                    requested,
+                    result_signed,
+                )?);
                 let condition_width = condition.comptime().r#type.total_width()?;
                 mapped.extend(
                     self.map_expression_span_positioned_to_actual(
@@ -1033,6 +1068,7 @@ impl Builder {
                         region: condition.region,
                         expression: requested,
                         aligned: false,
+                        kind: EdgeKind::Control,
                     }),
                 );
                 Some(mapped)
@@ -1070,6 +1106,7 @@ impl Builder {
                                         length: positioned.expression.length,
                                     },
                                     aligned: positioned.aligned,
+                                    kind: positioned.kind,
                                 }),
                         );
                     }
@@ -1077,18 +1114,29 @@ impl Builder {
                 }
                 Some(mapped)
             }
-            Expression::Unary(op, operand, _) if matches!(op, Op::BitNot | Op::Add) => {
+            Expression::Unary(Op::BitNot | Op::Add, operand, _) => {
                 self.map_expression_span_positioned_to_actual(operand, requested)
             }
+            Expression::Binary(left, Op::As, _, _) => self
+                .map_expression_span_positioned_with_signed(
+                    left,
+                    requested,
+                    expression.comptime().r#type.signed,
+                ),
             Expression::Binary(left, op, right, _)
-                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
-                    && left.comptime().r#type.total_width()?
-                        == expression.comptime().r#type.total_width()?
-                    && right.comptime().r#type.total_width()?
-                        == expression.comptime().r#type.total_width()? =>
+                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor) =>
             {
-                let mut mapped = self.map_expression_span_positioned_to_actual(left, requested)?;
-                mapped.extend(self.map_expression_span_positioned_to_actual(right, requested)?);
+                let result_signed = expression.comptime().r#type.signed;
+                let mut mapped = self.map_expression_span_positioned_with_signed(
+                    left,
+                    requested,
+                    result_signed,
+                )?;
+                mapped.extend(self.map_expression_span_positioned_with_signed(
+                    right,
+                    requested,
+                    result_signed,
+                )?);
                 Some(mapped)
             }
             Expression::Binary(left, op, right, _)
@@ -1123,6 +1171,7 @@ impl Builder {
                                 length: positioned.expression.length,
                             },
                             aligned: positioned.aligned,
+                            kind: positioned.kind,
                         })
                         .collect(),
                 )
@@ -1157,6 +1206,7 @@ impl Builder {
                                 length: positioned.expression.length,
                             },
                             aligned: positioned.aligned,
+                            kind: positioned.kind,
                         })
                         .collect(),
                 )
@@ -1192,6 +1242,7 @@ impl Builder {
                                     length: positioned.expression.length,
                                 },
                                 aligned: positioned.aligned,
+                                kind: positioned.kind,
                             }),
                     );
                 }
@@ -1212,6 +1263,7 @@ impl Builder {
                             region: sign.region,
                             expression: fill,
                             aligned: false,
+                            kind: EdgeKind::Value,
                         }),
                     );
                 }
@@ -1444,10 +1496,10 @@ impl Builder {
     }
 
     fn binary_rhs_is_reachable(&mut self, left: &Expression, op: Op) -> bool {
-        match (op, self.constant_condition(left)) {
-            (Op::LogicAnd, Some(false)) | (Op::LogicOr, Some(true)) => false,
-            _ => true,
-        }
+        !matches!(
+            (op, self.constant_condition(left)),
+            (Op::LogicAnd, Some(false)) | (Op::LogicOr, Some(true))
+        )
     }
 
     fn write_destination(
@@ -1498,6 +1550,7 @@ impl Builder {
         expression: &Expression,
         destinations: &[AssignDestination],
         dependencies: &mut Vec<(usize, EdgeKind)>,
+        extension_signed: Option<bool>,
     ) -> Option<Vec<Vec<AlignedDependency>>> {
         let mut expression_width = 0usize;
         let mut destination_lengths = Vec::with_capacity(destinations.len());
@@ -1523,12 +1576,13 @@ impl Builder {
         }
 
         let mut aligned = Vec::new();
-        let positioned = self.map_expression_span_positioned_to_actual(
+        let positioned = self.map_expression_span_positioned_with_signed(
             expression,
             Span {
                 start: 0,
                 length: expression_width,
             },
+            extension_signed.unwrap_or(expression.comptime().r#type.signed),
         )?;
         let mut retained = Vec::new();
         for positioned in positioned {
@@ -1542,7 +1596,7 @@ impl Builder {
                 }
                 aligned.push(AlignedDependency {
                     read,
-                    kind: EdgeKind::Value,
+                    kind: positioned.kind,
                     source: Span {
                         start: 0,
                         length: span.length,
@@ -1550,7 +1604,7 @@ impl Builder {
                     destination: positioned.expression,
                 });
             } else {
-                retained.push((read, EdgeKind::Control));
+                retained.push((read, positioned.kind));
             }
         }
         *dependencies = retained;

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -561,6 +561,9 @@ impl Builder {
             dependencies.sort_unstable();
             dependencies.dedup();
         }
+        for &output in &summary.outputs {
+            dependencies_by_output.entry(output).or_default();
+        }
 
         for (&output, dependencies) in &dependencies_by_output {
             let output_object = match output {
@@ -884,7 +887,7 @@ impl Builder {
     fn lower_observer_expression(&mut self, block: usize, expression: &Expression) {
         match expression {
             Expression::Term(factor) => match factor.as_ref() {
-                Factor::FunctionCall(call) if !call.outputs.is_empty() => {
+                Factor::FunctionCall(call) => {
                     self.lower_function_call(block, call, &[]);
                 }
                 Factor::SystemFunctionCall(call) => {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -79,6 +79,23 @@ pub(crate) fn map_expression_span_positioned(
         .map_expression_span_positioned_to_actual(expression, requested)
 }
 
+/// Map an expression after applying the assignment context supplied by a
+/// formal port or argument. Array literals are context-determined, so their
+/// own IR node does not necessarily retain the aggregate shape needed to map
+/// a child summary back into the actual expression.
+pub(crate) fn map_expression_span_positioned_as(
+    context: &Context,
+    expression: &Expression,
+    expected: &crate::ir::Type,
+    requested: Span,
+) -> Option<Vec<PositionedRegion>> {
+    let mut expression = expression.clone();
+    if matches!(expression, Expression::ArrayLiteral(_, _)) {
+        expression.comptime_mut().r#type = expected.clone();
+    }
+    map_expression_span_positioned(context, &expression, requested)
+}
+
 fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) -> bool {
     matches!(
         (left, right),
@@ -1114,6 +1131,120 @@ impl Builder {
                 }
                 Some(mapped)
             }
+            Expression::StructConstructor(r#type, fields, _) => {
+                let TypeKind::Struct(structure) = &r#type.kind else {
+                    return None;
+                };
+                if structure.members.len() != fields.len() {
+                    return None;
+                }
+
+                // A packed structure is laid out like a concatenation in
+                // declaration order: the first member occupies the most
+                // significant bits. The IR constructor has already expanded
+                // `default` and normalized named fields into that order.
+                let mut high = r#type.total_width()?;
+                let mut mapped = Vec::new();
+                for (member, (name, value)) in structure.members.iter().zip(fields) {
+                    if member.name != *name {
+                        return None;
+                    }
+                    let member_width = member.r#type.total_width()?;
+                    high = high.checked_sub(member_width)?;
+                    let member_span = Span {
+                        start: high,
+                        length: member_width,
+                    };
+                    let Some(overlap) = requested.intersection(member_span) else {
+                        continue;
+                    };
+                    let local = Span {
+                        start: overlap.start.checked_sub(member_span.start)?,
+                        length: overlap.length,
+                    };
+                    for positioned in self.map_expression_span_positioned_with_signed(
+                        value,
+                        local,
+                        member.r#type.signed,
+                    )? {
+                        mapped.push(PositionedRegion {
+                            region: positioned.region,
+                            expression: Span {
+                                start: positioned
+                                    .expression
+                                    .start
+                                    .checked_add(member_span.start)?,
+                                length: positioned.expression.length,
+                            },
+                            aligned: positioned.aligned,
+                            kind: positioned.kind,
+                        });
+                    }
+                }
+                (high == 0).then_some(mapped)
+            }
+            Expression::ArrayLiteral(items, _) => {
+                let dimensions = expression_type.array.as_slice();
+                let element_count = dimensions.first().copied().flatten()?;
+                let inner_count = dimensions[1..]
+                    .iter()
+                    .try_fold(1usize, |count, dimension| count.checked_mul((*dimension)?))?;
+                let element_length = packed_width.checked_mul(inner_count)?;
+                let mut element_type = expression_type.clone();
+                element_type.array = crate::ir::Shape::from(&dimensions[1..]);
+                element_type.set_array_expr(Vec::new());
+                let mut next_element = 0usize;
+                let mut default = None;
+                let mut mapped = Vec::new();
+
+                for item in items {
+                    let (value, copies) = match item {
+                        ArrayLiteralItem::Value(value, repeat) => {
+                            let copies = if let Some(repeat) = repeat {
+                                repeat.clone().eval_value(&mut self.context)?.to_usize()?
+                            } else {
+                                1
+                            };
+                            (value.as_ref(), copies)
+                        }
+                        ArrayLiteralItem::Defaul(value) => {
+                            if default.replace(value.as_ref()).is_some() {
+                                return None;
+                            }
+                            continue;
+                        }
+                    };
+                    let end_element = next_element.checked_add(copies)?;
+                    if end_element > element_count {
+                        return None;
+                    }
+                    self.map_repeated_array_item(
+                        value,
+                        next_element,
+                        end_element,
+                        element_length,
+                        requested,
+                        &element_type,
+                        &mut mapped,
+                    )?;
+                    next_element = end_element;
+                }
+
+                if next_element < element_count {
+                    let default = default?;
+                    self.map_repeated_array_item(
+                        default,
+                        next_element,
+                        element_count,
+                        element_length,
+                        requested,
+                        &element_type,
+                        &mut mapped,
+                    )?;
+                    next_element = element_count;
+                }
+                (next_element == element_count).then_some(mapped)
+            }
             Expression::Unary(Op::BitNot | Op::Add, operand, _) => {
                 self.map_expression_span_positioned_to_actual(operand, requested)
             }
@@ -1271,6 +1402,71 @@ impl Builder {
             }
             _ => None,
         }
+    }
+
+    /// Project only the repeated array copies intersected by `requested`.
+    /// This keeps a sparse element query independent of the declared array
+    /// length while preserving bit positions inside every repeated copy.
+    #[allow(clippy::too_many_arguments)]
+    fn map_repeated_array_item(
+        &mut self,
+        value: &Expression,
+        first_element: usize,
+        end_element: usize,
+        element_length: usize,
+        requested: Span,
+        element_type: &crate::ir::Type,
+        mapped: &mut Vec<PositionedRegion>,
+    ) -> Option<()> {
+        if first_element == end_element || element_length == 0 {
+            return Some(());
+        }
+        let covered = Span {
+            start: first_element.checked_mul(element_length)?,
+            length: end_element
+                .checked_sub(first_element)?
+                .checked_mul(element_length)?,
+        };
+        let Some(overlap) = requested.intersection(covered) else {
+            return Some(());
+        };
+        let mut contextual_value = None;
+        if matches!(value, Expression::ArrayLiteral(_, _)) {
+            let mut value = value.clone();
+            value.comptime_mut().r#type = element_type.clone();
+            contextual_value = Some(value);
+        }
+        let value = contextual_value.as_ref().unwrap_or(value);
+        let first_copy = overlap.start / element_length;
+        let last_copy = overlap.end()?.checked_sub(1)?.checked_div(element_length)?;
+        for copy in first_copy..=last_copy {
+            let copy_start = copy.checked_mul(element_length)?;
+            let copy_span = Span {
+                start: copy_start,
+                length: element_length,
+            };
+            let Some(copy_overlap) = requested.intersection(copy_span) else {
+                continue;
+            };
+            let local = Span {
+                start: copy_overlap.start.checked_sub(copy_start)?,
+                length: copy_overlap.length,
+            };
+            for positioned in
+                self.map_expression_span_positioned_with_signed(value, local, element_type.signed)?
+            {
+                mapped.push(PositionedRegion {
+                    region: positioned.region,
+                    expression: Span {
+                        start: positioned.expression.start.checked_add(copy_start)?,
+                        length: positioned.expression.length,
+                    },
+                    aligned: positioned.aligned,
+                    kind: positioned.kind,
+                });
+            }
+        }
+        Some(())
     }
 
     fn map_function_return_spans_to_actual(

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -55,6 +55,25 @@ pub(crate) fn map_expression_span(
     Builder::with_context(nested_context).map_expression_span_to_actual(expression, requested)
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct PositionedRegion {
+    pub region: Region<VarId>,
+    /// Bit coordinates in the mapped expression which this region supplies.
+    pub expression: Span,
+}
+
+pub(crate) fn map_expression_span_positioned(
+    context: &Context,
+    expression: &Expression,
+    requested: Span,
+) -> Option<Vec<PositionedRegion>> {
+    let mut nested_context = Context::default();
+    nested_context.variables = context.variables.clone();
+    nested_context.functions = context.functions.clone();
+    Builder::with_context(nested_context)
+        .map_expression_span_positioned_to_actual(expression, requested)
+}
+
 fn exact_regions_have_equal_length(left: Region<VarId>, right: Region<VarId>) -> bool {
     matches!(
         (left, right),
@@ -891,6 +910,190 @@ impl Builder {
                 let mut mapped = self.map_expression_span_to_actual(left, requested)?;
                 mapped.extend(self.map_expression_span_to_actual(right, requested)?);
                 Some(mapped)
+            }
+            _ => None,
+        }
+    }
+
+    fn map_expression_span_positioned_to_actual(
+        &mut self,
+        expression: &Expression,
+        requested: Span,
+    ) -> Option<Vec<PositionedRegion>> {
+        match expression {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(id, index, select, _) => {
+                    let Region::Exact {
+                        object,
+                        span: actual_span,
+                    } = self.variable_region(*id, index, select)
+                    else {
+                        return None;
+                    };
+                    if requested.end()? > actual_span.length {
+                        return None;
+                    }
+                    Some(vec![PositionedRegion {
+                        region: Region::Exact {
+                            object,
+                            span: Span {
+                                start: actual_span.start.checked_add(requested.start)?,
+                                length: requested.length,
+                            },
+                        },
+                        expression: requested,
+                    }])
+                }
+                Factor::Value(_) => Some(Vec::new()),
+                Factor::SystemFunctionCall(call) => match &call.kind {
+                    SystemFunctionKind::Bits(_)
+                    | SystemFunctionKind::Size(_)
+                    | SystemFunctionKind::Clog2(_) => Some(Vec::new()),
+                    SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
+                        self.map_expression_span_positioned_to_actual(&input.0, requested)
+                    }
+                    _ => None,
+                },
+                Factor::FunctionCall(call) => self
+                    .map_function_return_spans_to_actual(call, requested)
+                    .map(|mapped| {
+                        mapped
+                            .into_iter()
+                            .map(|(region, relative)| PositionedRegion {
+                                region,
+                                expression: Span {
+                                    start: requested.start + relative.start,
+                                    length: relative.length,
+                                },
+                            })
+                            .collect()
+                    }),
+                _ => None,
+            },
+            Expression::Concatenation(parts, _) => {
+                let mut low = 0usize;
+                let mut mapped = Vec::new();
+                for (part, repeat) in parts.iter().rev() {
+                    let width = part.comptime().r#type.total_width()?;
+                    let repeat = if let Some(repeat) = repeat {
+                        repeat.clone().eval_value(&mut self.context)?.to_usize()?
+                    } else {
+                        1
+                    };
+                    for copy in 0..repeat {
+                        let copy_start = low.checked_add(copy.checked_mul(width)?)?;
+                        let copy_span = Span {
+                            start: copy_start,
+                            length: width,
+                        };
+                        let Some(overlap) = requested.intersection(copy_span) else {
+                            continue;
+                        };
+                        let local = Span {
+                            start: overlap.start.checked_sub(copy_start)?,
+                            length: overlap.length,
+                        };
+                        mapped.extend(
+                            self.map_expression_span_positioned_to_actual(part, local)?
+                                .into_iter()
+                                .map(|positioned| PositionedRegion {
+                                    region: positioned.region,
+                                    expression: Span {
+                                        start: positioned.expression.start + copy_start,
+                                        length: positioned.expression.length,
+                                    },
+                                }),
+                        );
+                    }
+                    low = low.checked_add(width.checked_mul(repeat)?)?;
+                }
+                Some(mapped)
+            }
+            Expression::Unary(op, operand, _)
+                if matches!(op, Op::BitNot | Op::Add)
+                    && operand.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()? =>
+            {
+                self.map_expression_span_positioned_to_actual(operand, requested)
+            }
+            Expression::Binary(left, op, right, _)
+                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
+                    && left.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()?
+                    && right.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()? =>
+            {
+                let mut mapped = self.map_expression_span_positioned_to_actual(left, requested)?;
+                mapped.extend(self.map_expression_span_positioned_to_actual(right, requested)?);
+                Some(mapped)
+            }
+            Expression::Binary(left, op, right, _)
+                if matches!(op, Op::LogicShiftL | Op::ArithShiftL)
+                    && left.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()? =>
+            {
+                let width = expression.comptime().r#type.total_width()?;
+                let shift = right
+                    .clone()
+                    .eval_value(&mut self.context)?
+                    .to_usize()?
+                    .min(width);
+                let overlap = requested.intersection(Span {
+                    start: shift,
+                    length: width.checked_sub(shift)?,
+                });
+                let Some(overlap) = overlap else {
+                    return Some(Vec::new());
+                };
+                let source = Span {
+                    start: overlap.start.checked_sub(shift)?,
+                    length: overlap.length,
+                };
+                Some(
+                    self.map_expression_span_positioned_to_actual(left, source)?
+                        .into_iter()
+                        .map(|positioned| PositionedRegion {
+                            region: positioned.region,
+                            expression: Span {
+                                start: positioned.expression.start + shift,
+                                length: positioned.expression.length,
+                            },
+                        })
+                        .collect(),
+                )
+            }
+            Expression::Binary(left, Op::LogicShiftR, right, _)
+                if left.comptime().r#type.total_width()?
+                    == expression.comptime().r#type.total_width()? =>
+            {
+                let width = expression.comptime().r#type.total_width()?;
+                let shift = right
+                    .clone()
+                    .eval_value(&mut self.context)?
+                    .to_usize()?
+                    .min(width);
+                let Some(overlap) = requested.intersection(Span {
+                    start: 0,
+                    length: width.checked_sub(shift)?,
+                }) else {
+                    return Some(Vec::new());
+                };
+                let source = Span {
+                    start: overlap.start.checked_add(shift)?,
+                    length: overlap.length,
+                };
+                Some(
+                    self.map_expression_span_positioned_to_actual(left, source)?
+                        .into_iter()
+                        .map(|positioned| PositionedRegion {
+                            region: positioned.region,
+                            expression: Span {
+                                start: positioned.expression.start - shift,
+                                length: positioned.expression.length,
+                            },
+                        })
+                        .collect(),
+                )
             }
             _ => None,
         }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -3,8 +3,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::attribute::{Attribute, CondTypeItem};
-use crate::attribute_table;
 use crate::conv::Context;
 use crate::ir::{
     ArrayLiteralItem, AssignDestination, CasePattern, CombDeclaration, Expression, Factor,
@@ -380,19 +378,6 @@ fn weak_region(region: Region<VarId>) -> Region<VarId> {
         Region::Exact { object, span } => Region::UnknownRegion { object, span },
         region => region,
     }
-}
-
-fn has_cond_type(token: &TokenRange) -> bool {
-    let mut attrs = attribute_table::get(&token.beg);
-    attrs.reverse();
-    for attr in attrs {
-        match attr {
-            Attribute::CondType(CondTypeItem::None) => return false,
-            Attribute::CondType(_) => return true,
-            _ => {}
-        }
-    }
-    false
 }
 
 struct Builder {
@@ -926,7 +911,7 @@ impl Builder {
                     None
                 } else {
                     let join = self.new_block();
-                    if has_cond_type(&statement.token) {
+                    if statement.coverage_suppressed {
                         self.procedure.events[join].push(Event::SuppressRetentionDiagnostic);
                     }
                     for exit in exits {
@@ -1014,7 +999,7 @@ impl Builder {
                     None
                 } else {
                     let join = self.new_block();
-                    if has_cond_type(&statement.token) {
+                    if statement.coverage_suppressed {
                         self.procedure.events[join].push(Event::SuppressRetentionDiagnostic);
                     }
                     for exit in exits {

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -496,7 +496,9 @@ impl Builder {
         for dependency in &summary.dependencies {
             let mut mapped = Vec::new();
             let input_object = match dependency.input {
-                Region::Exact { object, .. } | Region::UnknownObject(object) => Some(object),
+                Region::Exact { object, .. }
+                | Region::UnknownRegion { object, .. }
+                | Region::UnknownObject(object) => Some(object),
                 Region::UnknownAll => None,
             };
             if let Some(formal) =
@@ -544,7 +546,9 @@ impl Builder {
 
         for (&output, dependencies) in &dependencies_by_output {
             let output_object = match output {
-                Region::Exact { object, .. } | Region::UnknownObject(object) => object,
+                Region::Exact { object, .. }
+                | Region::UnknownRegion { object, .. }
+                | Region::UnknownObject(object) => object,
                 Region::UnknownAll => continue,
             };
             let is_module_capture = self
@@ -1222,21 +1226,97 @@ impl Builder {
         let Some(width) = variable.total_width() else {
             return Region::UnknownObject(id);
         };
-        // `eval_value` maps an X/Z numeric index to zero for simulation
-        // convenience. Alias analysis must not mistake that fallback for a
-        // statically resolved address.
-        if !index.is_const() || !select.is_const_with_range() {
-            return Region::UnknownObject(id);
+        // Preserve the longest statically known prefix. `eval_value` maps an
+        // X/Z numeric index to zero for simulation convenience, so alias
+        // analysis must inspect every constant before accepting its value.
+        let mut index_path = Vec::new();
+        for expression in &index.0 {
+            if !expression.comptime().is_const {
+                break;
+            }
+            let Some(value) = expression.eval_value(&mut self.context) else {
+                break;
+            };
+            let Some(value) = (!value.is_xz()).then(|| value.to_usize()).flatten() else {
+                break;
+            };
+            index_path.push(value);
         }
-        let Some(index_path) = index.eval_value(&mut self.context) else {
-            return Region::UnknownObject(id);
-        };
+        if index_path.len() != index.0.len() {
+            let Some((first, last)) = variable.r#type.array.calc_range(&index_path) else {
+                return Region::UnknownObject(id);
+            };
+            let Some(start) = first.checked_mul(width) else {
+                return Region::UnknownObject(id);
+            };
+            let Some(length) = last
+                .checked_sub(first)
+                .and_then(|count| count.checked_add(1))
+                .and_then(|count| count.checked_mul(width))
+            else {
+                return Region::UnknownObject(id);
+            };
+            return Region::UnknownRegion {
+                object: id,
+                span: Span { start, length },
+            };
+        }
         let Some(array_index) = variable.r#type.array.calc_index(&index_path) else {
             return Region::UnknownObject(id);
         };
-        let Some((high, low)) = select.eval_value(&mut self.context, &variable.r#type, false)
-        else {
+        let Some(array_base) = array_index.checked_mul(width) else {
             return Region::UnknownObject(id);
+        };
+
+        let mut select_prefix = 0;
+        for expression in &select.0 {
+            if !expression.comptime().is_const {
+                break;
+            }
+            let Some(value) = expression.eval_value(&mut self.context) else {
+                break;
+            };
+            if value.is_xz() || value.to_usize().is_none() {
+                break;
+            }
+            select_prefix += 1;
+        }
+        let range_is_known = select.1.as_ref().is_none_or(|(_, expression)| {
+            expression.comptime().is_const
+                && expression
+                    .eval_value(&mut self.context)
+                    .is_some_and(|value| !value.is_xz() && value.to_usize().is_some())
+        });
+        if select_prefix == select.0.len() && range_is_known {
+            let Some((high, low)) = select.eval_value(&mut self.context, &variable.r#type, false)
+            else {
+                return Region::UnknownObject(id);
+            };
+            let Some(start) = array_base.checked_add(low) else {
+                return Region::UnknownObject(id);
+            };
+            let Some(length) = high.checked_sub(low).and_then(|delta| delta.checked_add(1)) else {
+                return Region::UnknownObject(id);
+            };
+            return Region::Exact {
+                object: id,
+                span: Span { start, length },
+            };
+        }
+
+        // An unresolved range bound invalidates its base dimension too: the
+        // selected interval may extend beyond that one element.
+        if select_prefix == select.0.len() && !range_is_known {
+            select_prefix = select_prefix.saturating_sub(1);
+        }
+        let (high, low) = if select_prefix == 0 {
+            (width.saturating_sub(1), 0)
+        } else {
+            let prefix = VarSelect(select.0[..select_prefix].to_vec(), None);
+            let Some(span) = prefix.eval_value(&mut self.context, &variable.r#type, false) else {
+                return Region::UnknownObject(id);
+            };
+            span
         };
         let start = match array_index
             .checked_mul(width)
@@ -1248,7 +1328,7 @@ impl Builder {
         let Some(length) = high.checked_sub(low).and_then(|delta| delta.checked_add(1)) else {
             return Region::UnknownObject(id);
         };
-        Region::Exact {
+        Region::UnknownRegion {
             object: id,
             span: Span { start, length },
         }

--- a/crates/analyzer/src/comb_memory_ssa.rs
+++ b/crates/analyzer/src/comb_memory_ssa.rs
@@ -60,6 +60,9 @@ pub(crate) struct PositionedRegion {
     pub region: Region<VarId>,
     /// Bit coordinates in the mapped expression which this region supplies.
     pub expression: Span,
+    /// False when this region controls the mapped expression span instead of
+    /// supplying corresponding data bits.
+    pub aligned: bool,
 }
 
 pub(crate) fn map_expression_span_positioned(
@@ -628,8 +631,13 @@ impl Builder {
                 {
                     let preserve_alignment = dependency.aligned
                         && actual_regions.len() == 1
-                        && exact_regions_have_equal_length(actual_regions[0], dependency.output);
-                    mapped.extend(actual_regions.into_iter().map(|actual_region| {
+                        && actual_regions[0].aligned
+                        && exact_regions_have_equal_length(
+                            actual_regions[0].region,
+                            dependency.output,
+                        );
+                    mapped.extend(actual_regions.into_iter().map(|actual| {
+                        let actual_region = actual.region;
                         MappedFunctionRead {
                             read: self.push_read(block, actual_region),
                             kind: dependency.kind,
@@ -871,17 +879,22 @@ impl Builder {
         &mut self,
         expression: &Expression,
         formal_region: Region<VarId>,
-    ) -> Option<Vec<Region<VarId>>> {
+    ) -> Option<Vec<PositionedRegion>> {
         let Region::Exact {
             span: formal_span, ..
         } = formal_region
         else {
             return None;
         };
-        if formal_span.end()? > expression.comptime().r#type.total_width()? {
+        let expression_length = expression
+            .comptime()
+            .r#type
+            .total_width()?
+            .checked_mul(expression.comptime().r#type.total_array().unwrap_or(1))?;
+        if formal_span.end()? > expression_length {
             return None;
         }
-        self.map_expression_span_to_actual(expression, formal_span)
+        self.map_expression_span_positioned_to_actual(expression, formal_span)
     }
 
     /// Maps a low-bit-based span of an expression to the source variable
@@ -929,6 +942,7 @@ impl Builder {
                             },
                         },
                         expression: requested,
+                        aligned: true,
                     }])
                 }
                 Factor::Value(_) => Some(Vec::new()),
@@ -946,17 +960,45 @@ impl Builder {
                     .map(|mapped| {
                         mapped
                             .into_iter()
-                            .map(|(region, relative)| PositionedRegion {
+                            .map(|(region, relative, aligned)| PositionedRegion {
                                 region,
                                 expression: Span {
                                     start: requested.start + relative.start,
                                     length: relative.length,
                                 },
+                                aligned,
                             })
                             .collect()
                     }),
                 _ => None,
             },
+            Expression::Ternary(condition, left, right, _) => {
+                if let Some(selected) = self.constant_condition(condition) {
+                    return self.map_expression_span_positioned_to_actual(
+                        if selected { left } else { right },
+                        requested,
+                    );
+                }
+                let mut mapped = self.map_expression_span_positioned_to_actual(left, requested)?;
+                mapped.extend(self.map_expression_span_positioned_to_actual(right, requested)?);
+                let condition_width = condition.comptime().r#type.total_width()?;
+                mapped.extend(
+                    self.map_expression_span_positioned_to_actual(
+                        condition,
+                        Span {
+                            start: 0,
+                            length: condition_width,
+                        },
+                    )?
+                    .into_iter()
+                    .map(|condition| PositionedRegion {
+                        region: condition.region,
+                        expression: requested,
+                        aligned: false,
+                    }),
+                );
+                Some(mapped)
+            }
             Expression::Concatenation(parts, _) => {
                 let mut low = 0usize;
                 let mut mapped = Vec::new();
@@ -989,6 +1031,7 @@ impl Builder {
                                         start: positioned.expression.start + copy_start,
                                         length: positioned.expression.length,
                                     },
+                                    aligned: positioned.aligned,
                                 }),
                         );
                     }
@@ -996,11 +1039,7 @@ impl Builder {
                 }
                 Some(mapped)
             }
-            Expression::Unary(op, operand, _)
-                if matches!(op, Op::BitNot | Op::Add)
-                    && operand.comptime().r#type.total_width()?
-                        == expression.comptime().r#type.total_width()? =>
-            {
+            Expression::Unary(op, operand, _) if matches!(op, Op::BitNot | Op::Add) => {
                 self.map_expression_span_positioned_to_actual(operand, requested)
             }
             Expression::Binary(left, op, right, _)
@@ -1045,6 +1084,7 @@ impl Builder {
                                 start: positioned.expression.start + shift,
                                 length: positioned.expression.length,
                             },
+                            aligned: positioned.aligned,
                         })
                         .collect(),
                 )
@@ -1078,9 +1118,66 @@ impl Builder {
                                 start: positioned.expression.start - shift,
                                 length: positioned.expression.length,
                             },
+                            aligned: positioned.aligned,
                         })
                         .collect(),
                 )
+            }
+            Expression::Binary(left, Op::ArithShiftR, right, _)
+                if left.comptime().r#type.signed
+                    && left.comptime().r#type.total_width()?
+                        == expression.comptime().r#type.total_width()? =>
+            {
+                let width = expression.comptime().r#type.total_width()?;
+                let shift = right
+                    .clone()
+                    .eval_value(&mut self.context)?
+                    .to_usize()?
+                    .min(width);
+                let live_length = width.checked_sub(shift)?;
+                let mut mapped = Vec::new();
+                if let Some(overlap) = requested.intersection(Span {
+                    start: 0,
+                    length: live_length,
+                }) {
+                    let source = Span {
+                        start: overlap.start.checked_add(shift)?,
+                        length: overlap.length,
+                    };
+                    mapped.extend(
+                        self.map_expression_span_positioned_to_actual(left, source)?
+                            .into_iter()
+                            .map(|positioned| PositionedRegion {
+                                region: positioned.region,
+                                expression: Span {
+                                    start: positioned.expression.start - shift,
+                                    length: positioned.expression.length,
+                                },
+                                aligned: positioned.aligned,
+                            }),
+                    );
+                }
+                if let Some(fill) = requested.intersection(Span {
+                    start: live_length,
+                    length: shift,
+                }) {
+                    mapped.extend(
+                        self.map_expression_span_positioned_to_actual(
+                            left,
+                            Span {
+                                start: width.checked_sub(1)?,
+                                length: 1,
+                            },
+                        )?
+                        .into_iter()
+                        .map(|sign| PositionedRegion {
+                            region: sign.region,
+                            expression: fill,
+                            aligned: false,
+                        }),
+                    );
+                }
+                Some(mapped)
             }
             _ => None,
         }
@@ -1090,7 +1187,7 @@ impl Builder {
         &mut self,
         call: &FunctionCall,
         requested: Span,
-    ) -> Option<Vec<(Region<VarId>, Span)>> {
+    ) -> Option<Vec<(Region<VarId>, Span, bool)>> {
         if self.call_stack.contains(&call.id) {
             return None;
         }
@@ -1160,7 +1257,8 @@ impl Builder {
                 },
             };
             let actual_regions = self.map_formal_region_to_actual(actual, formal_region)?;
-            for actual_region in actual_regions {
+            for actual in actual_regions {
+                let actual_region = actual.region;
                 let Region::Exact {
                     span: actual_span, ..
                 } = actual_region
@@ -1176,6 +1274,7 @@ impl Builder {
                         start: output_overlap.start.checked_sub(requested.start)?,
                         length: output_overlap.length,
                     },
+                    actual.aligned,
                 ));
             }
         }
@@ -1362,9 +1461,8 @@ impl Builder {
         destinations: &[AssignDestination],
         dependencies: &mut Vec<(usize, EdgeKind)>,
     ) -> Option<Vec<Vec<AlignedDependency>>> {
-        let expression_width = expression.comptime().r#type.total_width()?;
-        let mut high = expression_width;
-        let mut destination_spans = Vec::with_capacity(destinations.len());
+        let mut expression_width = 0usize;
+        let mut destination_lengths = Vec::with_capacity(destinations.len());
         for destination in destinations {
             let Region::Exact {
                 span: destination_span,
@@ -1373,33 +1471,51 @@ impl Builder {
             else {
                 return None;
             };
-            high = high.checked_sub(destination_span.length)?;
+            expression_width = expression_width.checked_add(destination_span.length)?;
+            destination_lengths.push(destination_span.length);
+        }
+        let mut high = expression_width;
+        let mut destination_spans = Vec::with_capacity(destinations.len());
+        for length in destination_lengths {
+            high = high.checked_sub(length)?;
             destination_spans.push(Span {
                 start: high,
-                length: destination_span.length,
+                length,
             });
         }
-        if high != 0 {
-            return None;
-        }
 
-        let mut dependency_cursor = 0usize;
         let mut aligned = Vec::new();
-        self.collect_aligned_expression_dependencies(
-            block,
+        let positioned = self.map_expression_span_positioned_to_actual(
             expression,
             Span {
                 start: 0,
                 length: expression_width,
             },
-            dependencies,
-            &mut dependency_cursor,
-            &mut aligned,
         )?;
-        if dependency_cursor != dependencies.len() {
-            return None;
+        let mut retained = Vec::new();
+        for positioned in positioned {
+            let Region::Exact { span, .. } = positioned.region else {
+                return None;
+            };
+            let read = self.push_read(block, positioned.region);
+            if positioned.aligned {
+                if span.length != positioned.expression.length {
+                    return None;
+                }
+                aligned.push(AlignedDependency {
+                    read,
+                    kind: EdgeKind::Value,
+                    source: Span {
+                        start: 0,
+                        length: span.length,
+                    },
+                    destination: positioned.expression,
+                });
+            } else {
+                retained.push((read, EdgeKind::Control));
+            }
         }
-        dependencies.clear();
+        *dependencies = retained;
         let mut ret = vec![Vec::new(); destinations.len()];
         for dependency in aligned {
             for (index, destination) in destination_spans.iter().copied().enumerate() {
@@ -1423,214 +1539,6 @@ impl Builder {
             }
         }
         Some(ret)
-    }
-
-    fn collect_aligned_expression_dependencies(
-        &mut self,
-        block: usize,
-        expression: &Expression,
-        destination: Span,
-        dependencies: &[(usize, EdgeKind)],
-        dependency_cursor: &mut usize,
-        aligned: &mut Vec<AlignedDependency>,
-    ) -> Option<()> {
-        if expression.comptime().r#type.total_width()? != destination.length {
-            return None;
-        }
-        match expression {
-            Expression::Term(factor) => match factor.as_ref() {
-                Factor::Value(_) => Some(()),
-                Factor::Variable(id, index, select, _) => {
-                    let Region::Exact {
-                        span: source_span, ..
-                    } = self.variable_region(*id, index, select)
-                    else {
-                        return None;
-                    };
-                    if source_span.length != destination.length {
-                        return None;
-                    }
-                    let &(read, kind) = dependencies.get(*dependency_cursor)?;
-                    if kind != EdgeKind::Value {
-                        return None;
-                    }
-                    *dependency_cursor += 1;
-                    aligned.push(AlignedDependency {
-                        read,
-                        kind,
-                        source: Span {
-                            start: 0,
-                            length: source_span.length,
-                        },
-                        destination,
-                    });
-                    Some(())
-                }
-                Factor::FunctionCall(call) => {
-                    let regions = self.map_function_return_spans_to_actual(
-                        call,
-                        Span {
-                            start: 0,
-                            length: destination.length,
-                        },
-                    )?;
-                    let dependency_count = regions.len();
-                    for (region, mapped_destination) in regions {
-                        let Region::Exact { span, .. } = region else {
-                            return None;
-                        };
-                        if span.length != mapped_destination.length {
-                            return None;
-                        }
-                        aligned.push(AlignedDependency {
-                            read: self.push_read(block, region),
-                            kind: EdgeKind::Value,
-                            source: Span {
-                                start: 0,
-                                length: span.length,
-                            },
-                            destination: Span {
-                                start: destination.start.checked_add(mapped_destination.start)?,
-                                length: mapped_destination.length,
-                            },
-                        });
-                    }
-                    for _ in 0..dependency_count {
-                        let (_, kind) = *dependencies.get(*dependency_cursor)?;
-                        if kind != EdgeKind::Value {
-                            return None;
-                        }
-                        *dependency_cursor += 1;
-                    }
-                    Some(())
-                }
-                _ => None,
-            },
-            Expression::Concatenation(parts, _) => {
-                let mut low = destination.end()?;
-                for (part, repeat) in parts {
-                    let width = part.comptime().r#type.total_width()?;
-                    let repeat = if let Some(repeat) = repeat {
-                        repeat.clone().eval_value(&mut self.context)?.to_usize()?
-                    } else {
-                        1
-                    };
-                    let group_width = width.checked_mul(repeat)?;
-                    low = low.checked_sub(group_width)?;
-                    let mut part_dependencies = Vec::new();
-                    self.collect_aligned_expression_dependencies(
-                        block,
-                        part,
-                        Span {
-                            start: 0,
-                            length: width,
-                        },
-                        dependencies,
-                        dependency_cursor,
-                        &mut part_dependencies,
-                    )?;
-                    for copy in 0..repeat {
-                        let copy_start = low.checked_add(copy.checked_mul(width)?)?;
-                        aligned.extend(part_dependencies.iter().map(|dependency| {
-                            AlignedDependency {
-                                read: dependency.read,
-                                kind: dependency.kind,
-                                source: dependency.source,
-                                destination: Span {
-                                    start: copy_start + dependency.destination.start,
-                                    length: dependency.destination.length,
-                                },
-                            }
-                        }));
-                    }
-                }
-                (low == destination.start).then_some(())
-            }
-            Expression::Unary(op, operand, _)
-                if matches!(op, Op::BitNot | Op::Add)
-                    && operand.comptime().r#type.total_width()? == destination.length =>
-            {
-                self.collect_aligned_expression_dependencies(
-                    block,
-                    operand,
-                    destination,
-                    dependencies,
-                    dependency_cursor,
-                    aligned,
-                )
-            }
-            Expression::Binary(left, op, right, _)
-                if matches!(op, Op::BitAnd | Op::BitOr | Op::BitXor | Op::BitXnor)
-                    && left.comptime().r#type.total_width()? == destination.length
-                    && right.comptime().r#type.total_width()? == destination.length =>
-            {
-                self.collect_aligned_expression_dependencies(
-                    block,
-                    left,
-                    destination,
-                    dependencies,
-                    dependency_cursor,
-                    aligned,
-                )?;
-                self.collect_aligned_expression_dependencies(
-                    block,
-                    right,
-                    destination,
-                    dependencies,
-                    dependency_cursor,
-                    aligned,
-                )
-            }
-            Expression::Binary(left, op, right, _)
-                if matches!(op, Op::LogicShiftL | Op::ArithShiftL)
-                    && left.comptime().r#type.total_width()? == destination.length =>
-            {
-                let shift = right
-                    .clone()
-                    .eval_value(&mut self.context)?
-                    .to_usize()?
-                    .min(destination.length);
-                let mut shifted = Vec::new();
-                self.collect_aligned_expression_dependencies(
-                    block,
-                    left,
-                    Span {
-                        start: 0,
-                        length: destination.length,
-                    },
-                    dependencies,
-                    dependency_cursor,
-                    &mut shifted,
-                )?;
-                let live_source = Span {
-                    start: 0,
-                    length: destination.length.checked_sub(shift)?,
-                };
-                for dependency in shifted {
-                    let Some(overlap) = dependency.destination.intersection(live_source) else {
-                        continue;
-                    };
-                    let offset = overlap.start.checked_sub(dependency.destination.start)?;
-                    aligned.push(AlignedDependency {
-                        read: dependency.read,
-                        kind: dependency.kind,
-                        source: Span {
-                            start: dependency.source.start.checked_add(offset)?,
-                            length: overlap.length,
-                        },
-                        destination: Span {
-                            start: destination
-                                .start
-                                .checked_add(overlap.start)?
-                                .checked_add(shift)?,
-                            length: overlap.length,
-                        },
-                    });
-                }
-                Some(())
-            }
-            _ => None,
-        }
     }
 
     fn push_read(&mut self, block: usize, region: Region<VarId>) -> usize {
@@ -1699,6 +1607,19 @@ impl Builder {
         let Some(width) = variable.total_width() else {
             return Region::UnknownObject(id);
         };
+        if index.0.is_empty() && select.0.is_empty() && select.1.is_none() {
+            let Some(length) = variable
+                .r#type
+                .total_array()
+                .and_then(|elements| elements.checked_mul(width))
+            else {
+                return Region::UnknownObject(id);
+            };
+            return Region::Exact {
+                object: id,
+                span: Span { start: 0, length },
+            };
+        }
         // Preserve the longest statically known prefix. `eval_value` maps an
         // X/Z numeric index to zero for simulation convenience, so alias
         // analysis must inspect every constant before accepting its value.

--- a/crates/analyzer/src/conv/context.rs
+++ b/crates/analyzer/src/conv/context.rs
@@ -50,10 +50,10 @@ pub struct Context {
     pub var_id: VarId,
     pub var_paths: HashMap<VarPath, (VarId, Comptime)>,
     pub func_paths: HashMap<FuncPath, VarId>,
-    /// Symbols whose function bodies are mid-conversion. Carried (via `inherit`)
-    /// across the fresh per-call contexts that mutual recursion creates, so
-    /// re-entry is detected and the IR conversion doesn't overflow.
-    pub converting_funcs: Vec<SymbolId>,
+    /// Function specializations whose bodies are mid-conversion. Carried (via
+    /// `inherit`) across fresh per-call contexts so true recursive re-entry is
+    /// detected without conflating finite generic specializations.
+    pub converting_funcs: Vec<FuncPath>,
     pub variables: HashMap<VarId, Variable>,
     pub functions: HashMap<VarId, Function>,
     pub port_types: HashMap<VarPath, (Type, ClockDomain)>,

--- a/crates/analyzer/src/conv/declaration.rs
+++ b/crates/analyzer/src/conv/declaration.rs
@@ -1141,7 +1141,7 @@ fn conv_function(
     // Re-entry while mid-conversion is a call cycle (mutual recursion
     // `f0 -> f1 -> f0`) that the same-context `func_paths` guard above misses,
     // since it recurses through fresh contexts. Bail; `type_dag` reports it.
-    if context.converting_funcs.contains(&symbol.id) {
+    if context.converting_funcs.contains(&path) {
         return Ok(());
     }
     let id = context.insert_func_path(path.clone());
@@ -1179,7 +1179,7 @@ fn conv_function(
 
     // Mark in-progress for the body conversion only (where recursion lands);
     // kept below the `?`-bearing setup so an early error leaves no stale entry.
-    context.converting_funcs.push(symbol.id);
+    context.converting_funcs.push(path.clone());
     context.push_affiliation(Affiliation::Function);
     context.push_hierarchy(name);
     context.push_namespace(namespace);

--- a/crates/analyzer/src/conv/ir.rs
+++ b/crates/analyzer/src/conv/ir.rs
@@ -305,6 +305,7 @@ impl Conv<(&ModuleDeclaration, bool)> for ir::Module {
         upper_context.inherit(&mut context);
 
         Ok(ir::Module {
+            specialization: None,
             name: module_declaration.identifier.text(),
             token: module_declaration.identifier.as_ref().into(),
             ports,
@@ -529,6 +530,7 @@ impl Conv<&ProtoModuleDeclaration> for ir::Module {
         upper_context.inherit(&mut context);
 
         Ok(ir::Module {
+            specialization: None,
             name: value.identifier.text(),
             token: value.identifier.as_ref().into(),
             ports,

--- a/crates/analyzer/src/conv/statement.rs
+++ b/crates/analyzer/src/conv/statement.rs
@@ -1,4 +1,6 @@
 use crate::analyzer_error::{ComponentInterfaceMismatchKind, MismatchTypeKind};
+use crate::attribute::{Attribute, CondTypeItem};
+use crate::attribute_table;
 use crate::conv::utils::{
     TbMethodCallPosition, TypePosition, argument_list, build_for_range, build_for_statement,
     case_patterns, check_assign_clock_domain, eval_array_range_assign, eval_assign_statement,
@@ -16,6 +18,19 @@ use crate::symbol_table;
 use crate::{AnalyzerError, ir_error};
 use veryl_parser::token_range::TokenRange;
 use veryl_parser::veryl_grammar_trait::*;
+
+fn coverage_suppressed(token: &TokenRange) -> bool {
+    let mut attrs = attribute_table::get(&token.beg);
+    attrs.reverse();
+    for attr in attrs {
+        match attr {
+            Attribute::CondType(CondTypeItem::None) => return false,
+            Attribute::CondType(_) => return true,
+            _ => {}
+        }
+    }
+    false
+}
 
 impl Conv<&StatementBlock> for ir::StatementBlock {
     fn conv(context: &mut Context, value: &StatementBlock) -> IrResult<Self> {
@@ -658,11 +673,13 @@ impl Conv<&IfStatement> for ir::StatementBlock {
                 break;
             }
 
+            let token = x.into();
             let statement = ir::Statement::If(ir::IfStatement {
                 cond,
                 true_side,
                 false_side: vec![],
-                token: x.into(),
+                coverage_suppressed: coverage_suppressed(&token),
+                token,
             });
 
             append_leaf_false(&mut false_side, vec![statement]);
@@ -681,11 +698,13 @@ impl Conv<&IfStatement> for ir::StatementBlock {
         if false_side_only {
             Ok(ir::StatementBlock(false_side))
         } else {
+            let token = value.into();
             let statement = ir::Statement::If(ir::IfStatement {
                 cond,
                 true_side,
                 false_side,
-                token: value.into(),
+                coverage_suppressed: coverage_suppressed(&token),
+                token,
             });
             Ok(ir::StatementBlock(vec![statement]))
         }
@@ -737,11 +756,13 @@ impl Conv<&IfResetStatement> for ir::StatementBlock {
                 break;
             }
 
+            let token = x.into();
             let statement = ir::Statement::If(ir::IfStatement {
                 cond,
                 true_side,
                 false_side: vec![],
-                token: x.into(),
+                coverage_suppressed: coverage_suppressed(&token),
+                token,
             });
 
             append_leaf_false(&mut false_side, vec![statement]);
@@ -1019,12 +1040,14 @@ impl Conv<&CaseStatement> for ir::StatementBlock {
             return Ok(ir::StatementBlock::default());
         }
 
+        let token = value.case.case_token.token.into();
         Ok(ir::StatementBlock(vec![ir::Statement::Case(
             ir::CaseStatement {
                 arms,
                 default,
                 case_target: Box::new(tgt),
-                token: value.case.case_token.token.into(),
+                coverage_suppressed: coverage_suppressed(&token),
+                token,
             },
         )]))
     }
@@ -1113,6 +1136,7 @@ impl Conv<&SwitchStatement> for ir::StatementBlock {
                 cond,
                 true_side: body,
                 false_side: std::mem::take(&mut tail),
+                coverage_suppressed: coverage_suppressed(&token),
                 token,
             })];
         }

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -3278,6 +3278,7 @@ pub fn get_component(
                 let component: IrResult<ir::Module> = Conv::conv(c, (x, header_only));
                 match component {
                     Ok(mut component) => {
+                        component.specialization = Some(sig.clone());
                         if !c.config.retain_component_body {
                             component.functions.clear();
                             component.declarations.clear();
@@ -3327,6 +3328,7 @@ pub fn get_component(
                 let component: IrResult<ir::Module> = Conv::conv(c, x);
                 match component {
                     Ok(mut component) => {
+                        component.specialization = Some(sig.clone());
                         if !c.config.retain_component_body {
                             component.functions.clear();
                             component.declarations.clear();

--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -3890,7 +3890,12 @@ pub fn function_call(
     sig.normalize();
 
     // same signature re-entered => true infinite recursion
-    if context.function_call_stack.contains(&sig) {
+    let unresolved_generic_template = !symbol_table::get(sig.symbol)
+        .unwrap()
+        .generic_parameters()
+        .is_empty()
+        && sig.generic_parameters.is_empty();
+    if !unresolved_generic_template && context.function_call_stack.contains(&sig) {
         context.insert_error(AnalyzerError::infinite_recursion(&token));
         return Err(ir_error!(token));
     }

--- a/crates/analyzer/src/ir/module.rs
+++ b/crates/analyzer/src/ir/module.rs
@@ -10,9 +10,7 @@ use crate::ir::{
 use crate::symbol::ClockDomain;
 use crate::value::ValueBigUint;
 use indent::indent_all_by;
-use std::collections::BTreeSet;
 use std::fmt;
-use veryl_causal::region::Region;
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
 
@@ -74,49 +72,6 @@ impl Module {
             let snapshot = std::mem::take(&mut new_table.refernced);
             self.per_decl_refs.insert(i, snapshot);
             assign_table.merge_by_or_from(context, &mut new_table, true, true);
-        }
-
-        // Dynamic destinations are weak writes: one evaluation writes only
-        // the selected region and leaves other candidates untouched. The
-        // enumerating AssignTable cannot represent that fact for unknown or
-        // oversized arrays, so use the sparse MemorySSA coverage summary to
-        // report it here. Entry retention itself is deliberately not added to
-        // the combinational dependency graph.
-        for declaration in &self.declarations {
-            let Declaration::Comb(comb) = declaration else {
-                continue;
-            };
-            let Ok(analysis) = crate::comb_memory_ssa::analyze(self, comb) else {
-                continue;
-            };
-            let mut diagnosed_writes = BTreeSet::new();
-            for retained in &analysis.retained_outputs {
-                let Some(write) = retained.origin else {
-                    // Ordinary control-flow retention is handled by the
-                    // existing branch and runtime-loop coverage checks.
-                    continue;
-                };
-                if !diagnosed_writes.insert(write) {
-                    continue;
-                }
-                let Some(token) = analysis.write_tokens.get(&write) else {
-                    continue;
-                };
-                let object = match retained.output {
-                    Region::Exact { object, .. }
-                    | Region::UnknownRegion { object, .. }
-                    | Region::UnknownObject(object) => object,
-                    Region::UnknownAll => continue,
-                };
-                let Some(variable) = self.variables.get(&object) else {
-                    continue;
-                };
-                context.insert_error(crate::AnalyzerError::uncovered_branch(
-                    &variable.path.to_string(),
-                    token,
-                    &[*token],
-                ));
-            }
         }
 
         for x in self.functions.values() {

--- a/crates/analyzer/src/ir/module.rs
+++ b/crates/analyzer/src/ir/module.rs
@@ -5,7 +5,7 @@ use crate::attribute_table;
 use crate::conv::Context;
 use crate::ir::assign_table::{AssignTable, ReferencedEntry};
 use crate::ir::{
-    Declaration, FfTable, Function, Type, VarId, VarIndex, VarKind, VarPath, Variable,
+    Declaration, FfTable, Function, Signature, Type, VarId, VarIndex, VarKind, VarPath, Variable,
 };
 use crate::symbol::ClockDomain;
 use crate::value::ValueBigUint;
@@ -21,6 +21,10 @@ pub type AssignTokens = HashMap<VarId, Vec<TokenRange>>;
 
 #[derive(Clone)]
 pub struct Module {
+    /// Exact elaboration identity. Generic arguments and connected modport
+    /// specializations participate in this key; source-level templates which
+    /// have not been concretely elaborated have no identity.
+    pub(crate) specialization: Option<Signature>,
     pub name: StrId,
     pub token: TokenRange,
     pub ports: HashMap<VarPath, VarId>,

--- a/crates/analyzer/src/ir/module.rs
+++ b/crates/analyzer/src/ir/module.rs
@@ -10,7 +10,9 @@ use crate::ir::{
 use crate::symbol::ClockDomain;
 use crate::value::ValueBigUint;
 use indent::indent_all_by;
+use std::collections::BTreeSet;
 use std::fmt;
+use veryl_causal::region::Region;
 use veryl_parser::resource_table::StrId;
 use veryl_parser::token_range::TokenRange;
 
@@ -72,6 +74,49 @@ impl Module {
             let snapshot = std::mem::take(&mut new_table.refernced);
             self.per_decl_refs.insert(i, snapshot);
             assign_table.merge_by_or_from(context, &mut new_table, true, true);
+        }
+
+        // Dynamic destinations are weak writes: one evaluation writes only
+        // the selected region and leaves other candidates untouched. The
+        // enumerating AssignTable cannot represent that fact for unknown or
+        // oversized arrays, so use the sparse MemorySSA coverage summary to
+        // report it here. Entry retention itself is deliberately not added to
+        // the combinational dependency graph.
+        for declaration in &self.declarations {
+            let Declaration::Comb(comb) = declaration else {
+                continue;
+            };
+            let Ok(analysis) = crate::comb_memory_ssa::analyze(self, comb) else {
+                continue;
+            };
+            let mut diagnosed_writes = BTreeSet::new();
+            for retained in &analysis.retained_outputs {
+                let Some(write) = retained.origin else {
+                    // Ordinary control-flow retention is handled by the
+                    // existing branch and runtime-loop coverage checks.
+                    continue;
+                };
+                if !diagnosed_writes.insert(write) {
+                    continue;
+                }
+                let Some(token) = analysis.write_tokens.get(&write) else {
+                    continue;
+                };
+                let object = match retained.output {
+                    Region::Exact { object, .. }
+                    | Region::UnknownRegion { object, .. }
+                    | Region::UnknownObject(object) => object,
+                    Region::UnknownAll => continue,
+                };
+                let Some(variable) = self.variables.get(&object) else {
+                    continue;
+                };
+                context.insert_error(crate::AnalyzerError::uncovered_branch(
+                    &variable.path.to_string(),
+                    token,
+                    &[*token],
+                ));
+            }
         }
 
         for x in self.functions.values() {

--- a/crates/analyzer/src/ir/signature.rs
+++ b/crates/analyzer/src/ir/signature.rs
@@ -178,6 +178,18 @@ impl Signature {
 
                     sig.full_path
                         .append(&mut found.inner_namespace().paths.to_vec());
+                } else if let Some(last) = path.paths.last() {
+                    // A finite recursive generic call can elaborate a new
+                    // value (for example N - 1) before a structural instance
+                    // symbol has been materialized. Keep the resolved actuals
+                    // in the signature so conversion can instantiate that
+                    // specialization instead of lowering the call to unknown.
+                    let parameters = symbol.found.generic_parameters();
+                    if parameters.len() == last.arguments.len() {
+                        for ((name, _), argument) in parameters.iter().zip(&last.arguments) {
+                            sig.add_generic_parameter(*name, argument.clone());
+                        }
+                    }
                 }
             }
         }

--- a/crates/analyzer/src/ir/statement.rs
+++ b/crates/analyzer/src/ir/statement.rs
@@ -859,6 +859,9 @@ pub struct IfStatement {
     pub cond: Expression,
     pub true_side: Vec<Statement>,
     pub false_side: Vec<Statement>,
+    /// The source conditional carries a non-`none` `cond_type`, so retained
+    /// paths introduced by this join do not produce coverage diagnostics.
+    pub coverage_suppressed: bool,
     pub token: TokenRange,
 }
 
@@ -1052,6 +1055,8 @@ pub struct CaseStatement {
     pub arms: Vec<CaseArm>,
     pub default: Vec<Statement>,
     pub case_target: Box<Expression>,
+    /// See [`IfStatement::coverage_suppressed`].
+    pub coverage_suppressed: bool,
     pub token: TokenRange,
 }
 
@@ -1298,6 +1303,7 @@ impl CaseStatement {
                 cond,
                 true_side: arm.body.clone(),
                 false_side: std::mem::take(&mut tail),
+                coverage_suppressed: self.coverage_suppressed,
                 token: arm.token,
             };
             tail = vec![Statement::If(if_stmt)];

--- a/crates/analyzer/src/ir/statement.rs
+++ b/crates/analyzer/src/ir/statement.rs
@@ -386,9 +386,28 @@ impl Statement {
             }
             Statement::FunctionCall(x) => x.eval_assign(context, assign_table, assign_context),
             Statement::For(x) => {
+                // A runtime loop may execute zero times. Treat its body as one
+                // coverage arm and the zero-trip path as an empty arm; merely
+                // walking the body once incorrectly marks every body write as
+                // unconditional.
+                let mut body_table = AssignTable::new(context);
+                std::mem::swap(&mut body_table.refernced, &mut assign_table.refernced);
+                let base_tables = if assign_table.table.is_empty() {
+                    Cow::Borrowed(base_tables)
+                } else {
+                    let mut base_tables = base_tables.to_vec();
+                    base_tables.push(assign_table);
+                    Cow::Owned(base_tables)
+                };
                 for s in &x.body {
-                    s.eval_assign(context, assign_table, assign_context, base_tables);
+                    s.eval_assign(context, &mut body_table, assign_context, &base_tables);
                 }
+                if assign_context.is_comb() {
+                    let zero_trip = AssignTable::new(context);
+                    body_table.check_uncoverd(context, &zero_trip, &base_tables);
+                }
+                assign_table.merge_by_or(context, &mut body_table, false);
+                std::mem::swap(&mut assign_table.refernced, &mut body_table.refernced);
             }
             Statement::TbMethodCall(x) => {
                 // A component method's return value drives its destination

--- a/crates/analyzer/src/ir/statement.rs
+++ b/crates/analyzer/src/ir/statement.rs
@@ -2,7 +2,7 @@ use crate::AnalyzerError;
 use crate::conv::Context;
 use crate::ir::assign_table::{AssignContext, AssignTable};
 use crate::ir::ff_table::AssignTarget;
-use crate::ir::utils::{allow_missing_reset_statement, has_cond_type};
+use crate::ir::utils::allow_missing_reset_statement;
 use crate::ir::{
     Comptime, Expression, FfTable, FunctionCall, Op, SystemFunctionCall, SystemFunctionInput, Type,
     VarId, VarIndex, VarPath, VarSelect,
@@ -386,28 +386,9 @@ impl Statement {
             }
             Statement::FunctionCall(x) => x.eval_assign(context, assign_table, assign_context),
             Statement::For(x) => {
-                // A runtime loop may execute zero times. Treat its body as one
-                // coverage arm and the zero-trip path as an empty arm; merely
-                // walking the body once incorrectly marks every body write as
-                // unconditional.
-                let mut body_table = AssignTable::new(context);
-                std::mem::swap(&mut body_table.refernced, &mut assign_table.refernced);
-                let base_tables = if assign_table.table.is_empty() {
-                    Cow::Borrowed(base_tables)
-                } else {
-                    let mut base_tables = base_tables.to_vec();
-                    base_tables.push(assign_table);
-                    Cow::Owned(base_tables)
-                };
                 for s in &x.body {
-                    s.eval_assign(context, &mut body_table, assign_context, &base_tables);
+                    s.eval_assign(context, assign_table, assign_context, base_tables);
                 }
-                if assign_context.is_comb() {
-                    let zero_trip = AssignTable::new(context);
-                    body_table.check_uncoverd(context, &zero_trip, &base_tables);
-                }
-                assign_table.merge_by_or(context, &mut body_table, false);
-                std::mem::swap(&mut assign_table.refernced, &mut body_table.refernced);
             }
             Statement::TbMethodCall(x) => {
                 // A component method's return value drives its destination
@@ -938,10 +919,6 @@ impl IfStatement {
             x.eval_assign(context, &mut false_table, assign_context, &base_tables);
         }
 
-        if assign_context.is_comb() && !has_cond_type(&self.token) {
-            true_table.check_uncoverd(context, &false_table, &base_tables);
-        }
-
         true_table.merge_by_or(context, &mut false_table, false);
         assign_table.merge_by_or(context, &mut true_table, false);
         std::mem::swap(&mut assign_table.refernced, &mut false_table.refernced);
@@ -1099,7 +1076,7 @@ pub enum CasePattern {
 
 impl CasePattern {
     /// `None` when either side is non-const.
-    fn matches(&self, target: &Value, context: &mut Context) -> Option<bool> {
+    pub(crate) fn matches(&self, target: &Value, context: &mut Context) -> Option<bool> {
         let target_n = target.to_usize()?;
         match self {
             CasePattern::Eq(e) => {
@@ -1253,11 +1230,6 @@ impl CaseStatement {
         }
         let final_referenced = std::mem::take(&mut default_table.refernced);
         branch_tables.push(default_table);
-
-        if assign_context.is_comb() && !has_cond_type(&self.token) {
-            let refs: Vec<&AssignTable> = branch_tables.iter().collect();
-            AssignTable::check_uncoverd_n_way(context, &refs, &base_tables);
-        }
 
         let mut acc = branch_tables.pop().expect("default_table");
         for mut t in branch_tables.into_iter().rev() {

--- a/crates/analyzer/src/ir/utils.rs
+++ b/crates/analyzer/src/ir/utils.rs
@@ -1,21 +1,8 @@
-use crate::attribute::{AllowItem, Attribute, CondTypeItem};
+use crate::attribute::{AllowItem, Attribute};
 use crate::attribute_table;
 use crate::ir::comptime::TypeKind;
 use crate::value::Value;
 use veryl_parser::token_range::TokenRange;
-
-pub fn has_cond_type(token: &TokenRange) -> bool {
-    let mut attrs = attribute_table::get(&token.beg);
-    attrs.reverse();
-    for attr in attrs {
-        match attr {
-            Attribute::CondType(CondTypeItem::None) => return false,
-            Attribute::CondType(_) => return true,
-            _ => (),
-        }
-    }
-    false
-}
 
 pub fn allow_missing_reset_statement(token: &TokenRange) -> bool {
     attribute_table::contains(

--- a/crates/analyzer/src/lib.rs
+++ b/crates/analyzer/src/lib.rs
@@ -3,6 +3,7 @@ pub mod analyzer_error;
 pub mod attribute;
 pub mod attribute_table;
 pub mod comb_loop_detect;
+mod comb_memory_ssa;
 pub mod component_manifest_table;
 pub mod connect_operation_table;
 pub mod conv;

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -24117,6 +24117,38 @@ fn combinational_loop_nested_repeat_actual_survives_module_boundary() {
 }
 
 #[test]
+fn combinational_loop_periodic_output_maps_concatenated_actual() {
+    // Why this case exists: a child periodic output may legally connect to a
+    // concatenated parent lvalue. Each output fragment must be clipped in the
+    // child's coordinates; requiring one whole destination silently drops the
+    // real a -> child.o[0] -> a feedback path.
+    assert_comb_loop_for_case(
+        "a periodic child output survives a concatenated parent destination",
+        r#"
+        module Fanout (
+            i: input  logic,
+            o: output logic<2>,
+        ) {
+            assign o = {i repeat 2};
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            var a: logic;
+            var b: logic;
+            inst u: Fanout (
+                i: a,
+                o: {b, a},
+            );
+            assign o = b;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_review_uses_structural_selector_overlap() {
     // Why these cases exist: structural feedback compares each access's
     // independently possible region. Both `idx` and `~idx` can address

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13604,6 +13604,51 @@ fn combinational_loop_function_output_weak_write_retains_coverage() {
 }
 
 #[test]
+fn combinational_loop_branch_weak_writes_share_one_coverage_diagnostic() {
+    // Why this case exists: distinct weak writes can reach the same retained
+    // object through different branches. Coverage reporting should present one
+    // coherent variable diagnostic containing both assignment sites.
+    let errors = analyze(
+        r#"
+        module Top (
+            condition: input  logic,
+            left     : input  logic<2>,
+            right    : input  logic<2>,
+            o        : output logic,
+        ) {
+            var value: logic<4>;
+            always_comb {
+                if condition {
+                    value[left] = 1;
+                } else {
+                    value[right] = 0;
+                }
+                o = value[0];
+            }
+        }
+        "#,
+    );
+    let coverage = errors
+        .iter()
+        .filter(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(coverage.len(), 1, "{errors:#?}");
+    let AnalyzerError::UncoveredBranch {
+        error_locations, ..
+    } = coverage[0]
+    else {
+        unreachable!()
+    };
+    assert_eq!(error_locations.len(), 2, "{errors:#?}");
+    assert!(
+        errors
+            .iter()
+            .all(|error| !matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "implicit preservation is not combinational feedback: {errors:#?}"
+    );
+}
+
+#[test]
 fn comb_loop_ifstmt_feed_forward_array() {
     // False positive: an always_comb for-loop over cross-coupled arrays that
     // reads index i and writes i+1 (a feed-forward / acyclic CORDIC-style

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10241,7 +10241,6 @@ fn combinational_loop_review_dynamic_write_is_a_weak_update() {
 }
 
 #[test]
-#[ignore = "known bug: overlapping bounded wildcard regions are disconnected graph nodes"]
 fn combinational_loop_review_aliases_overlapping_unknown_regions() {
     // Why this case exists: mem[i][j] and mem[0][k] can denote the same
     // element when i == 0 and j == k. Region::may_alias already says these

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10533,7 +10533,6 @@ fn combinational_loop_review_preserves_split_function_return_bits() {
 }
 
 #[test]
-#[ignore = "known bug: recursive function identity ignores generic specialization"]
 fn combinational_loop_review_distinguishes_generic_function_specializations() {
     // Why this case exists: recurse::<2> and recurse::<1> are distinct finite
     // specializations. Elaboration reduces the call to passed = feedback, so

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10055,7 +10055,6 @@ fn combinational_loop_review_preserves_vector_function_return_bits() {
 }
 
 #[test]
-#[ignore = "known bug: multi-destination assignments lose bit correspondence"]
 fn combinational_loop_review_preserves_concatenated_lhs_bits() {
     // Why this case exists: {o[1], o[0]} = value maps each destination bit to
     // one RHS bit. Broadcasting all RHS dependencies to both destinations
@@ -10074,10 +10073,27 @@ fn combinational_loop_review_preserves_concatenated_lhs_bits() {
         "#,
         false,
     );
+
+    // Why this control exists: o[0] is mapped from value[0], so feeding o[0]
+    // back into value[0] is a real same-bit cycle that aligned lowering must
+    // retain while removing the disjoint-bit false positive above.
+    assert_comb_loop_for_case(
+        "a concatenated assignment retains same-bit feedback",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            var value: logic<2>;
+            assign {o[1], o[0]} = value;
+            assign value[0] = o[0];
+            assign value[1] = 0;
+        }
+        "#,
+        true,
+    );
 }
 
 #[test]
-#[ignore = "known bug: constant shifts lose positional dependencies"]
 fn combinational_loop_review_preserves_constant_shift_positions() {
     // Why this case exists: the low bit of a logical left shift is constant
     // zero. Treating every result bit as dependent on every operand bit
@@ -10096,6 +10112,23 @@ fn combinational_loop_review_preserves_constant_shift_positions() {
         }
         "#,
         false,
+    );
+
+    // Why this control exists: after a one-bit left shift, o[1] is value[0].
+    // Returning o[1] to value[0] is therefore a real positional cycle.
+    assert_comb_loop_for_case(
+        "a constant left shift retains displaced same-bit feedback",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = value << 1;
+            assign value[0] = o[1];
+            assign value[3:1] = 0;
+        }
+        "#,
+        true,
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -3,6 +3,9 @@ use crate::ir::Ir;
 use crate::{Analyzer, AnalyzerError, attribute_table, symbol_table};
 use std::collections::HashMap;
 use std::thread;
+use veryl_causal::graph::{
+    AnalysisFailure, AnalysisGap, IncompleteReason, LoopAnalysisGap, OpaqueBoundary,
+};
 use veryl_metadata::{Lint, Metadata, ProjectProperty};
 use veryl_parser::Parser;
 use veryl_parser::doc_comment_table;
@@ -9877,7 +9880,7 @@ fn comb_loop_bounded_dynamic_write_is_complete() {
     assert!(
         result.incomplete.iter().all(|module| !module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)),
+            .contains(&IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion))),
         "a dynamic write bounded to values must be complete: {result:#?}"
     );
 
@@ -9925,7 +9928,7 @@ fn comb_loop_function_dynamic_read_is_complete() {
     assert!(
         dynamic_function.incomplete.iter().all(|module| !module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)),
+            .contains(&IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion))),
         "a dynamic function read bounded to its formal must be complete: {dynamic_function:#?}"
     );
 }
@@ -9968,7 +9971,7 @@ fn comb_loop_bounded_dynamic_read_retains_feedback() {
     assert!(
         dynamic_loop.incomplete.iter().all(|module| !module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)),
+            .contains(&IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion))),
         "a conservative bounded loop is complete: {dynamic_loop:#?}"
     );
 }
@@ -13130,7 +13133,7 @@ fn comb_loop_finite_recursive_module_specializations_are_complete() {
     assert!(
         acyclic.incomplete.iter().all(|module| !module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::RecursiveCall)),
+            .contains(&IncompleteReason::Analysis(AnalysisGap::RecursiveCall))),
         "finite concrete specialization recursion must be complete: {acyclic:#?}"
     );
 
@@ -13159,7 +13162,7 @@ fn comb_loop_finite_recursive_module_specializations_are_complete() {
     assert!(
         cyclic.incomplete.iter().all(|module| !module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::RecursiveCall)),
+            .contains(&IncompleteReason::Analysis(AnalysisGap::RecursiveCall))),
         "a finite recursive chain is not an incomplete boundary: {cyclic:#?}"
     );
 }
@@ -13187,7 +13190,7 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         module.module == "Top"
             && module
                 .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent))
     }));
 
     let inout = analyze_comb_detailed(
@@ -13202,7 +13205,7 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         module.module == "Top"
             && module
                 .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::InoutPort)
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::InoutPort))
     }));
 
     // Why this case exists: even a fully modeled expression on an SV input
@@ -13235,7 +13238,7 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         module.module == "Top"
             && module
                 .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent))
     }));
 
     // Why this case exists: incomplete coverage and a proven loop are
@@ -13271,7 +13274,7 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         module.module == "Top"
             && module
                 .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent))
     }));
     let diagnostics = analyze(external_and_proven_loop_code);
     assert!(
@@ -13314,11 +13317,12 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         function_actual_loop.errors
     );
     assert!(
-        function_actual_loop.incomplete.iter().all(|module| !module
-            .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::MalformedModel)),
+        function_actual_loop
+            .failures
+            .iter()
+            .all(|module| !module.reasons.contains(&AnalysisFailure::MalformedModel)),
         "a legal function-call actual is not an unsupported causal model: {:#?}",
-        function_actual_loop.incomplete
+        function_actual_loop.failures
     );
 
     let ignored_function_argument = analyze_comb_detailed(
@@ -13352,20 +13356,18 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
     );
     assert!(
         ignored_function_argument
-            .incomplete
+            .failures
             .iter()
-            .all(|module| !module
-                .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::MalformedModel)),
+            .all(|module| !module.reasons.contains(&AnalysisFailure::MalformedModel)),
         "a legal constant-returning function is fully modeled: {:#?}",
-        ignored_function_argument.incomplete
+        ignored_function_argument.failures
     );
 }
 
 #[test]
 fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
     // Why this case exists: a nonconstant bound prevents frontend unrolling,
-    // so the causal adapter must retain RuntimeLoop coverage provenance. That
+    // so the causal adapter must retain a DynamicTripCount analysis gap. That
     // uncertainty must not discard an independent, exact dependency from the
     // same block or replace its hard loop diagnostic.
     let code = r#"
@@ -13399,7 +13401,9 @@ fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
         module.module == "Top"
             && module
                 .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::RuntimeLoop)
+                .contains(&IncompleteReason::Analysis(AnalysisGap::Loop(
+                    LoopAnalysisGap::DynamicTripCount,
+                )))
     }));
 
     let diagnostics = analyze(code);
@@ -13409,6 +13413,66 @@ fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
             .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
         "the ordinary analyzer must diagnose the proven loop: {diagnostics:#?}"
     );
+}
+
+#[test]
+fn comb_loop_incomplete_provenance_classes_coexist() {
+    // Why this case exists: opaque feedthrough and an unanalyzed language
+    // construct both make the result incomplete, but have different remedies.
+    // Their provenance must survive together without weakening a third,
+    // independently proven cycle.
+    let detailed = analyze_comb_detailed(
+        r#"
+        module Top (
+            n: input  logic<32>,
+            o: output logic,
+        ) {
+            var from_sv: logic;
+            var a      : logic;
+            var b      : logic;
+            inst u: $sv::Ext (
+                i_data: a,
+                o_data: from_sv,
+            );
+            always_comb {
+                for index in 0..n {
+                    $display("index=%d", index);
+                }
+            }
+            assign a = b;
+            assign b = a;
+            assign o = b | from_sv;
+        }
+        "#,
+    );
+
+    assert_eq!(
+        detailed
+            .errors
+            .iter()
+            .filter(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }))
+            .count(),
+        1,
+        "the proven cycle remains the only hard loop: {detailed:#?}"
+    );
+    let top = detailed
+        .incomplete
+        .iter()
+        .find(|module| module.module == "Top")
+        .expect("Top must expose both incomplete causes");
+    assert!(
+        top.reasons
+            .contains(&IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent))
+    );
+    assert!(
+        top.reasons
+            .contains(&IncompleteReason::Analysis(AnalysisGap::Loop(
+                LoopAnalysisGap::DynamicTripCount
+            )))
+    );
+    assert!(detailed.failures.is_empty(), "{detailed:#?}");
+    assert!(detailed.is_valid(), "{detailed:#?}");
+    assert!(!detailed.is_complete(), "{detailed:#?}");
 }
 
 #[test]
@@ -14034,7 +14098,9 @@ fn comb_loop_over_limit_const_loop_does_not_prove_dead_edges() {
     assert!(detailed.incomplete.iter().any(|module| {
         module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::RuntimeLoop)
+            .contains(&IncompleteReason::Analysis(AnalysisGap::Loop(
+                LoopAnalysisGap::ExpansionLimit,
+            )))
     }));
 }
 
@@ -14074,7 +14140,7 @@ fn comb_loop_const_iterator_preserves_must_write_paths() {
 fn comb_loop_singleton_break_is_fully_analyzed() {
     // Why this case exists: break makes this const singleton use the compact
     // runtime-form CFG, but there is no loop backedge and therefore no
-    // RuntimeLoop uncertainty to expose through check_detailed.
+    // loop-analysis gap to expose through check_detailed.
     let detailed = analyze_comb_detailed(
         r#"
         module Top (
@@ -14093,9 +14159,10 @@ fn comb_loop_singleton_break_is_fully_analyzed() {
     );
     assert!(detailed.errors.is_empty(), "{detailed:#?}");
     assert!(detailed.incomplete.iter().all(|module| {
-        !module
+        module
             .reasons
-            .contains(&veryl_causal::graph::IncompleteReason::RuntimeLoop)
+            .iter()
+            .all(|reason| !matches!(reason, IncompleteReason::Analysis(AnalysisGap::Loop(_))))
     }));
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9868,6 +9868,239 @@ fn assert_comb_loop_for_case(case: &str, code: &str, expected: bool) {
 }
 
 #[test]
+#[ignore = "known bug: a dynamic suffix currently erases its longest static prefix"]
+fn combinational_loop_review_preserves_longest_static_prefix() {
+    // Why this case exists: IEEE 1800-2023 11.5.3 confines buff[0][idx]
+    // to the statically selected row. Aliasing it with buff[1] rejects legal,
+    // bit-disjoint SystemVerilog and makes the analyzer stronger than the LRM.
+    assert_comb_loop_for_case(
+        "a dynamic suffix aliases only its longest static prefix",
+        r#"
+        module Top (
+            idx: input  logic<2>,
+            src: input  logic,
+            o  : output logic,
+        ) {
+            var buff: logic<4, 4>;
+            always_comb {
+                buff[1] = 0;
+                buff[1][0] = src;
+            }
+            always_comb {
+                buff[0][idx] = buff[1][0];
+                o = buff[0][0];
+            }
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: function summaries do not preserve module-scope reads"]
+fn combinational_loop_review_keeps_function_global_read() {
+    // Why this case exists: IEEE 1800-2023 9.2.2.2.1 includes variables read
+    // by a called function in always_comb. A global capture is not a formal
+    // argument, but it is still a real x -> o dependency and closes this loop.
+    assert_comb_loop_for_case(
+        "a called function retains a captured module-scope read",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function get_x () -> logic {
+                return x;
+            }
+            always_comb {
+                o = get_x();
+            }
+            always_comb {
+                x = o;
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: function summaries do not preserve module-scope writes"]
+fn combinational_loop_review_keeps_function_global_write() {
+    // Why this case exists: IEEE 1800-2023 9.2.2.2 treats a variable written
+    // by a called function as written by the always_comb process. Side effects
+    // on module scope must therefore survive function-summary projection.
+    assert_comb_loop_for_case(
+        "a called function retains a captured module-scope write",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function set_x (
+                a: input logic,
+            ) {
+                x = a;
+            }
+            always_comb {
+                set_x(o);
+            }
+            always_comb {
+                o = x;
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: dynamic output regions disappear from module summaries"]
+fn combinational_loop_review_keeps_dynamic_region_across_modules() {
+    // Why this case exists: an instance port is a SystemVerilog data path, so
+    // a child wildcard output must remain a wildcard through every summary.
+    // For idx == 0 the Top-level feedback path is realizable and structural.
+    assert_comb_loop_for_case(
+        "a dynamic child output preserves feedback across two summaries",
+        r#"
+        module Leaf (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Middle (
+            i  : input  logic,
+            idx: input  logic,
+            o  : output logic<2>,
+        ) {
+            inst u: Leaf (
+                i: i,
+                o: o[idx],
+            );
+        }
+
+        module Top (
+            idx: input  logic,
+            o  : output logic,
+        ) {
+            var feedback: logic;
+            var bus     : logic<2>;
+            inst u: Middle (
+                i  : feedback,
+                idx: idx,
+                o  : bus,
+            );
+            assign feedback = bus[0];
+            assign o = feedback;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: break does not terminate the current CFG path"]
+fn combinational_loop_review_drops_unreachable_statements_after_break() {
+    // Why this case exists: IEEE 1800-2023 12.8 makes break jump to the loop
+    // exit. Statements after it are unreachable and cannot prove a hard SCC.
+    assert_comb_loop_for_case(
+        "unreachable statements after break do not form a loop",
+        r#"
+        module Top (
+            n: input  logic<32>,
+            o: output logic,
+        ) {
+            var x: logic;
+            var y: logic;
+            always_comb {
+                for i in 0..n {
+                    break;
+                    x = y;
+                    y = x;
+                }
+                o = 0;
+            }
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: vector function returns lose result-bit correspondence"]
+fn combinational_loop_review_preserves_vector_function_return_bits() {
+    // Why this case exists: identity(value)[0] depends only on value[0].
+    // Collapsing a vector return to an object-wide dependency invents the
+    // value[1] -> o[0] -> value[1] cycle rejected by the current analyzer.
+    assert_comb_loop_for_case(
+        "a vector function return preserves bit identity",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function identity (
+                x: input logic<2>,
+            ) -> logic<2> {
+                return x;
+            }
+            var value: logic<2>;
+            assign o = identity(value);
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: multi-destination assignments lose bit correspondence"]
+fn combinational_loop_review_preserves_concatenated_lhs_bits() {
+    // Why this case exists: {o[1], o[0]} = value maps each destination bit to
+    // one RHS bit. Broadcasting all RHS dependencies to both destinations
+    // invents a value[1] -> o[0] -> value[1] cycle.
+    assert_comb_loop_for_case(
+        "a concatenated assignment destination preserves bit identity",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            var value: logic<2>;
+            assign {o[1], o[0]} = value;
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: constant shifts lose positional dependencies"]
+fn combinational_loop_review_preserves_constant_shift_positions() {
+    // Why this case exists: the low bit of a logical left shift is constant
+    // zero. Treating every result bit as dependent on every operand bit
+    // invents a value[1] -> o[0] -> value[1] cycle.
+    assert_comb_loop_for_case(
+        "a constant left shift preserves its zero-filled low bit",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = value << 1;
+            assign value[0] = 0;
+            assign value[1] = o[0];
+            assign value[3:2] = 0;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
 fn combinational_loop_memory_ssa_celox_regression_corpus() {
     // Ported from celox/tests/basic.rs::test_always_comb_read_before_write_uses_previous_value.
     assert_comb_loop_for_case(

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13340,6 +13340,29 @@ fn combinational_loop_dynamic_element_retention_is_not_feedback() {
 }
 
 #[test]
+fn combinational_loop_oversized_dynamic_retention_is_sparse_and_not_feedback() {
+    // Why this case exists: the legacy assignment table skips arrays above its
+    // enumeration limit. Retention coverage must stay declaration-width
+    // independent instead of either disappearing or expanding 131072 elements,
+    // and it still must not enter the combinational SCC graph.
+    assert_incomplete_assignment_without_comb_loop(
+        "an oversized dynamic store is diagnosed without element enumeration",
+        r#"
+        module Top (
+            index: input  logic<17>,
+            o    : output logic,
+        ) {
+            var held: logic [131072];
+            always_comb {
+                held[index] = 1;
+                o = held[0];
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
 fn combinational_loop_missing_if_arm_retention_is_not_feedback() {
     // Why this case exists: the existing uncovered-branch checker already
     // identifies this latch. The causal graph must not add a second and

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10914,6 +10914,66 @@ fn combinational_loop_review_short_circuits_logical_rhs_side_effects() {
 }
 
 #[test]
+#[ignore = "captured final-review regression: instance fallback retains dead logical RHS"]
+fn combinational_loop_review_short_circuits_instance_logical_actuals() {
+    let case = |name: &str, expression: &str, expected: bool| {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Pass (
+                    i: input  logic,
+                    o: output logic,
+                ) {{
+                    assign o = i;
+                }}
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic;
+                    var passed: logic;
+                    inst u: Pass (
+                        i: {expression},
+                        o: passed,
+                    );
+                    assign feedback = passed;
+                    assign o = passed;
+                }}
+                "#
+            ),
+            expected,
+        );
+    };
+
+    // Why these cases exist: short-circuiting is part of the value feeding an
+    // instance port, not only function-effect lowering. A dead RHS cannot
+    // create a feedback edge through a pass-through child.
+    case(
+        "a false logical-and instance actual drops its dead RHS",
+        "1'b0 && feedback",
+        false,
+    );
+    case(
+        "a true logical-or instance actual drops its dead RHS",
+        "1'b1 || feedback",
+        false,
+    );
+
+    // Why these controls exist: when the constant LHS requires RHS
+    // evaluation, the pass-through child closes a real feedback path.
+    case(
+        "a true logical-and instance actual retains its live RHS",
+        "1'b1 && feedback",
+        true,
+    );
+    case(
+        "a false logical-or instance actual retains its live RHS",
+        "1'b0 || feedback",
+        true,
+    );
+}
+
+#[test]
 #[ignore = "captured final-review regression: nested ternary loses bit positions"]
 fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
     // Why this case exists: bitwise negation does not change bit positions.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10200,6 +10200,381 @@ fn combinational_loop_review_preserves_constant_shift_positions() {
 }
 
 #[test]
+#[ignore = "known bug: an unresolved write is modeled as a strong update of every candidate"]
+fn combinational_loop_review_dynamic_write_is_a_weak_update() {
+    // Why this case exists: o[idx] writes exactly one candidate. For idx != 1,
+    // the old o[1] remains live through o[0] = o[1]; o[1] = o[0], so a real
+    // structural self-dependency must not be killed by the dynamic store.
+    assert_comb_loop_for_case(
+        "a dynamic store cannot kill every candidate definition",
+        r#"
+        module Top (
+            idx: input  logic<2>,
+            o  : output logic<4>,
+        ) {
+            always_comb {
+                o[idx] = 0;
+                o[0] = o[1];
+                o[1] = o[0];
+            }
+        }
+        "#,
+        true,
+    );
+
+    // Why this control exists: a full-width write really does kill every
+    // candidate before the assignment chain and must remain loop-free.
+    assert_comb_loop_for_case(
+        "a full store still kills every candidate definition",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            always_comb {
+                o = 0;
+                o[0] = o[1];
+                o[1] = o[0];
+            }
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: overlapping bounded wildcard regions are disconnected graph nodes"]
+fn combinational_loop_review_aliases_overlapping_unknown_regions() {
+    // Why this case exists: mem[i][j] and mem[0][k] can denote the same
+    // element when i == 0 and j == k. Region::may_alias already says these
+    // bounded regions overlap, so the graph must preserve that realizable SCC.
+    assert_comb_loop_for_case(
+        "overlapping dynamic prefixes retain realizable feedback",
+        r#"
+        module Top (
+            i: input  logic,
+            j: input  logic,
+            k: input  logic,
+            o: output logic,
+        ) {
+            var mem: logic [2, 2];
+            var feedback: logic;
+            always_comb {
+                mem[i][j] = feedback;
+            }
+            always_comb {
+                feedback = mem[0][k];
+            }
+            assign o = feedback;
+        }
+        "#,
+        true,
+    );
+
+    // Why this control exists: statically disjoint row one cannot alias row
+    // zero, even though both have a dynamic suffix.
+    assert_comb_loop_for_case(
+        "disjoint dynamic prefixes remain independent",
+        r#"
+        module Top (
+            j: input  logic,
+            k: input  logic,
+            o: output logic,
+        ) {
+            var mem: logic [2, 2];
+            var feedback: logic;
+            always_comb {
+                mem[1][j] = feedback;
+            }
+            always_comb {
+                feedback = mem[0][k];
+            }
+            assign o = feedback;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: module summaries discard aligned bit coordinates"]
+fn combinational_loop_review_preserves_module_summary_positions() {
+    // Why this case exists: Child is a bitwise identity. child_o[1] is driven
+    // by the constant child_i[1], so feeding it to child_i[0] is acyclic.
+    // A module summary must not collapse the identity into an all-to-all edge.
+    assert_comb_loop_for_case(
+        "a vector identity module preserves disjoint bit positions",
+        r#"
+        module Child (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            assign o = i;
+        }
+        module Top (
+            o: output logic<2>,
+        ) {
+            var child_i: logic<2>;
+            var child_o: logic<2>;
+            inst u: Child (
+                i: child_i,
+                o: child_o,
+            );
+            assign child_i[0] = child_o[1];
+            assign child_i[1] = 0;
+            assign o = child_o;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: returning child_o[0] to its corresponding
+    // child_i[0] is a real same-bit loop across the instance boundary.
+    assert_comb_loop_for_case(
+        "a vector identity module retains same-bit feedback",
+        r#"
+        module Child (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            assign o = i;
+        }
+        module Top (
+            o: output logic<2>,
+        ) {
+            var child_i: logic<2>;
+            var child_o: logic<2>;
+            inst u: Child (
+                i: child_i,
+                o: child_o,
+            );
+            assign child_i[0] = child_o[0];
+            assign child_i[1] = 0;
+            assign o = child_o;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: a dynamic instance output drops its address dependency"]
+fn combinational_loop_review_keeps_instance_output_address_dependency() {
+    // Why this case exists: idx selects the instance output destination and
+    // is itself read from one candidate destination. This is the same address
+    // feedback already detected for a procedural bus[idx] assignment.
+    assert_comb_loop_for_case(
+        "a dynamic instance output retains address feedback",
+        r#"
+        module Child (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+        module Top (
+            seed: input  logic,
+            o   : output logic,
+        ) {
+            var idx: logic;
+            var bus: logic [2];
+            inst u: Child (
+                i: seed,
+                o: bus[idx],
+            );
+            assign idx = bus[0];
+            assign o = idx;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: dependency-free captured function writes disappear from summaries"]
+fn combinational_loop_review_keeps_dependency_free_function_write() {
+    // Why this case exists: clear_x writes x even though the written value has
+    // no signal dependency. That write kills LiveOnEntry before o reads x;
+    // omitting it invents x -> o -> x feedback.
+    assert_comb_loop_for_case(
+        "a constant captured function write participates in procedural order",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function clear_x () {
+                x = 0;
+            }
+            always_comb {
+                clear_x();
+                o = x;
+                x = o;
+            }
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: observer lowering skips return-only function side effects"]
+fn combinational_loop_review_keeps_observer_function_side_effect() {
+    // Why this case exists: IEEE 1800-2023 11.3.5 preserves side effects of
+    // evaluated expressions. touch(o) is evaluated as a display argument, and
+    // 9.2.2.2 makes its captured x write part of the always_comb procedure.
+    assert_comb_loop_for_case(
+        "a display argument retains a called function global write",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function touch (
+                a: input logic,
+            ) -> logic {
+                x = a;
+                return 0;
+            }
+            always_comb {
+                $display("touch=%d", touch(o));
+            }
+            always_comb {
+                o = x;
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: an unused child input hides function side effects in its actual"]
+fn combinational_loop_review_keeps_instance_actual_function_side_effect() {
+    // Why this case exists: IEEE 1800-2023 4.9.6 models an input connection as
+    // an implicit continuous assignment. Its actual expression is evaluated
+    // even when the child has no output feedthrough, so touch(o) still writes x.
+    assert_comb_loop_for_case(
+        "an instance input actual retains a called function global write",
+        r#"
+        module Sink (
+            i: input logic,
+        ) {}
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function touch (
+                a: input logic,
+            ) -> logic {
+                x = a;
+                return 0;
+            }
+            inst u: Sink (
+                i: touch(o),
+            );
+            assign o = x;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: function output arguments discard aligned bit coordinates"]
+fn combinational_loop_review_preserves_vector_function_output_bits() {
+    // Why this case exists: output argument y is a vector identity of x.
+    // Broadcasting all x bits to all y bits invents value[1] -> o[0] feedback.
+    assert_comb_loop_for_case(
+        "a vector function output argument preserves bit identity",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function copy (
+                x: input  logic<2>,
+                y: output logic<2>,
+            ) {
+                y = x;
+            }
+            var value: logic<2>;
+            always_comb {
+                copy(value, o);
+            }
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: split function return dependencies fall back to all-to-all"]
+fn combinational_loop_review_preserves_split_function_return_bits() {
+    // Why this case exists: {high, low}[0] is low. Returning o[0] to high is
+    // acyclic when low is constant, even though the return uses two regions.
+    assert_comb_loop_for_case(
+        "a concatenated function return preserves each source bit",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function combine_bits (
+                high: input logic,
+                low : input logic,
+            ) -> logic<2> {
+                return {high, low};
+            }
+            var high: logic;
+            var low: logic;
+            assign o = combine_bits(high, low);
+            assign high = o[0];
+            assign low = 0;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "known bug: recursive function identity ignores generic specialization"]
+fn combinational_loop_review_distinguishes_generic_function_specializations() {
+    // Why this case exists: recurse::<2> and recurse::<1> are distinct finite
+    // specializations. Elaboration reduces the call to passed = feedback, so
+    // treating the second specialization as infinite recursion hides a real SCC.
+    let errors = analyze_with_large_stack(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function recurse::<N: u32> (
+                x: input logic,
+            ) -> logic {
+                gen M: u32 = N - 1;
+                if N == 1 {
+                    return x;
+                } else {
+                    return recurse::<M>(x);
+                }
+            }
+            var feedback: logic;
+            var passed: logic;
+            assign passed = recurse::<2>(feedback);
+            assign feedback = passed;
+            assign o = feedback;
+        }
+        "#,
+    );
+    let actual = errors
+        .iter()
+        .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }));
+    assert!(
+        actual,
+        "finite generic recursion retains the specialized feedthrough: {errors:?}"
+    );
+}
+
+#[test]
 fn combinational_loop_memory_ssa_celox_regression_corpus() {
     // Ported from celox/tests/basic.rs::test_always_comb_read_before_write_uses_previous_value.
     assert_comb_loop_for_case(

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10974,7 +10974,6 @@ fn combinational_loop_review_short_circuits_instance_logical_actuals() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: nested ternary loses bit positions"]
 fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
     // Why this case exists: bitwise negation does not change bit positions.
     // The nested ternary still maps o[0] only from value[0] (or a constant),
@@ -11015,7 +11014,6 @@ fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: ternary positions disappear at call boundaries"]
 fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
     // Why this case exists: low reads only bit zero of its formal. A ternary
     // actual preserves that bit position, so feedback into value[1] is
@@ -11124,7 +11122,6 @@ fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: unpacked module ports collapse element positions"]
 fn combinational_loop_review_preserves_unpacked_port_element_positions() {
     // Why this case exists: Child is an element-wise identity over an unpacked
     // array. Returning child_o[1] to child_i[0] crosses distinct elements and
@@ -11187,7 +11184,6 @@ fn combinational_loop_review_preserves_unpacked_port_element_positions() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: unpacked function actual collapses elements"]
 fn combinational_loop_review_preserves_unpacked_function_actual_positions() {
     // Why this case exists: high reads only unpacked element one. Feeding its
     // result to value[0] is element-disjoint and must not fall back to reading
@@ -11236,7 +11232,6 @@ fn combinational_loop_review_preserves_unpacked_function_actual_positions() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: local right shift loses zero-fill positions"]
 fn combinational_loop_review_preserves_local_right_shift_positions() {
     // Why this case exists: (value >> 1)[3] is an inserted zero. Returning
     // that discarded high bit to value[0] cannot form feedback.
@@ -11275,7 +11270,6 @@ fn combinational_loop_review_preserves_local_right_shift_positions() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: arithmetic right shift loses source positions"]
 fn combinational_loop_review_preserves_arithmetic_right_shift_positions() {
     // Why this case exists: for a one-bit arithmetic right shift, o[0] is
     // value[1]; discarded value[0] cannot influence it. Whole-vector fallback

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10565,7 +10565,6 @@ fn combinational_loop_review_distinguishes_generic_function_specializations() {
 }
 
 #[test]
-#[ignore = "known bug: repeat concatenation loses positional bit correspondence"]
 fn combinational_loop_review_preserves_repeat_concatenation_positions() {
     // Why this case exists: {value repeat 2} is {value, value}, so o[0]
     // depends only on value[0]. Broadcasting value[1] to o[0] invents a loop.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22447,6 +22447,105 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
             expected,
         );
     }
+
+    // Why these cases exist: each brace level corresponds to one unpacked
+    // dimension. Flattening all literal items without preserving that nesting
+    // would swap or merge unrelated inner elements.
+    for (name, actual, expected) in [
+        (
+            "a nested array literal keeps an inner element loop-free",
+            "'{'{0, feedback}, '{0, 0}}",
+            false,
+        ),
+        (
+            "a nested array literal retains inner-element feedback",
+            "'{'{feedback, 0}, '{0, 0}}",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Pick (
+                    i: input  logic [2, 2],
+                    o: output logic,
+                ) {{
+                    assign o = i[0][0];
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic;
+                    var passed  : logic;
+                    inst u: Pick (
+                        i: {actual},
+                        o: passed,
+                    );
+                    assign feedback = passed;
+                    assign o = passed;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why this case exists: projecting only the constructor member consumed
+    // as a value must not remove effects of a function called in another
+    // member. The function writes `state`, closing a real loop through `o`.
+    assert_comb_loop_for_case(
+        "a structure constructor retains effects from an unobserved member",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            struct Pair {
+                a: logic,
+                b: logic,
+            }
+            var pair : Pair;
+            var state: logic;
+            function touch (x: input logic) -> logic {
+                state = x;
+                return 0;
+            }
+            assign pair = Pair'{a: 0, b: touch(o)};
+            assign o = state;
+        }
+        "#,
+        true,
+    );
+
+    // Why this case exists: a sparse query through a large replication should
+    // inspect only the selected copy, not materialize every declared element.
+    assert_comb_loop_for_case(
+        "a large array repeat remains sparse and bit-precise",
+        r#"
+        module Pick (
+            i: input  logic<2> [200000],
+            o: output logic,
+        ) {
+            assign o = i[199999][0];
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            var value : logic<2>;
+            var passed: logic;
+            inst u: Pick (
+                i: '{value repeat 200000},
+                o: passed,
+            );
+            assign value[1] = passed;
+            assign value[0] = 0;
+            assign o = passed;
+        }
+        "#,
+        false,
+    );
 }
 
 #[test]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -21952,6 +21952,7 @@ fn reanalyze_after_drop() {
     const CODE: &str = r#"package P {
     const A: u32 = 1;
 }
+
 package Q::<W: u32> {
     const B: u32 = W;
 }
@@ -21999,4 +22000,208 @@ module M {
 
     let errors = analyze();
     assert!(errors.is_empty(), "{errors:?}");
+}
+
+#[test]
+#[ignore = "captured third-review regression: context width loses extension positions"]
+fn combinational_loop_review_preserves_context_width_extension_positions() {
+    // Why these cases exist: IEEE 1800-2023 11.8.2 zero-extends an unsigned
+    // two-bit RHS to its four-bit assignment context. The new high bits are
+    // constants, while the low-bit control remains a real feedback path.
+    for (name, feedback, expected) in [
+        (
+            "unsigned extension does not read a zero-filled high bit",
+            "o[3]",
+            false,
+        ),
+        (
+            "unsigned extension retains its corresponding low bit",
+            "o[0]",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    o: output logic<4>,
+                ) {{
+                    var value: logic<2>;
+                    assign o = value;
+                    assign value[0] = {feedback};
+                    assign value[1] = 0;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: signed extension replicates only the source sign
+    // bit. Feedback from a high destination bit to value[0] is disjoint, but
+    // feedback to value[1] is a real sign-fill cycle.
+    for (name, target, expected) in [
+        (
+            "signed extension does not read a non-sign source bit",
+            0,
+            false,
+        ),
+        ("signed extension retains its replicated sign bit", 1, true),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    o: output logic<4>,
+                ) {{
+                    var value: logic<2>;
+                    assign o = $signed(value);
+                    assign value[{target}] = o[3];
+                    assign value[{}] = 0;
+                }}
+                "#,
+                1 - target
+            ),
+            expected,
+        );
+    }
+
+    // Why this case exists: conditional operands are extended to the result
+    // width before selection (11.4.11); the control dependency does not turn
+    // an unsigned zero-fill bit into data feedthrough.
+    assert_comb_loop_for_case(
+        "a ternary preserves unsigned zero extension",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic<4>,
+        ) {
+            var value: logic<2>;
+            assign o = if sel ? value : 4'b0;
+            assign value[0] = o[3];
+            assign value[1] = 0;
+        }
+        "#,
+        false,
+    );
+
+    // Why these cases exist: formal argument coercion uses the same unsigned
+    // extension at function and module boundaries; a high formal bit is zero.
+    assert_comb_loop_for_case(
+        "a function formal high bit does not read an unsigned short actual",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var value: logic<2>;
+            function high (
+                i: input logic<4>,
+            ) -> logic {
+                return i[3];
+            }
+            assign o = high(value);
+            assign value[0] = o;
+            assign value[1] = 0;
+        }
+        "#,
+        false,
+    );
+    assert_comb_loop_for_case(
+        "a module formal high bit does not read an unsigned short actual",
+        r#"
+        module High (
+            i: input  logic<4>,
+            o: output logic,
+        ) {
+            assign o = i[3];
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var value: logic<2>;
+            inst u: High (
+                i: value,
+                o: o,
+            );
+            assign value[0] = o;
+            assign value[1] = 0;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "captured third-review regression: dynamic selectors discard bounded values"]
+fn combinational_loop_review_bounds_dynamic_selector_values() {
+    // Why these cases exist: a two-state one-bit selector has exactly the
+    // values {0,1}. Adding two therefore reaches only elements {2,3}; element
+    // zero is disjoint, while element two is a real candidate.
+    for (name, target, expected) in [
+        (
+            "a shifted one-bit index cannot reach element zero",
+            0,
+            false,
+        ),
+        ("a shifted one-bit index can reach element two", 2, true),
+    ] {
+        let clears = match target {
+            0 => "assign value[1] = 0; assign value[2] = 0; assign value[3] = 0;",
+            2 => "assign value[0] = 0; assign value[1] = 0; assign value[3] = 0;",
+            _ => unreachable!(),
+        };
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    idx: input  bit,
+                    o  : output logic,
+                ) {{
+                    var value: logic [4];
+                    assign o = value[idx + 2];
+                    assign value[{target}] = o;
+                    {clears}
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: an indexed part-select with base {0,1} and width
+    // two reaches only bits 0..2. Bit three is disjoint; bit zero is reachable.
+    for (name, target, expected) in [
+        (
+            "a bounded indexed part-select cannot reach bit three",
+            3,
+            false,
+        ),
+        ("a bounded indexed part-select can reach bit zero", 0, true),
+    ] {
+        let clears = match target {
+            0 => "assign value[1] = 0; assign value[2] = 0; assign value[3] = 0;",
+            3 => "assign value[0] = 0; assign value[1] = 0; assign value[2] = 0;",
+            _ => unreachable!(),
+        };
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    idx: input  bit,
+                    o  : output logic<2>,
+                ) {{
+                    var value: logic<4>;
+                    assign o = value[idx+:2];
+                    assign value[{target}] = o[0];
+                    {clears}
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -29,6 +29,26 @@ fn analyze(code: &str) -> Vec<AnalyzerError> {
 }
 
 #[track_caller]
+fn analyze_comb_detailed(code: &str) -> crate::comb_loop_detect::CombAnalysisResult {
+    symbol_table::clear();
+    attribute_table::clear();
+    doc_comment_table::clear();
+
+    let metadata = Metadata::create_default("prj").unwrap();
+    let parser = Parser::parse(code, &"").unwrap();
+    let analyzer = Analyzer::new(&metadata);
+    let mut context = Context::default();
+    let mut ir = Ir::default();
+    let pass1 = analyzer.analyze_pass1("prj", &parser.veryl);
+    assert!(pass1.is_empty(), "{pass1:?}");
+    let post1 = Analyzer::analyze_post_pass1();
+    assert!(post1.is_empty(), "{post1:?}");
+    let pass2 = analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
+    assert!(pass2.is_empty(), "{pass2:?}");
+    crate::comb_loop_detect::check_detailed(&ir)
+}
+
+#[track_caller]
 fn analyze_with_lint(code: &str, lint: Lint) -> Vec<AnalyzerError> {
     symbol_table::clear();
     attribute_table::clear();
@@ -12906,26 +12926,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
 
 #[test]
 fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
-    fn detailed(code: &str) -> crate::comb_loop_detect::CombAnalysisResult {
-        symbol_table::clear();
-        attribute_table::clear();
-        doc_comment_table::clear();
-
-        let metadata = Metadata::create_default("prj").unwrap();
-        let parser = Parser::parse(code, &"").unwrap();
-        let analyzer = Analyzer::new(&metadata);
-        let mut context = Context::default();
-        let mut ir = Ir::default();
-        let pass1 = analyzer.analyze_pass1("prj", &parser.veryl);
-        assert!(pass1.is_empty(), "{pass1:?}");
-        let post1 = Analyzer::analyze_post_pass1();
-        assert!(post1.is_empty(), "{post1:?}");
-        let pass2 = analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
-        assert!(pass2.is_empty(), "{pass2:?}");
-        crate::comb_loop_detect::check_detailed(&ir)
-    }
-
-    let external = detailed(
+    let external = analyze_comb_detailed(
         r#"
         module Top (
             o: output logic,
@@ -12949,7 +12950,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
                 .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
     }));
 
-    let inout = detailed(
+    let inout = analyze_comb_detailed(
         r#"
         module Top (
             io: inout tri logic,
@@ -12967,7 +12968,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
     // Why this case exists: a dynamic selection inside a function must carry
     // its unresolved region provenance through the function summary. Function
     // lowering must not silently turn it into complete coverage.
-    let complex_function = detailed(
+    let complex_function = analyze_comb_detailed(
         r#"
         module Top (
             i    : input  logic<4>,
@@ -13004,7 +13005,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
     // cannot prove feedthrough inside the external component. A feedback-like
     // connection around that boundary stays incomplete rather than becoming a
     // stronger-than-source hard loop.
-    let complex_external_actual = detailed(
+    let complex_external_actual = analyze_comb_detailed(
         r#"
         module Top (
             o: output logic,
@@ -13053,7 +13054,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
             assign o = b | from_sv;
         }
         "#;
-    let external_and_proven_loop = detailed(external_and_proven_loop_code);
+    let external_and_proven_loop = analyze_comb_detailed(external_and_proven_loop_code);
     assert!(
         external_and_proven_loop
             .errors
@@ -13076,7 +13077,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         "the ordinary analyzer must diagnose the proven loop: {diagnostics:#?}"
     );
 
-    let function_actual_loop = detailed(
+    let function_actual_loop = analyze_comb_detailed(
         r#"
         module Child (
             i: input  logic,
@@ -13116,7 +13117,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         function_actual_loop.incomplete
     );
 
-    let ignored_function_argument = detailed(
+    let ignored_function_argument = analyze_comb_detailed(
         r#"
         module Child (
             i: input  logic,
@@ -13159,34 +13160,50 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
 
 #[test]
 fn combinational_loop_incomplete_effect_does_not_erase_proven_edges() {
-    // A loop construct carries explicit coverage provenance until break and
-    // runtime iteration semantics are modeled completely. That uncertainty
-    // must not discard an independent, exact dependency from the same block.
-    let result = analyze(
-        r#"
+    // Why this case exists: a nonconstant bound prevents frontend unrolling,
+    // so the causal adapter must retain RuntimeLoop coverage provenance. That
+    // uncertainty must not discard an independent, exact dependency from the
+    // same block or replace its hard loop diagnostic.
+    let code = r#"
         module Top (
-            i: input  logic,
+            n: input  logic<32>,
             o: output logic,
         ) {
-            var scratch: logic [1];
             var a: logic;
             var b: logic;
             always_comb {
-                for index in 0..1 {
-                    scratch[index] = i;
+                for index in 0..n {
+                    $display("index=%d", index);
                 }
-                a = b;
-                b = a;
-                o = b;
             }
+            assign a = b;
+            assign b = a;
+            assign o = b;
         }
-        "#,
+        "#;
+    let detailed = analyze_comb_detailed(code);
+    assert_eq!(
+        detailed
+            .errors
+            .iter()
+            .filter(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }))
+            .count(),
+        1,
+        "only the independent proven loop should be diagnosed: {detailed:#?}"
     );
+    assert!(detailed.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::RuntimeLoop)
+    }));
+
+    let diagnostics = analyze(code);
     assert!(
-        result
+        diagnostics
             .iter()
             .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
-        "an incomplete effect must not hide an unrelated proven loop: {result:#?}"
+        "the ordinary analyzer must diagnose the proven loop: {diagnostics:#?}"
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22599,22 +22599,14 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
 }
 
 #[test]
-#[ignore = "captured third-review follow-up: correlated selectors need guarded regions"]
-fn combinational_loop_review_preserves_selector_correlation() {
-    // Why these cases exist: bounded evaluation must preserve correlation
-    // between a read and write selector. For one-bit two-state idx, idx and
-    // ~idx are always distinct, while two identical selectors may alias.
-    for (name, write_index, expected) in [
-        (
-            "complementary selectors cannot address the same bit",
-            "~idx",
-            false,
-        ),
-        (
-            "identical selectors retain a possible same-bit cycle",
-            "idx",
-            true,
-        ),
+fn combinational_loop_review_uses_structural_selector_overlap() {
+    // Why these cases exist: structural feedback compares each access's
+    // independently possible region. Both `idx` and `~idx` can address
+    // elements {0,1}, so their regions overlap without relational selector
+    // reasoning. The identical-selector case is the direct control.
+    for (name, write_index) in [
+        ("complementary selectors retain structural overlap", "~idx"),
+        ("identical selectors retain structural overlap", "idx"),
     ] {
         assert_comb_loop_for_case(
             name,
@@ -22630,7 +22622,7 @@ fn combinational_loop_review_preserves_selector_correlation() {
                 }}
                 "#
             ),
-            expected,
+            true,
         );
     }
 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9867,7 +9867,14 @@ fn combinational_loop_memory_ssa_retains_dynamic_region_uncertainty() {
     let post1 = Analyzer::analyze_post_pass1();
     assert!(post1.is_empty(), "{post1:?}");
     let pass2 = analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
-    assert!(pass2.is_empty(), "{pass2:?}");
+    // Why this assertion exists: a dynamic destination is a weak write, so
+    // the assignment pass must report its retained candidates even though the
+    // comb-loop pass keeps that uncertainty out of hard SCC diagnostics.
+    assert_eq!(pass2.len(), 1, "{pass2:?}");
+    assert!(
+        matches!(pass2[0], AnalyzerError::UncoveredBranch { .. }),
+        "{pass2:?}"
+    );
 
     let result = crate::comb_loop_detect::check_detailed(&ir);
     assert!(result.errors.is_empty(), "{:#?}", result.errors);
@@ -13412,13 +13419,12 @@ fn combinational_loop_missing_switch_default_retention_is_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_latch_boundary_breaks_a_cross_variable_cycle() {
-    // Why this case exists: collapsing a latched variable's pre-state and
-    // next-state into one NodeKey invents the cycle held -> o -> enable ->
-    // held. A state boundary must cut that path even when the false SCC spans
-    // several source variables instead of appearing as a direct self-edge.
-    assert_incomplete_assignment_without_comb_loop(
-        "a retained variable is a state boundary inside a larger apparent SCC",
+fn combinational_loop_retention_does_not_hide_cross_variable_feedback() {
+    // Why this case exists: retention itself is diagnosed as incomplete
+    // assignment, but it must not erase the explicit held -> o -> enable
+    // value/control dependencies. Those dependencies form proven structural
+    // feedback independently of the retained entry-state path.
+    let errors = analyze(
         r#"
         module Top (
             o: output logic,
@@ -13434,6 +13440,18 @@ fn combinational_loop_latch_boundary_breaks_a_cross_variable_cycle() {
             assign enable = o;
         }
         "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })),
+        "the missing assignment path must remain diagnosed: {errors:#?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "retention must not hide independently proven structural feedback: {errors:#?}"
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10565,6 +10565,167 @@ fn combinational_loop_review_distinguishes_generic_function_specializations() {
 }
 
 #[test]
+#[ignore = "known bug: repeat concatenation loses positional bit correspondence"]
+fn combinational_loop_review_preserves_repeat_concatenation_positions() {
+    // Why this case exists: {value repeat 2} is {value, value}, so o[0]
+    // depends only on value[0]. Broadcasting value[1] to o[0] invents a loop.
+    assert_comb_loop_for_case(
+        "repeat concatenation keeps a disjoint low-bit path loop-free",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<2>;
+            assign o = {value repeat 2};
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: feeding o[0] back to value[0] selects the
+    // corresponding repeated bit and therefore is a real structural SCC.
+    assert_comb_loop_for_case(
+        "repeat concatenation still detects a corresponding-bit loop",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<2>;
+            assign o = {value repeat 2};
+            assign value[0] = o[0];
+            assign value[1] = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: instance actual mapping ignores constant shift positions"]
+fn combinational_loop_review_preserves_instance_shift_positions() {
+    // Why this case exists: (value << 1)[0] is an inserted constant zero.
+    // Falling back to every operand creates a fictitious value[1] path.
+    assert_comb_loop_for_case(
+        "an instance actual left shift keeps its inserted bit loop-free",
+        r#"
+        module Child (
+            i: input  logic<4>,
+            o: output logic<4>,
+        ) {
+            assign o = i;
+        }
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            var passed: logic<4>;
+            inst u: Child (
+                i: value << 1,
+                o: passed,
+            );
+            assign value[0] = 0;
+            assign value[1] = passed[0];
+            assign value[3:2] = 0;
+            assign o = passed;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: passed[1] is value[0], so feeding it back to
+    // value[0] is the corresponding shifted-bit SCC and must remain detected.
+    assert_comb_loop_for_case(
+        "an instance actual left shift detects its live shifted bit",
+        r#"
+        module Child (
+            i: input  logic<4>,
+            o: output logic<4>,
+        ) {
+            assign o = i;
+        }
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            var passed: logic<4>;
+            inst u: Child (
+                i: value << 1,
+                o: passed,
+            );
+            assign value[0] = passed[1];
+            assign value[3:1] = 0;
+            assign o = passed;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "known bug: instance actual mapping ignores repeat-concat positions"]
+fn combinational_loop_review_preserves_instance_repeat_positions() {
+    // Why this case exists: {high repeat 2, low}[2] is high. Treating every
+    // operand as a source invents a low -> child_o -> low feedback path.
+    assert_comb_loop_for_case(
+        "an instance repeat actual keeps an unrelated operand loop-free",
+        r#"
+        module Child (
+            i: input  logic<3>,
+            o: output logic,
+        ) {
+            assign o = i[2];
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var high: logic;
+            var low: logic;
+            var child_o: logic;
+            inst u: Child (
+                i: {high repeat 2, low},
+                o: child_o,
+            );
+            assign high = 0;
+            assign low = child_o;
+            assign o = child_o;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: feeding child_o back to high closes the actual
+    // i[2] path and must remain a real loop after positional mapping.
+    assert_comb_loop_for_case(
+        "an instance repeat actual detects its selected repeated operand",
+        r#"
+        module Child (
+            i: input  logic<3>,
+            o: output logic,
+        ) {
+            assign o = i[2];
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var high: logic;
+            var low: logic;
+            var child_o: logic;
+            inst u: Child (
+                i: {high repeat 2, low},
+                o: child_o,
+            );
+            assign high = child_o;
+            assign low = 0;
+            assign o = child_o;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_memory_ssa_celox_regression_corpus() {
     // Ported from celox/tests/basic.rs::test_always_comb_read_before_write_uses_previous_value.
     assert_comb_loop_for_case(

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13510,6 +13510,90 @@ fn combinational_loop_default_before_runtime_loop_kills_retention() {
 }
 
 #[test]
+fn combinational_loop_full_write_after_runtime_loop_kills_retention() {
+    // Why this case exists: incomplete-assignment coverage is a property of
+    // the procedure exit, not of an intermediate statement. A later full
+    // write kills the zero-trip entry value left by the runtime loop.
+    let errors = analyze(
+        r#"
+        module Top (
+            n: input  logic<32>,
+            o: output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for index in 0..n {
+                    value = index[0];
+                }
+                value = 0;
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors.is_empty(),
+        "a later full write kills runtime-loop retention: {errors:#?}"
+    );
+}
+
+#[test]
+fn combinational_loop_nonempty_runtime_form_loop_has_no_zero_trip_path() {
+    // Why this case exists: `break` keeps a constant loop in runtime-form IR,
+    // but 0..1 still enters its body exactly once. Runtime representation does
+    // not by itself imply that a zero-trip path is reachable.
+    let errors = analyze(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for index in 0..1 {
+                    value = index[0];
+                    break;
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors.is_empty(),
+        "a statically nonempty loop assigns before breaking: {errors:#?}"
+    );
+}
+
+#[test]
+fn combinational_loop_function_output_weak_write_retains_coverage() {
+    // Why this case exists: a function output argument is copied back to its
+    // caller, but a dynamic write inside the function still leaves unselected
+    // packed bits without a definition. Function summarization must preserve
+    // that exit-coverage fact without inventing a comb dependency.
+    assert_incomplete_assignment_without_comb_loop(
+        "a function output weak write remains incomplete at the caller",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            function write_selected (
+                index: input  logic<2>,
+                value: output logic<4>,
+            ) {
+                value[index] = 1;
+            }
+            var value: logic<4>;
+            always_comb {
+                write_selected(index, value);
+                o = value[0];
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
 fn comb_loop_ifstmt_feed_forward_array() {
     // False positive: an always_comb for-loop over cross-coupled arrays that
     // reads index i and writes i+1 (a feed-forward / acyclic CORDIC-style

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10001,7 +10001,6 @@ fn combinational_loop_review_keeps_dynamic_region_across_modules() {
 }
 
 #[test]
-#[ignore = "known bug: break does not terminate the current CFG path"]
 fn combinational_loop_review_drops_unreachable_statements_after_break() {
     // Why this case exists: IEEE 1800-2023 12.8 makes break jump to the loop
     // exit. Statements after it are unreachable and cannot prove a hard SCC.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10386,7 +10386,6 @@ fn combinational_loop_review_keeps_instance_output_address_dependency() {
 }
 
 #[test]
-#[ignore = "known bug: dependency-free captured function writes disappear from summaries"]
 fn combinational_loop_review_keeps_dependency_free_function_write() {
     // Why this case exists: clear_x writes x even though the written value has
     // no signal dependency. That write kills LiveOnEntry before o reads x;
@@ -10413,7 +10412,6 @@ fn combinational_loop_review_keeps_dependency_free_function_write() {
 }
 
 #[test]
-#[ignore = "known bug: observer lowering skips return-only function side effects"]
 fn combinational_loop_review_keeps_observer_function_side_effect() {
     // Why this case exists: IEEE 1800-2023 11.3.5 preserves side effects of
     // evaluated expressions. touch(o) is evaluated as a display argument, and

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10955,6 +10955,178 @@ fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
 }
 
 #[test]
+#[ignore = "captured final-review regression: ternary positions disappear at call boundaries"]
+fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
+    // Why this case exists: low reads only bit zero of its formal. A ternary
+    // actual preserves that bit position, so feedback into value[1] is
+    // disjoint even when the mapping crosses a function-call boundary.
+    assert_comb_loop_for_case(
+        "a function ternary actual keeps a disjoint bit loop-free",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic,
+        ) {
+            function low (
+                x: input logic<2>,
+            ) -> logic {
+                return x[0];
+            }
+            var value: logic<2>;
+            assign o = low(if sel ? value : 0);
+            assign value[0] = 0;
+            assign value[1] = o;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: returning the selected bit to value[0] closes
+    // the function actual's real corresponding-bit path.
+    assert_comb_loop_for_case(
+        "a function ternary actual detects its corresponding-bit loop",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic,
+        ) {
+            function low (
+                x: input logic<2>,
+            ) -> logic {
+                return x[0];
+            }
+            var value: logic<2>;
+            assign o = low(if sel ? value : 0);
+            assign value[0] = o;
+            assign value[1] = 0;
+        }
+        "#,
+        true,
+    );
+
+    // Why this case exists: the same positional rule must survive a module
+    // port boundary; child output o depends only on actual bit zero.
+    assert_comb_loop_for_case(
+        "an instance ternary actual keeps a disjoint bit loop-free",
+        r#"
+        module Low (
+            i: input  logic<2>,
+            o: output logic,
+        ) {
+            assign o = i[0];
+        }
+        module Top (
+            sel: input  logic,
+            o  : output logic,
+        ) {
+            var value: logic<2>;
+            var passed: logic;
+            inst u: Low (
+                i: if sel ? value : 0,
+                o: passed,
+            );
+            assign value[0] = 0;
+            assign value[1] = passed;
+            assign o = passed;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: feeding the child result back to actual bit
+    // zero is a real loop through the instance boundary.
+    assert_comb_loop_for_case(
+        "an instance ternary actual detects its corresponding-bit loop",
+        r#"
+        module Low (
+            i: input  logic<2>,
+            o: output logic,
+        ) {
+            assign o = i[0];
+        }
+        module Top (
+            sel: input  logic,
+            o  : output logic,
+        ) {
+            var value: logic<2>;
+            var passed: logic;
+            inst u: Low (
+                i: if sel ? value : 0,
+                o: passed,
+            );
+            assign value[0] = passed;
+            assign value[1] = 0;
+            assign o = passed;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "captured final-review regression: unpacked module ports collapse element positions"]
+fn combinational_loop_review_preserves_unpacked_port_element_positions() {
+    // Why this case exists: Child is an element-wise identity over an unpacked
+    // array. Returning child_o[1] to child_i[0] crosses distinct elements and
+    // must not be widened to whole-array feedback at the instance boundary.
+    assert_comb_loop_for_case(
+        "an unpacked-array module port keeps disjoint elements loop-free",
+        r#"
+        module Child (
+            i: input  logic [2],
+            o: output logic [2],
+        ) {
+            assign o[0] = i[0];
+            assign o[1] = i[1];
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var child_i: logic [2];
+            var child_o: logic [2];
+            inst u: Child (
+                i: child_i,
+                o: child_o,
+            );
+            assign child_i[0] = child_o[1];
+            assign child_i[1] = 0;
+            assign o = child_o[0];
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: returning child_o[0] to the corresponding
+    // child_i[0] element is a real instance-boundary SCC.
+    assert_comb_loop_for_case(
+        "an unpacked-array module port detects same-element feedback",
+        r#"
+        module Child (
+            i: input  logic [2],
+            o: output logic [2],
+        ) {
+            assign o[0] = i[0];
+            assign o[1] = i[1];
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var child_i: logic [2];
+            var child_o: logic [2];
+            inst u: Child (
+                i: child_i,
+                o: child_o,
+            );
+            assign child_i[0] = child_o[0];
+            assign child_i[1] = 0;
+            assign o = child_o[0];
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 #[ignore = "captured final-review regression: local right shift loses zero-fill positions"]
 fn combinational_loop_review_preserves_local_right_shift_positions() {
     // Why this case exists: (value >> 1)[3] is an inserted zero. Returning

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -14254,6 +14254,13 @@ fn uncovered_branch() {
     "#;
 
     let errors = analyze(code);
+    // Why this assertion exists: legacy branch bookkeeping and MemorySSA both
+    // observe this latch, but the analyzer must expose one diagnostic.
+    assert_eq!(
+        errors.len(),
+        1,
+        "coverage must not be reported twice: {errors:#?}"
+    );
     assert!(matches!(errors[0], AnalyzerError::UncoveredBranch { .. }));
 
     let code = r#"

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9839,7 +9839,10 @@ fn comb_loop_statement_order_and_observer_semantics() {
 }
 
 #[test]
-fn comb_loop_dynamic_write_reports_region_uncertainty() {
+fn comb_loop_bounded_dynamic_write_is_complete() {
+    // Why this case exists: an unresolved selector still stays within the
+    // declared values object. Whole-object expansion is conservative and
+    // complete even though coverage analysis separately reports retention.
     symbol_table::clear();
     attribute_table::clear();
     doc_comment_table::clear();
@@ -9871,12 +9874,12 @@ fn comb_loop_dynamic_write_reports_region_uncertainty() {
 
     let result = crate::comb_loop_detect::check_detailed(&ir);
     assert!(result.errors.is_empty(), "{:#?}", result.errors);
-    assert!(result.incomplete.iter().any(|module| {
-        module.module == "Top"
-            && module
-                .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)
-    }));
+    assert!(
+        result.incomplete.iter().all(|module| !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)),
+        "a dynamic write bounded to values must be complete: {result:#?}"
+    );
 
     // Why this assertion exists: the ordinary analyzer consumes coverage from
     // the same post-pass MemorySSA run, while the detailed loop API keeps hard
@@ -9893,6 +9896,80 @@ fn comb_loop_dynamic_write_reports_region_uncertainty() {
             .iter()
             .all(|error| !matches!(error, AnalyzerError::CombinationalLoop { .. })),
         "{diagnostics:?}"
+    );
+}
+
+#[test]
+fn comb_loop_function_dynamic_read_is_complete() {
+    // Why this case exists: a function summary must retain the declared shape
+    // of a formal argument. A dynamic selection within that formal is bounded
+    // and must not become incomplete merely by crossing the call boundary.
+    let dynamic_function = analyze_comb_detailed(
+        r#"
+        module Top (
+            i    : input  logic<4>,
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            function select (
+                x    : input logic<4>,
+                index: input logic<2>,
+            ) -> logic {
+                return x[index];
+            }
+            assign o = select(i, index);
+        }
+        "#,
+    );
+    assert!(dynamic_function.errors.is_empty(), "{dynamic_function:#?}");
+    assert!(
+        dynamic_function.incomplete.iter().all(|module| !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)),
+        "a dynamic function read bounded to its formal must be complete: {dynamic_function:#?}"
+    );
+}
+
+#[test]
+fn comb_loop_bounded_dynamic_read_retains_feedback() {
+    // Why this case exists: treating a bounded dynamic access as complete must
+    // not erase its conservative dependency. A feedback path through a child
+    // module remains a proven structural combinational loop.
+    let dynamic_loop = analyze_comb_detailed(
+        r#"
+        module Child (
+            i    : input  logic<4>,
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            assign o = i[index];
+        }
+        module Top (
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            var feedback: logic;
+            inst child: Child (
+                i: {3'b0, feedback},
+                index,
+                o: feedback,
+            );
+            assign o = feedback;
+        }
+        "#,
+    );
+    assert!(
+        dynamic_loop
+            .errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "a bounded dynamic read must retain its conservative loop: {dynamic_loop:#?}"
+    );
+    assert!(
+        dynamic_loop.incomplete.iter().all(|module| !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)),
+        "a conservative bounded loop is complete: {dynamic_loop:#?}"
     );
 }
 
@@ -13127,42 +13204,6 @@ fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
                 .reasons
                 .contains(&veryl_causal::graph::IncompleteReason::InoutPort)
     }));
-
-    // Why this case exists: a dynamic selection inside a function must carry
-    // its unresolved region provenance through the function summary. Function
-    // lowering must not silently turn it into complete coverage.
-    let complex_function = analyze_comb_detailed(
-        r#"
-        module Top (
-            i    : input  logic<4>,
-            index: input  logic<2>,
-            o    : output logic,
-        ) {
-            function select (
-                x    : input logic<4>,
-                index: input logic<2>,
-            ) -> logic {
-                return x[index];
-            }
-            assign o = select(i, index);
-        }
-        "#,
-    );
-    assert!(
-        complex_function.errors.is_empty(),
-        "incomplete function coverage must not become a hard loop: {:#?}",
-        complex_function.errors
-    );
-    assert!(
-        complex_function.incomplete.iter().any(|module| {
-            module.module == "Top"
-                && module
-                    .reasons
-                    .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)
-        }),
-        "a function with a dynamic selection must retain incomplete provenance: {:#?}",
-        complex_function.incomplete
-    );
 
     // Why this case exists: even a fully modeled expression on an SV input
     // cannot prove feedthrough inside the external component. A feedback-like

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10355,7 +10355,6 @@ fn combinational_loop_review_preserves_module_summary_positions() {
 }
 
 #[test]
-#[ignore = "known bug: a dynamic instance output drops its address dependency"]
 fn combinational_loop_review_keeps_instance_output_address_dependency() {
     // Why this case exists: idx selects the instance output destination and
     // is itself read from one candidate destination. This is the same address

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10200,7 +10200,6 @@ fn combinational_loop_review_preserves_constant_shift_positions() {
 }
 
 #[test]
-#[ignore = "known bug: an unresolved write is modeled as a strong update of every candidate"]
 fn combinational_loop_review_dynamic_write_is_a_weak_update() {
     // Why this case exists: o[idx] writes exactly one candidate. For idx != 1,
     // the old o[1] remains live through o[0] = o[1]; o[1] = o[0], so a real

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -11226,6 +11226,63 @@ fn combinational_loop_review_preserves_local_right_shift_positions() {
 }
 
 #[test]
+#[ignore = "captured final-review regression: arithmetic right shift loses source positions"]
+fn combinational_loop_review_preserves_arithmetic_right_shift_positions() {
+    // Why this case exists: for a one-bit arithmetic right shift, o[0] is
+    // value[1]; discarded value[0] cannot influence it. Whole-vector fallback
+    // invents value[0] -> o[0] feedback.
+    assert_comb_loop_for_case(
+        "an arithmetic right shift keeps a discarded bit loop-free",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = $signed(value) >>> 1;
+            assign value[0] = o[0];
+            assign value[3:1] = 0;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: o[0] is the live source value[1], so returning
+    // it to value[1] is a real shifted-bit SCC.
+    assert_comb_loop_for_case(
+        "an arithmetic right shift detects its live shifted bit",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = $signed(value) >>> 1;
+            assign value[0] = 0;
+            assign value[1] = o[0];
+            assign value[3:2] = 0;
+        }
+        "#,
+        true,
+    );
+
+    // Why this control exists: the vacated MSB is a replication of the sign
+    // bit, so sign feedback remains a real (non-positional) dependency.
+    assert_comb_loop_for_case(
+        "an arithmetic right shift retains sign-fill feedback",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = $signed(value) >>> 1;
+            assign value[2:0] = 0;
+            assign value[3] = o[3];
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_review_preserves_function_actual_shift_positions() {
     // Why this case exists: (value << 1)[0] is an inserted zero. Passing the
     // shifted vector through a function must not broadcast value[1] to o.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22643,6 +22643,127 @@ fn combinational_loop_whole_unpacked_instance_is_sparse_and_precise() {
 }
 
 #[test]
+fn combinational_loop_periodic_repeat_is_sparse_and_phase_precise() {
+    // Why these cases exist: Veryl elaborates a succinct array repeat into one
+    // assignment per element. Causal summaries must recover one periodic
+    // transfer whose size is independent of 200,000 copies, while retaining
+    // the bit phase both locally and through a module boundary.
+    for (name, through_instance, count, index, output_bit, expected) in [
+        (
+            "local repeat retains matching phase feedback",
+            false,
+            64,
+            42,
+            0,
+            true,
+        ),
+        (
+            "local repeat keeps a different phase disjoint",
+            false,
+            64,
+            42,
+            1,
+            false,
+        ),
+        (
+            "instance repeat retains matching phase feedback",
+            true,
+            200_000,
+            123_456,
+            0,
+            true,
+        ),
+        (
+            "instance repeat keeps a different phase disjoint",
+            true,
+            64,
+            42,
+            1,
+            false,
+        ),
+    ] {
+        let body = if through_instance {
+            r#"
+                inst u: Broadcast (
+                    i: feedback,
+                    o: passed,
+                );
+            "#
+        } else {
+            "assign passed = '{feedback repeat COUNT};"
+        }
+        .replace("COUNT", &count.to_string());
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Broadcast (
+                    i: input  logic<2>,
+                    o: output logic<2> [{count}],
+                ) {{
+                    assign o = '{{i repeat {count}}};
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic<2>;
+                    var passed  : logic<2> [{count}];
+                    {body}
+                    assign feedback[0] = passed[{index}][{output_bit}];
+                    assign feedback[1] = 0;
+                    assign o = passed[0][0];
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why this extra hierarchy exists: an intermediate module observes only
+    // one input phase while forwarding the whole periodic output. Its summary
+    // must retain both the sparse phase partition and the regular transfer for
+    // the next module boundary.
+    for (output_bit, expected) in [(0, true), (1, false)] {
+        assert_comb_loop_for_case(
+            "a periodic phase survives two module summaries",
+            &format!(
+                r#"
+                module Broadcast (
+                    i: input  logic<2>,
+                    o: output logic<2> [64],
+                ) {{
+                    assign o = '{{i repeat 64}};
+                }}
+
+                module Wrapper (
+                    i  : input  logic<2>,
+                    o  : output logic<2> [64],
+                    tap: output logic,
+                ) {{
+                    inst u: Broadcast (i: i, o: o);
+                    assign tap = i[0];
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic<2>;
+                    var passed  : logic<2> [64];
+                    var tap     : logic;
+                    inst u: Wrapper (i: feedback, o: passed, tap: tap);
+                    assign feedback[0] = passed[42][{output_bit}];
+                    assign feedback[1] = 0;
+                    assign o = tap;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+}
+
+#[test]
 fn combinational_loop_review_uses_structural_selector_overlap() {
     // Why these cases exist: structural feedback compares each access's
     // independently possible region. Both `idx` and `~idx` can address

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13024,6 +13024,70 @@ fn comb_loop_module_boundary_region_mapping() {
 }
 
 #[test]
+fn comb_loop_finite_recursive_module_specializations_are_complete() {
+    // Why this case exists: source-level recursion by module name is not a
+    // cyclic elaboration when a parameter produces a finite chain of distinct
+    // concrete specializations. The chain must retain its feedthrough summary
+    // without acquiring RecursiveCall incompleteness.
+    let recursive_chain = r#"
+        module Recursive #(
+            param DEPTH: u32 = 3,
+        )(
+            i: input  logic,
+            o: output logic,
+        ) {
+            if DEPTH == 0 :base {
+                assign o = i;
+            } else {
+                inst next: Recursive #(
+                    DEPTH: DEPTH - 1
+                )(
+                    i,
+                    o,
+                );
+            }
+        }
+    "#;
+    let acyclic = analyze_comb_detailed(recursive_chain);
+    assert!(acyclic.errors.is_empty(), "{acyclic:#?}");
+    assert!(
+        acyclic.incomplete.iter().all(|module| !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::RecursiveCall)),
+        "finite concrete specialization recursion must be complete: {acyclic:#?}"
+    );
+
+    let cyclic = analyze_comb_detailed(&format!(
+        r#"
+        {recursive_chain}
+        module Top (
+            o: output logic,
+        ) {{
+            var feedback: logic;
+            inst chain: Recursive (
+                i: feedback,
+                o: feedback,
+            );
+            assign o = feedback;
+        }}
+        "#
+    ));
+    assert!(
+        cyclic
+            .errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "feedthrough must survive every finite recursive specialization: {cyclic:#?}"
+    );
+    assert!(
+        cyclic.incomplete.iter().all(|module| !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::RecursiveCall)),
+        "a finite recursive chain is not an incomplete boundary: {cyclic:#?}"
+    );
+}
+
+#[test]
 fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
     let external = analyze_comb_detailed(
         r#"

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10914,7 +10914,6 @@ fn combinational_loop_review_short_circuits_logical_rhs_side_effects() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: instance fallback retains dead logical RHS"]
 fn combinational_loop_review_short_circuits_instance_logical_actuals() {
     let case = |name: &str, expression: &str, expected: bool| {
         assert_comb_loop_for_case(

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10903,7 +10903,6 @@ fn combinational_loop_review_preserves_function_actual_shift_positions() {
 }
 
 #[test]
-#[ignore = "captured independent-review regression: vector ternary loses bit positions"]
 fn combinational_loop_review_preserves_vector_ternary_positions() {
     // Why this case exists: both branches preserve vector bit positions, so
     // o[0] can read only value[0] (or the constant), never value[1].

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22302,6 +22302,154 @@ fn combinational_loop_review_preserves_expression_coercions() {
 }
 
 #[test]
+fn combinational_loop_review_preserves_assignment_pattern_positions() {
+    // Why these cases exist: IEEE 1800-2023 10.9.2 evaluates each structure
+    // constructor expression in the assignment context of its named member.
+    // A dependency supplying `b` must not be widened to the unrelated `a`.
+    for (name, constructor, expected) in [
+        (
+            "a structure constructor keeps an unrelated member loop-free",
+            "Pair'{a: 0, b: o}",
+            false,
+        ),
+        (
+            "a structure constructor retains corresponding-member feedback",
+            "Pair'{a: o, b: 0}",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    o: output logic,
+                ) {{
+                    struct Pair {{
+                        a: logic,
+                        b: logic,
+                    }}
+                    var pair: Pair;
+                    assign pair = {constructor};
+                    assign o = pair.a;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: IEEE 1800-2023 10.9.1 maps array-pattern
+    // expressions element by element. The module reads only element zero, so
+    // an actual dependency in element one is disjoint while element-zero
+    // feedback remains a real loop.
+    for (name, actual, expected) in [
+        (
+            "an array literal keeps an unrelated instance element loop-free",
+            "'{0, feedback}",
+            false,
+        ),
+        (
+            "an array literal retains corresponding-element feedback",
+            "'{feedback, 0}",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Pick (
+                    i: input  logic [2],
+                    o: output logic,
+                ) {{
+                    assign o = i[0];
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic;
+                    var passed  : logic;
+                    inst u: Pick (
+                        i: {actual},
+                        o: passed,
+                    );
+                    assign feedback = passed;
+                    assign o = passed;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: `default` and replication copy the same typed
+    // element value into every destination element. They retain bit-to-bit
+    // correspondence within each copy rather than becoming all-to-all.
+    for (name, actual, observed, feedback_bit, expected) in [
+        (
+            "an array default preserves corresponding bits in every element",
+            "'{default: value}",
+            "i[1][0]",
+            1,
+            false,
+        ),
+        (
+            "an array default retains same-bit feedback",
+            "'{default: value}",
+            "i[1][0]",
+            0,
+            true,
+        ),
+        (
+            "an array repeat preserves corresponding bits in every element",
+            "'{value repeat 2}",
+            "i[1][0]",
+            1,
+            false,
+        ),
+        (
+            "an array repeat retains same-bit feedback",
+            "'{value repeat 2}",
+            "i[1][0]",
+            0,
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Pick (
+                    i: input  logic<2> [2],
+                    o: output logic,
+                ) {{
+                    assign o = {observed};
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var value : logic<2>;
+                    var passed: logic;
+                    inst u: Pick (
+                        i: {actual},
+                        o: passed,
+                    );
+                    assign value[{feedback_bit}] = passed;
+                    assign value[{}] = 0;
+                    assign o = passed;
+                }}
+                "#,
+                1 - feedback_bit
+            ),
+            expected,
+        );
+    }
+}
+
+#[test]
 #[ignore = "captured third-review follow-up: correlated selectors need guarded regions"]
 fn combinational_loop_review_preserves_selector_correlation() {
     // Why these cases exist: bounded evaluation must preserve correlation

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10442,7 +10442,6 @@ fn combinational_loop_review_keeps_observer_function_side_effect() {
 }
 
 #[test]
-#[ignore = "known bug: an unused child input hides function side effects in its actual"]
 fn combinational_loop_review_keeps_instance_actual_function_side_effect() {
     // Why this case exists: IEEE 1800-2023 4.9.6 models an input connection as
     // an implicit continuous assignment. Its actual expression is evaluated

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13575,6 +13575,65 @@ fn combinational_loop_nonempty_runtime_form_loop_has_no_zero_trip_path() {
 }
 
 #[test]
+fn combinational_loop_empty_runtime_form_loop_has_no_body_path() {
+    // Why this case exists: `break` keeps this const-evaluable empty range in
+    // runtime-form IR, but its body is still unreachable. Treating "empty" as
+    // merely "possibly empty" invents both a write and a hard cycle.
+    let errors = analyze(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var a: logic;
+            var b: logic;
+            always_comb {
+                for _index in 1..1 {
+                    a = b;
+                    break;
+                }
+            }
+            assign b = a;
+            assign o = b;
+        }
+        "#,
+    );
+    assert!(
+        errors.iter().all(|error| !matches!(
+            error,
+            AnalyzerError::CombinationalLoop { .. } | AnalyzerError::UncoveredBranch { .. }
+        )),
+        "an empty loop has no reachable body assignment: {errors:#?}"
+    );
+}
+
+#[test]
+fn combinational_loop_break_before_write_retains_coverage() {
+    // Why this case exists: a const singleton loop is guaranteed to enter its
+    // body, but a conditional break can still bypass a later assignment. The
+    // missed write is a coverage error, not a zero-trip path or comb feedback.
+    assert_incomplete_assignment_without_comb_loop(
+        "a break before the first write leaves the output unassigned",
+        r#"
+        module Top (
+            stop: input  logic,
+            o   : output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for _index in 0..1 {
+                    if stop {
+                        break;
+                    }
+                    value = 1;
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
 fn combinational_loop_function_output_weak_write_retains_coverage() {
     // Why this case exists: a function output argument is copied back to its
     // caller, but a dynamic write inside the function still leaves unselected
@@ -13598,6 +13657,69 @@ fn combinational_loop_function_output_weak_write_retains_coverage() {
                 write_selected(index, value);
                 o = value[0];
             }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn combinational_loop_function_capture_coverage_obeys_caller_order() {
+    // Why this case exists: a function's module-scope write is part of its
+    // caller procedure. A dominating default or a later full write supplies
+    // every preserved bit, so function-local weak-write coverage must not be
+    // finalized before the caller MemorySSA reaches its exit.
+    for body in [
+        "value = 0; write_selected(index);",
+        "write_selected(index); value = 0;",
+    ] {
+        let errors = analyze(&format!(
+            r#"
+            module Top (
+                index: input  logic<2>,
+                o    : output logic,
+            ) {{
+                var value: logic<4>;
+                function write_selected (
+                    index: input logic<2>,
+                ) {{
+                    value[index] = 1;
+                }}
+                always_comb {{
+                    {body}
+                    o = value[0];
+                }}
+            }}
+            "#
+        ));
+        assert!(
+            errors
+                .iter()
+                .all(|error| !matches!(error, AnalyzerError::UncoveredBranch { .. })),
+            "caller ordering completely defines the captured value: {errors:#?}"
+        );
+    }
+}
+
+#[test]
+fn combinational_loop_uncalled_function_still_checks_output_coverage() {
+    // Why this case exists: output-argument completeness is a property of the
+    // function definition, not of whether an always_comb happens to call it.
+    // A runtime loop may execute zero times and leave the output unassigned.
+    assert_incomplete_assignment_without_comb_loop(
+        "an uncalled function still has to assign its output on every path",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function maybe_write (
+                n    : input  logic<32>,
+                value: output logic,
+            ) {
+                for _index in 0..n {
+                    value = 1;
+                }
+            }
+            assign o = 0;
         }
         "#,
     );

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -24703,6 +24703,7 @@ fn comb_loop_uses_structural_selector_regions() {
         );
     }
 }
+#[test]
 fn orphan_else_across_scopes() {
     // The ifdef/elsif/else attribute state persisted across attribute-group
     // lists and nesting levels, so an orphan #[else] chained to an #[ifdef]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9867,14 +9867,7 @@ fn combinational_loop_memory_ssa_retains_dynamic_region_uncertainty() {
     let post1 = Analyzer::analyze_post_pass1();
     assert!(post1.is_empty(), "{post1:?}");
     let pass2 = analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
-    // Why this assertion exists: a dynamic destination is a weak write, so
-    // the assignment pass must report its retained candidates even though the
-    // comb-loop pass keeps that uncertainty out of hard SCC diagnostics.
-    assert_eq!(pass2.len(), 1, "{pass2:?}");
-    assert!(
-        matches!(pass2[0], AnalyzerError::UncoveredBranch { .. }),
-        "{pass2:?}"
-    );
+    assert!(pass2.is_empty(), "{pass2:?}");
 
     let result = crate::comb_loop_detect::check_detailed(&ir);
     assert!(result.errors.is_empty(), "{:#?}", result.errors);
@@ -9884,6 +9877,23 @@ fn combinational_loop_memory_ssa_retains_dynamic_region_uncertainty() {
                 .reasons
                 .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)
     }));
+
+    // Why this assertion exists: the ordinary analyzer consumes coverage from
+    // the same post-pass MemorySSA run, while the detailed loop API keeps hard
+    // SCC diagnostics and incompleteness separate.
+    let diagnostics = analyze(code);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })),
+        "{diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|error| !matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "{diagnostics:?}"
+    );
 }
 
 fn assert_comb_loop_for_case(case: &str, code: &str, expected: bool) {
@@ -13549,8 +13559,8 @@ fn combinational_loop_nonempty_runtime_form_loop_has_no_zero_trip_path() {
         ) {
             var value: logic;
             always_comb {
-                for index in 0..1 {
-                    value = index[0];
+                for _index in 0..1 {
+                    value = 1;
                     break;
                 }
                 o = value;

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -12964,6 +12964,118 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
                 .contains(&veryl_causal::graph::IncompleteReason::InoutPort)
     }));
 
+    // Why this case exists: a dynamic selection inside a function must carry
+    // its unresolved region provenance through the function summary. Function
+    // lowering must not silently turn it into complete coverage.
+    let complex_function = detailed(
+        r#"
+        module Top (
+            i    : input  logic<4>,
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            function select (
+                x    : input logic<4>,
+                index: input logic<2>,
+            ) -> logic {
+                return x[index];
+            }
+            assign o = select(i, index);
+        }
+        "#,
+    );
+    assert!(
+        complex_function.errors.is_empty(),
+        "incomplete function coverage must not become a hard loop: {:#?}",
+        complex_function.errors
+    );
+    assert!(
+        complex_function.incomplete.iter().any(|module| {
+            module.module == "Top"
+                && module
+                    .reasons
+                    .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)
+        }),
+        "a function with a dynamic selection must retain incomplete provenance: {:#?}",
+        complex_function.incomplete
+    );
+
+    // Why this case exists: even a fully modeled expression on an SV input
+    // cannot prove feedthrough inside the external component. A feedback-like
+    // connection around that boundary stays incomplete rather than becoming a
+    // stronger-than-source hard loop.
+    let complex_external_actual = detailed(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function invert (x: input logic) -> logic {
+                return !x;
+            }
+            var feedback: logic;
+            inst u: $sv::Ext (
+                i_data: invert(invert(feedback)),
+                o_data: feedback,
+            );
+            assign o = feedback;
+        }
+        "#,
+    );
+    assert!(
+        complex_external_actual.errors.is_empty(),
+        "an opaque SV feedthrough must not become a hard loop: {:#?}",
+        complex_external_actual.errors
+    );
+    assert!(complex_external_actual.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
+    }));
+
+    // Why this case exists: incomplete coverage and a proven loop are
+    // independent facts. Keep the coverage provenance for detailed clients,
+    // while the analyzer's diagnostic result contains the proven loop.
+    let external_and_proven_loop_code = r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {
+            var from_sv: logic;
+            var a      : logic;
+            var b      : logic;
+            inst u: $sv::Ext (
+                i_data: i,
+                o_data: from_sv,
+            );
+            assign a = b;
+            assign b = a;
+            assign o = b | from_sv;
+        }
+        "#;
+    let external_and_proven_loop = detailed(external_and_proven_loop_code);
+    assert!(
+        external_and_proven_loop
+            .errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "a proven loop must remain the hard diagnostic: {:#?}",
+        external_and_proven_loop.errors
+    );
+    assert!(external_and_proven_loop.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
+    }));
+    let diagnostics = analyze(external_and_proven_loop_code);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "the ordinary analyzer must diagnose the proven loop: {diagnostics:#?}"
+    );
+
     let function_actual_loop = detailed(
         r#"
         module Child (

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9887,6 +9887,22 @@ fn assert_comb_loop_for_case(case: &str, code: &str, expected: bool) {
     assert_eq!(actual, expected, "{case}: {errors:?}");
 }
 
+fn assert_incomplete_assignment_without_comb_loop(case: &str, code: &str) {
+    let errors = analyze(code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })),
+        "{case}: retained entry state must be diagnosed as an incomplete assignment: {errors:#?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|error| !matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "{case}: state retention is not combinational feedback: {errors:#?}"
+    );
+}
+
 #[test]
 fn combinational_loop_review_preserves_longest_static_prefix() {
     // Why this case exists: IEEE 1800-2023 11.5.3 confines buff[0][idx]
@@ -13273,6 +13289,182 @@ fn combinational_loop_diagnostic_uses_exact_minimal_assignment_witness() {
         code.find("assign b = a;")
             .expect("short-cycle return assignment")
             + "assign ".len()
+    );
+}
+
+#[test]
+fn combinational_loop_runtime_zero_trip_retention_is_not_feedback() {
+    // Why this case exists: a runtime loop can execute zero times. The value
+    // retained on that path infers state, but it is not a same-evaluation read
+    // from `held` and therefore must not become a combinational self-loop.
+    assert_incomplete_assignment_without_comb_loop(
+        "a zero-trip runtime loop retains state rather than feeding back combinationally",
+        r#"
+        module Top (
+            n: input  logic<32>,
+            o: output logic,
+        ) {
+            var held: logic;
+            always_comb {
+                for index in 0..n {
+                    held = index[0];
+                }
+                o = held;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn combinational_loop_dynamic_element_retention_is_not_feedback() {
+    // Why this case exists: one dynamic element write leaves every other
+    // candidate element unchanged. May-write coverage must not masquerade as
+    // must-write coverage, and the preserved elements are latch state rather
+    // than a combinational self-read.
+    assert_incomplete_assignment_without_comb_loop(
+        "a dynamic element store leaves unselected elements unassigned",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            var held: logic [4];
+            always_comb {
+                held[index] = 1;
+                o = held[0];
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn combinational_loop_missing_if_arm_retention_is_not_feedback() {
+    // Why this case exists: the existing uncovered-branch checker already
+    // identifies this latch. The causal graph must not add a second and
+    // semantically incorrect combinational-loop diagnosis for the same
+    // unassigned path.
+    assert_incomplete_assignment_without_comb_loop(
+        "an if without an else infers a latch, not a combinational loop",
+        r#"
+        module Top (
+            enable: input  logic,
+            o     : output logic,
+        ) {
+            var held: logic;
+            always_comb {
+                if enable {
+                    held = 1;
+                }
+                o = held;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn combinational_loop_missing_switch_default_retention_is_not_feedback() {
+    // Why this case exists: n-way control flow reaches the same entry-state
+    // phi as an uncovered if. Missing-default retention must receive the same
+    // latch diagnosis without being reclassified as combinational feedback.
+    assert_incomplete_assignment_without_comb_loop(
+        "a switch without a default infers a latch, not a combinational loop",
+        r#"
+        module Top (
+            select: input  logic,
+            o     : output logic,
+        ) {
+            var held: logic;
+            always_comb {
+                switch {
+                    select: held = 1;
+                }
+                o = held;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn combinational_loop_latch_boundary_breaks_a_cross_variable_cycle() {
+    // Why this case exists: collapsing a latched variable's pre-state and
+    // next-state into one NodeKey invents the cycle held -> o -> enable ->
+    // held. A state boundary must cut that path even when the false SCC spans
+    // several source variables instead of appearing as a direct self-edge.
+    assert_incomplete_assignment_without_comb_loop(
+        "a retained variable is a state boundary inside a larger apparent SCC",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var enable: logic;
+            var held  : logic;
+            always_comb {
+                if enable {
+                    held = 0;
+                }
+                o = held;
+            }
+            assign enable = o;
+        }
+        "#,
+    );
+}
+
+#[test]
+fn combinational_loop_explicit_self_read_remains_feedback() {
+    // Why this case exists: removing entry-state retention edges wholesale
+    // would also hide a real source read. The fix must distinguish an implicit
+    // preserve path from the explicit `value = value` dependency.
+    let errors = analyze(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                value = value;
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "an explicit same-evaluation self-read remains combinational feedback: {errors:#?}"
+    );
+}
+
+#[test]
+fn combinational_loop_default_before_runtime_loop_kills_retention() {
+    // Why this case exists: a dominating full assignment removes the entry
+    // state before a possibly-zero-trip loop. This is the positive control for
+    // both coverage and loop analysis and must remain diagnostic-free.
+    let errors = analyze(
+        r#"
+        module Top (
+            n: input  logic<32>,
+            o: output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                value = 0;
+                for index in 0..n {
+                    value = index[0];
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors.is_empty(),
+        "a dominating default is complete: {errors:#?}"
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10526,6 +10526,38 @@ fn combinational_loop_review_keeps_instance_actual_function_side_effect() {
 }
 
 #[test]
+fn combinational_loop_review_keeps_instance_selector_function_side_effect() {
+    // Why this case exists: an otherwise plain instance actual still evaluates
+    // the expressions in its selectors. Skipping the observer for mem[touch(o)]
+    // would lose touch's module-scope write and hide the x -> o -> x cycle.
+    assert_comb_loop_for_case(
+        "an instance input selector retains a called function global write",
+        r#"
+        module Sink (
+            i: input logic,
+        ) {}
+        module Top (
+            mem: input  logic<2>,
+            o  : output logic,
+        ) {
+            var x: logic;
+            function touch (
+                a: input logic,
+            ) -> logic {
+                x = a;
+                return 0;
+            }
+            inst u: Sink (
+                i: mem[touch(o)],
+            );
+            assign o = x;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_review_preserves_vector_function_output_bits() {
     // Why this case exists: output argument y is a vector identity of x.
     // Broadcasting all x bits to all y bits invents value[1] -> o[0] feedback.
@@ -13694,6 +13726,35 @@ fn combinational_loop_runtime_form_cardinality_variants() {
 }
 
 #[test]
+fn combinational_loop_singleton_break_is_not_runtime_incomplete() {
+    // Why this case exists: break makes this const singleton use the compact
+    // runtime-form CFG, but there is no loop backedge and therefore no
+    // RuntimeLoop uncertainty to expose through check_detailed.
+    let detailed = analyze_comb_detailed(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for _index in 0..1 {
+                    value = 1;
+                    break;
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(detailed.errors.is_empty(), "{detailed:#?}");
+    assert!(detailed.incomplete.iter().all(|module| {
+        !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::RuntimeLoop)
+    }));
+}
+
+#[test]
 fn combinational_loop_finite_runtime_form_recurrence_is_not_feedback() {
     // Why this case exists: a conditional break keeps a finite const loop in
     // runtime-form IR. Its loop-carried value is a bounded combinational chain
@@ -13887,10 +13948,10 @@ fn combinational_loop_function_summary_fanout_is_memoized() {
 }
 
 #[test]
-fn combinational_loop_malformed_effect_keeps_proven_edges_in_same_procedure() {
-    // Why this case exists: one statement rejected during IR conversion makes
-    // the procedure incomplete, but must not discard an independent exact
-    // cycle lowered from the remaining statements in that same always_comb.
+fn combinational_loop_malformed_effect_is_a_causal_barrier() {
+    // Why this case exists: a rejected statement may have unknown side
+    // effects, so a cycle which crosses it is not proven. The malformed
+    // procedure must not suppress a separate exact cycle in another procedure.
     let errors = analyze(
         r#"
         module Top (
@@ -13898,20 +13959,31 @@ fn combinational_loop_malformed_effect_keeps_proven_edges_in_same_procedure() {
         ) {
             var a: logic;
             var b: logic;
+            var c: logic;
+            var d: logic;
             always_comb {
-                missing_function();
                 a = b;
+                missing_function();
                 b = a;
-                o = b;
+            }
+            always_comb {
+                c = d;
+                d = c;
+                o = d;
             }
         }
         "#,
     );
+    let loops = errors
+        .iter()
+        .filter_map(|error| match error {
+            AnalyzerError::CombinationalLoop { identifier, .. } => Some(identifier.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
     assert!(
-        errors
-            .iter()
-            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
-        "malformed uncertainty must not erase an independently proven loop: {errors:#?}"
+        loops.len() == 1 && matches!(loops[0], "c" | "d"),
+        "only the cycle independent of the malformed barrier is proven: {errors:#?}"
     );
 }
 
@@ -13958,6 +14030,87 @@ fn combinational_loop_branch_weak_writes_share_one_coverage_diagnostic() {
             .all(|error| !matches!(error, AnalyzerError::CombinationalLoop { .. })),
         "implicit preservation is not combinational feedback: {errors:#?}"
     );
+}
+
+#[test]
+fn combinational_loop_runtime_coverage_sites_stay_region_local() {
+    // Why this case exists: value[1] is fully defined even though it is also
+    // written in a runtime loop. Its loop assignment must not be reported as a
+    // covered site for the independently retained value[0].
+    let code = r#"
+        module Top (
+            n        : input  logic<32>,
+            condition: input  logic,
+            o        : output logic<2>,
+        ) {
+            var value: logic<2>;
+            always_comb {
+                value[1] = 0;
+                for _index in 0..n {
+                    value[1] = 1;
+                }
+                if condition {
+                    value[0] = 1;
+                }
+                o = value;
+            }
+        }
+    "#;
+    let errors = analyze(code);
+    let coverage = errors
+        .iter()
+        .filter_map(|error| match error {
+            AnalyzerError::UncoveredBranch {
+                error_locations, ..
+            } => Some(error_locations),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(coverage.len(), 1, "{errors:#?}");
+    assert_eq!(coverage[0].len(), 1, "{errors:#?}");
+}
+
+#[test]
+fn combinational_loop_captured_coverage_sites_stay_region_local() {
+    // Why this case exists: function summary coverage is mapped back into the
+    // caller one captured region at a time. A caller default for value[1] must
+    // prevent that bit's function assignment from appearing in value[0]'s
+    // remaining coverage diagnostic.
+    let code = r#"
+        module Top (
+            n: input  logic<32>,
+            o: output logic,
+        ) {
+            var value: logic<2>;
+            function write_bits (
+                n: input logic<32>,
+            ) {
+                for _index in 0..n {
+                    value[0] = 1;
+                }
+                for _index in 0..n {
+                    value[1] = 1;
+                }
+            }
+            always_comb {
+                value[1] = 0;
+                write_bits(n);
+                o = value[0];
+            }
+        }
+    "#;
+    let errors = analyze(code);
+    let coverage = errors
+        .iter()
+        .filter_map(|error| match error {
+            AnalyzerError::UncoveredBranch {
+                error_locations, ..
+            } => Some(error_locations),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(coverage.len(), 1, "{errors:#?}");
+    assert_eq!(coverage[0].len(), 1, "{errors:#?}");
 }
 
 #[test]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13208,6 +13208,75 @@ fn combinational_loop_incomplete_effect_does_not_erase_proven_edges() {
 }
 
 #[test]
+fn combinational_loop_diagnostic_uses_exact_minimal_assignment_witness() {
+    // Why this case exists: all four variables belong to one maximal SCC, and
+    // `a` has two reaching assignments in different branches. The actionable
+    // witness is the short a/b cycle; reporting a=d, c=b, or d=c would expose
+    // SCC membership rather than the actual cycle selected for this diagnostic.
+    let code = r#"
+    module Top (
+        select: input  logic,
+        o     : output logic,
+    ) {
+        var a: logic;
+        var b: logic;
+        var c: logic;
+        var d: logic;
+        always_comb {
+            if select {
+                a = b;
+            } else {
+                a = d;
+            }
+        }
+        assign b = a;
+        assign c = b;
+        assign d = c;
+        assign o = a;
+    }
+    "#;
+    let errors = analyze(code);
+    let loops = errors
+        .iter()
+        .filter(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(loops.len(), 1, "{errors:#?}");
+    let AnalyzerError::CombinationalLoop {
+        identifier,
+        input,
+        error_location,
+        loop_participants,
+        ..
+    } = loops[0]
+    else {
+        unreachable!()
+    };
+    assert_eq!(identifier, "a");
+    assert_eq!(loop_participants.len(), 1, "{errors:#?}");
+
+    let local_offset = |absolute: usize| {
+        let mut base = 0usize;
+        for source in &input.sources {
+            if absolute < base + source.text.len() {
+                return absolute - base;
+            }
+            base += source.text.len();
+        }
+        panic!("diagnostic offset {absolute} is outside its sources")
+    };
+    assert_eq!(
+        local_offset(error_location.offset()),
+        code.find("a = b;").expect("short-cycle assignment")
+    );
+    assert_eq!(
+        local_offset(loop_participants[0].offset()),
+        code.find("assign b = a;")
+            .expect("short-cycle return assignment")
+            + "assign ".len()
+    );
+}
+
+#[test]
 fn comb_loop_ifstmt_feed_forward_array() {
     // False positive: an always_comb for-loop over cross-coupled arrays that
     // reads index i and writes i+1 (a feed-forward / acyclic CORDIC-style

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9120,8 +9120,8 @@ fn unassignable_output() {
 #[test]
 fn combinational_loop_oversized_array_is_sparse_and_complete() {
     // Why this case exists: a sequential memory with a combinational read must
-    // remain loop-free, and its analysis cost must not scale with all 8M
-    // declared elements merely because both accesses use a dynamic index.
+    // remain loop-free even when its declared index space is too large for the
+    // analyzer's ordinary elaboration limit.
     let code = r#"
     module ModuleA (
         clk:  input  clock,
@@ -9868,7 +9868,6 @@ fn assert_comb_loop_for_case(case: &str, code: &str, expected: bool) {
 }
 
 #[test]
-#[ignore = "known bug: a dynamic suffix currently erases its longest static prefix"]
 fn combinational_loop_review_preserves_longest_static_prefix() {
     // Why this case exists: IEEE 1800-2023 11.5.3 confines buff[0][idx]
     // to the statically selected row. Aliasing it with buff[1] rejects legal,
@@ -10003,7 +10002,6 @@ fn combinational_loop_review_keeps_function_global_write() {
 }
 
 #[test]
-#[ignore = "known bug: dynamic output regions disappear from module summaries"]
 fn combinational_loop_review_keeps_dynamic_region_across_modules() {
     // Why this case exists: an instance port is a SystemVerilog data path, so
     // a child wildcard output must remain a wildcard through every summary.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13634,6 +13634,66 @@ fn combinational_loop_break_before_write_retains_coverage() {
 }
 
 #[test]
+fn combinational_loop_runtime_form_cardinality_variants() {
+    // Why this case exists: inclusive, reverse, and stepped ranges share the
+    // same source-level cardinality rules even when break prevents unrolling.
+    // Singleton bodies have an early-break coverage path; empty bodies have no
+    // reachable assignment or dependency at all.
+    for range in ["0..=0", "rev 0..1", "0..1 step += 2"] {
+        assert_incomplete_assignment_without_comb_loop(
+            "a singleton runtime-form range can break before its write",
+            &format!(
+                r#"
+                module Top (
+                    stop: input  logic,
+                    o   : output logic,
+                ) {{
+                    var value: logic;
+                    always_comb {{
+                        for _index in {range} {{
+                            if stop {{
+                                break;
+                            }}
+                            value = 1;
+                        }}
+                        o = value;
+                    }}
+                }}
+                "#
+            ),
+        );
+    }
+
+    for range in ["1..1", "rev 1..1", "1..1 step += 2"] {
+        let errors = analyze(&format!(
+            r#"
+            module Top (
+                o: output logic,
+            ) {{
+                var a: logic;
+                var b: logic;
+                always_comb {{
+                    for _index in {range} {{
+                        a = b;
+                        break;
+                    }}
+                }}
+                assign b = a;
+                assign o = b;
+            }}
+            "#
+        ));
+        assert!(
+            errors.iter().all(|error| !matches!(
+                error,
+                AnalyzerError::CombinationalLoop { .. } | AnalyzerError::UncoveredBranch { .. }
+            )),
+            "an empty {range} loop has no body path: {errors:#?}"
+        );
+    }
+}
+
+#[test]
 fn combinational_loop_function_output_weak_write_retains_coverage() {
     // Why this case exists: a function output argument is copied back to its
     // caller, but a dynamic write inside the function still leaves unselected
@@ -13701,6 +13761,33 @@ fn combinational_loop_function_capture_coverage_obeys_caller_order() {
 }
 
 #[test]
+fn combinational_loop_function_capture_without_default_retains_coverage() {
+    // Why this case exists: the caller-order kill controls above need a
+    // positive control. Without a caller default, a captured dynamic write
+    // still leaves unselected bits unassigned at the always_comb exit.
+    assert_incomplete_assignment_without_comb_loop(
+        "a captured weak write without a caller default remains incomplete",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            var value: logic<4>;
+            function write_selected (
+                index: input logic<2>,
+            ) {
+                value[index] = 1;
+            }
+            always_comb {
+                write_selected(index);
+                o = value[0];
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
 fn combinational_loop_uncalled_function_still_checks_output_coverage() {
     // Why this case exists: output-argument completeness is a property of the
     // function definition, not of whether an always_comb happens to call it.
@@ -13722,6 +13809,78 @@ fn combinational_loop_uncalled_function_still_checks_output_coverage() {
             assign o = 0;
         }
         "#,
+    );
+}
+
+#[test]
+fn combinational_loop_function_summary_fanout_is_memoized() {
+    // Why this case exists: each function calls the previous specialization
+    // twice, so per-call recursive analysis grows as 2^N. The source contains
+    // only N unique function bodies and must be analyzed in O(N) summaries.
+    let mut functions = String::from(
+        r#"
+        function f0 (
+            x: input logic,
+        ) -> logic {
+            return x;
+        }
+        "#,
+    );
+    for depth in 1..=14 {
+        functions.push_str(&format!(
+            r#"
+            function f{depth} (
+                x: input logic,
+            ) -> logic {{
+                return f{previous}(x) ^ f{previous}(x);
+            }}
+            "#,
+            previous = depth - 1,
+        ));
+    }
+    let errors = analyze(&format!(
+        r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {{
+            {functions}
+            assign o = f14(i);
+        }}
+        "#
+    ));
+    assert!(
+        errors.is_empty(),
+        "acyclic function fanout is valid: {errors:#?}"
+    );
+}
+
+#[test]
+fn combinational_loop_malformed_effect_keeps_proven_edges_in_same_procedure() {
+    // Why this case exists: one statement rejected during IR conversion makes
+    // the procedure incomplete, but must not discard an independent exact
+    // cycle lowered from the remaining statements in that same always_comb.
+    let errors = analyze(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var a: logic;
+            var b: logic;
+            always_comb {
+                missing_function();
+                a = b;
+                b = a;
+                o = b;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "malformed uncertainty must not erase an independently proven loop: {errors:#?}"
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10855,7 +10855,6 @@ fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
 }
 
 #[test]
-#[ignore = "captured independent-review regression: function actual shift loses bit positions"]
 fn combinational_loop_review_preserves_function_actual_shift_positions() {
     // Why this case exists: (value << 1)[0] is an inserted zero. Passing the
     // shifted vector through a function must not broadcast value[1] to o.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22133,7 +22133,6 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
 }
 
 #[test]
-#[ignore = "captured third-review regression: dynamic selectors discard bounded values"]
 fn combinational_loop_review_bounds_dynamic_selector_values() {
     // Why these cases exist: a two-state one-bit selector has exactly the
     // values {0,1}. Adding two therefore reaches only elements {2,3}; element

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9897,7 +9897,6 @@ fn combinational_loop_review_preserves_longest_static_prefix() {
 }
 
 #[test]
-#[ignore = "known bug: function summaries do not preserve module-scope reads"]
 fn combinational_loop_review_keeps_function_global_read() {
     // Why this case exists: IEEE 1800-2023 9.2.2.2.1 includes variables read
     // by a called function in always_comb. A global capture is not a formal
@@ -9922,10 +9921,33 @@ fn combinational_loop_review_keeps_function_global_read() {
         "#,
         true,
     );
+
+    // Why this control exists: a captured read alone is not feedback. Its
+    // source may be driven independently from an input without a return path.
+    assert_comb_loop_for_case(
+        "a captured function read remains feed-forward without a return path",
+        r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {
+            var x: logic;
+            function get_x () -> logic {
+                return x;
+            }
+            always_comb {
+                o = get_x();
+            }
+            always_comb {
+                x = i;
+            }
+        }
+        "#,
+        false,
+    );
 }
 
 #[test]
-#[ignore = "known bug: function summaries do not preserve module-scope writes"]
 fn combinational_loop_review_keeps_function_global_write() {
     // Why this case exists: IEEE 1800-2023 9.2.2.2 treats a variable written
     // by a called function as written by the always_comb process. Side effects
@@ -9951,6 +9973,32 @@ fn combinational_loop_review_keeps_function_global_write() {
         }
         "#,
         true,
+    );
+
+    // Why this control exists: a captured function write from an independent
+    // input is a normal feed-forward side effect, not a loop by itself.
+    assert_comb_loop_for_case(
+        "a captured function write remains feed-forward without a return path",
+        r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {
+            var x: logic;
+            function set_x (
+                a: input logic,
+            ) {
+                x = a;
+            }
+            always_comb {
+                set_x(i);
+            }
+            always_comb {
+                o = x;
+            }
+        }
+        "#,
+        false,
     );
 }
 
@@ -10028,7 +10076,6 @@ fn combinational_loop_review_drops_unreachable_statements_after_break() {
 }
 
 #[test]
-#[ignore = "known bug: vector function returns lose result-bit correspondence"]
 fn combinational_loop_review_preserves_vector_function_return_bits() {
     // Why this case exists: identity(value)[0] depends only on value[0].
     // Collapsing a vector return to an object-wide dependency invents the
@@ -10051,6 +10098,28 @@ fn combinational_loop_review_preserves_vector_function_return_bits() {
         }
         "#,
         false,
+    );
+
+    // Why this control exists: output bit zero corresponds to input bit zero
+    // through identity. Feeding that same bit back must remain a real loop.
+    assert_comb_loop_for_case(
+        "a vector function return retains same-bit feedback",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function identity (
+                x: input logic<2>,
+            ) -> logic<2> {
+                return x;
+            }
+            var value: logic<2>;
+            assign o = identity(value);
+            assign value[0] = o[0];
+            assign value[1] = 0;
+        }
+        "#,
+        true,
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10474,7 +10474,6 @@ fn combinational_loop_review_keeps_instance_actual_function_side_effect() {
 }
 
 #[test]
-#[ignore = "known bug: function output arguments discard aligned bit coordinates"]
 fn combinational_loop_review_preserves_vector_function_output_bits() {
     // Why this case exists: output argument y is a vector identity of x.
     // Broadcasting all x bits to all y bits invents value[1] -> o[0] feedback.
@@ -10503,7 +10502,6 @@ fn combinational_loop_review_preserves_vector_function_output_bits() {
 }
 
 #[test]
-#[ignore = "known bug: split function return dependencies fall back to all-to-all"]
 fn combinational_loop_review_preserves_split_function_return_bits() {
     // Why this case exists: {high, low}[0] is low. Returning o[0] to high is
     // acyclic when low is constant, even though the return uses two regions.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22205,8 +22205,7 @@ fn combinational_loop_review_bounds_dynamic_selector_values() {
 }
 
 #[test]
-#[ignore = "captured third-review follow-up: coercions and correlated selectors"]
-fn combinational_loop_review_preserves_coercions_and_selector_correlation() {
+fn combinational_loop_review_preserves_expression_coercions() {
     // Why these cases exist: both ternary operands are signed and four bits
     // wide after context sizing. Its high result bit depends only on the
     // two-bit value's sign bit, not on value[0].
@@ -22300,7 +22299,11 @@ fn combinational_loop_review_preserves_coercions_and_selector_correlation() {
             expected,
         );
     }
+}
 
+#[test]
+#[ignore = "captured third-review follow-up: correlated selectors need guarded regions"]
+fn combinational_loop_review_preserves_selector_correlation() {
     // Why these cases exist: bounded evaluation must preserve correlation
     // between a read and write selector. For one-bit two-state idx, idx and
     // ~idx are always distinct, while two identical selectors may alias.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -14134,6 +14134,32 @@ fn combinational_loop_function_summary_fanout_is_memoized() {
 }
 
 #[test]
+fn combinational_loop_rejected_periodic_run_is_scanned_once() {
+    // Why this case exists: a long run with one source but the same exact
+    // destination is legal sequential overwrite, not a periodic transfer.
+    // Rejecting the candidate must not sort every remaining suffix again.
+    let assignments = "a = i;\n".repeat(4096);
+    let errors = analyze(&format!(
+        r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {{
+            var a: logic;
+            always_comb {{
+                {assignments}
+            }}
+            assign o = a;
+        }}
+        "#
+    ));
+    assert!(
+        errors.is_empty(),
+        "repeated overwrite is valid: {errors:#?}"
+    );
+}
+
+#[test]
 fn combinational_loop_malformed_effect_is_a_causal_barrier() {
     // Why this case exists: a rejected statement may have unknown side
     // effects, so a cycle which crosses it is not proven. The malformed

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10558,6 +10558,40 @@ fn combinational_loop_review_keeps_instance_selector_function_side_effect() {
 }
 
 #[test]
+fn combinational_loop_review_keeps_instance_output_selector_function_side_effect() {
+    // Why this case exists: an output connection evaluates the selector in its
+    // destination. The observer must retain touch(o)'s module-scope write even
+    // though the child output value itself is constant.
+    assert_comb_loop_for_case(
+        "an instance output selector retains a called function global write",
+        r#"
+        module Source (
+            o: output logic,
+        ) {
+            assign o = 0;
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var bus: logic<2>;
+            var x  : logic;
+            function touch (
+                a: input logic,
+            ) -> logic {
+                x = a;
+                return 0;
+            }
+            inst u: Source (
+                o: bus[touch(o)],
+            );
+            assign o = x;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_review_preserves_vector_function_output_bits() {
     // Why this case exists: output argument y is a vector identity of x.
     // Broadcasting all x bits to all y bits invents value[1] -> o[0] feedback.
@@ -13671,7 +13705,7 @@ fn combinational_loop_runtime_form_cardinality_variants() {
     // same source-level cardinality rules even when break prevents unrolling.
     // Singleton bodies have an early-break coverage path; empty bodies have no
     // reachable assignment or dependency at all.
-    for range in ["0..=0", "rev 0..1", "0..1 step += 2"] {
+    for range in ["0..=0", "rev 0..1", "1..2 step *= 2"] {
         assert_incomplete_assignment_without_comb_loop(
             "a singleton runtime-form range can break before its write",
             &format!(
@@ -13696,7 +13730,7 @@ fn combinational_loop_runtime_form_cardinality_variants() {
         );
     }
 
-    for range in ["1..1", "rev 1..1", "1..1 step += 2"] {
+    for range in ["1..1", "rev 1..1", "2..2 step *= 2"] {
         let errors = analyze(&format!(
             r#"
             module Top (
@@ -13723,6 +13757,69 @@ fn combinational_loop_runtime_form_cardinality_variants() {
             "an empty {range} loop has no body path: {errors:#?}"
         );
     }
+}
+
+#[test]
+fn combinational_loop_runtime_form_iterator_constants_prune_dead_edges() {
+    // Why this case exists: break keeps the singleton loop in runtime-form IR,
+    // but its sole iterator value is still the constant 1. The unreachable
+    // i==0 assignment must not create a stronger-than-SV a -> b -> a loop.
+    assert_comb_loop_for_case(
+        "a runtime-form singleton retains its iterator constant",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var a: logic;
+            var b: logic;
+            always_comb {
+                for i in 1..2 {
+                    if i == 0 {
+                        a = b;
+                    } else {
+                        a = 0;
+                    }
+                    break;
+                }
+            }
+            assign b = a;
+            assign o = b;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+fn combinational_loop_runtime_form_iterator_constants_preserve_must_write() {
+    // Why this case exists: the two const iterations are i=0 and i=1, and the
+    // only reachable break follows the i=1 assignment. Every exit is covered;
+    // collapsing both iterations into one unknown body invents retention.
+    let errors = analyze(
+        r#"
+        module Top (
+            stop: input  logic,
+            o   : output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for i in 0..2 {
+                    if i == 1 {
+                        value = 1;
+                    }
+                    if i == 1 && stop {
+                        break;
+                    }
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors.is_empty(),
+        "all finite-loop exits assign value: {errors:#?}"
+    );
 }
 
 #[test]
@@ -13786,6 +13883,34 @@ fn combinational_loop_finite_runtime_form_recurrence_is_not_feedback() {
 }
 
 #[test]
+fn combinational_loop_finite_runtime_form_explicit_self_read_is_feedback() {
+    // Why this case exists: bounded lowering must remove only loop-carried
+    // pseudo-feedback. Without a dominating seed, the first iteration's
+    // explicit value read still forms real combinational self-feedback.
+    assert_comb_loop_for_case(
+        "a finite runtime-form loop retains its first explicit self-read",
+        r#"
+        module Top (
+            stop: input  logic,
+            o   : output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for _index in 0..2 {
+                    value = !value;
+                    if stop {
+                        break;
+                    }
+                }
+                o = value;
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_function_output_weak_write_retains_coverage() {
     // Why this case exists: a function output argument is copied back to its
     // caller, but a dynamic write inside the function still leaves unselected
@@ -13843,12 +13968,7 @@ fn combinational_loop_function_capture_coverage_obeys_caller_order() {
             }}
             "#
         ));
-        assert!(
-            errors
-                .iter()
-                .all(|error| !matches!(error, AnalyzerError::UncoveredBranch { .. })),
-            "caller ordering completely defines the captured value: {errors:#?}"
-        );
+        assert!(errors.is_empty(), "caller ordering is valid: {errors:#?}");
     }
 }
 
@@ -14033,6 +14153,40 @@ fn combinational_loop_branch_weak_writes_share_one_coverage_diagnostic() {
 }
 
 #[test]
+fn combinational_loop_dynamic_runtime_coverage_is_not_duplicated() {
+    // Why this case exists: both legacy branch bookkeeping and MemorySSA can
+    // observe the missing path inside a dynamic loop. Coverage ownership must
+    // produce one warning rather than appending the same warning twice.
+    let errors = analyze(
+        r#"
+        module Top (
+            n        : input  logic<32>,
+            condition: input  logic,
+            o        : output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                for _index in 0..n {
+                    if condition {
+                        value = 1;
+                    }
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+            .count(),
+        1,
+        "dynamic-loop coverage must be reported once: {errors:#?}"
+    );
+}
+
+#[test]
 fn combinational_loop_runtime_coverage_sites_stay_region_local() {
     // Why this case exists: value[1] is fully defined even though it is also
     // written in a runtime loop. Its loop assignment must not be reported as a
@@ -14068,6 +14222,10 @@ fn combinational_loop_runtime_coverage_sites_stay_region_local() {
         .collect::<Vec<_>>();
     assert_eq!(coverage.len(), 1, "{errors:#?}");
     assert_eq!(coverage[0].len(), 1, "{errors:#?}");
+    assert_eq!(
+        coverage[0][0].offset(),
+        code.find("value[0] = 1").expect("retained bit assignment")
+    );
 }
 
 #[test]
@@ -14111,6 +14269,11 @@ fn combinational_loop_captured_coverage_sites_stay_region_local() {
         .collect::<Vec<_>>();
     assert_eq!(coverage.len(), 1, "{errors:#?}");
     assert_eq!(coverage[0].len(), 1, "{errors:#?}");
+    assert_eq!(
+        coverage[0][0].offset(),
+        code.find("value[0] = 1")
+            .expect("retained capture assignment")
+    );
 }
 
 #[test]
@@ -14254,13 +14417,6 @@ fn uncovered_branch() {
     "#;
 
     let errors = analyze(code);
-    // Why this assertion exists: legacy branch bookkeeping and MemorySSA both
-    // observe this latch, but the analyzer must expose one diagnostic.
-    assert_eq!(
-        errors.len(),
-        1,
-        "coverage must not be reported twice: {errors:#?}"
-    );
     assert!(matches!(errors[0], AnalyzerError::UncoveredBranch { .. }));
 
     let code = r#"

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22203,3 +22203,134 @@ fn combinational_loop_review_bounds_dynamic_selector_values() {
         );
     }
 }
+
+#[test]
+#[ignore = "captured third-review follow-up: coercions and correlated selectors"]
+fn combinational_loop_review_preserves_coercions_and_selector_correlation() {
+    // Why these cases exist: both ternary operands are signed and four bits
+    // wide after context sizing. Its high result bit depends only on the
+    // two-bit value's sign bit, not on value[0].
+    for (name, target, expected) in [
+        (
+            "a signed ternary high bit is disjoint from a non-sign bit",
+            0,
+            false,
+        ),
+        (
+            "a signed ternary high bit retains its sign-bit dependency",
+            1,
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    sel: input  logic,
+                    o  : output logic<4>,
+                ) {{
+                    var value: logic<2>;
+                    assign o = if sel ? $signed(value) : 4'sb0;
+                    assign value[{target}] = o[3];
+                    assign value[{}] = 0;
+                }}
+                "#,
+                1 - target
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: numeric casts truncate or zero-extend at their
+    // declared width, and mixed-width bitwise operands are coerced to their
+    // common expression width before applying the operator.
+    for (name, expression, feedback, expected) in [
+        (
+            "a widening cast zero-fills its high bits",
+            "value as 4",
+            "o[3]",
+            false,
+        ),
+        (
+            "a widening cast retains its low bits",
+            "value as 4",
+            "o[0]",
+            true,
+        ),
+        (
+            "a narrowing cast discards its high source bits",
+            "value as 2",
+            "o[3]",
+            false,
+        ),
+        (
+            "a narrowing cast retains its low source bits",
+            "value as 2",
+            "o[0]",
+            true,
+        ),
+        (
+            "mixed-width bitwise zero-fills a short unsigned operand",
+            "value | 4'b0",
+            "o[3]",
+            false,
+        ),
+        (
+            "mixed-width bitwise retains a corresponding short operand bit",
+            "value | 4'b0",
+            "o[0]",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    o: output logic<4>,
+                ) {{
+                    var value: logic<2>;
+                    assign o = {expression};
+                    assign value[0] = {feedback};
+                    assign value[1] = 0;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: bounded evaluation must preserve correlation
+    // between a read and write selector. For one-bit two-state idx, idx and
+    // ~idx are always distinct, while two identical selectors may alias.
+    for (name, write_index, expected) in [
+        (
+            "complementary selectors cannot address the same bit",
+            "~idx",
+            false,
+        ),
+        (
+            "identical selectors retain a possible same-bit cycle",
+            "idx",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    idx: input  bit,
+                    o  : output logic,
+                ) {{
+                    var value: logic<2>;
+                    assign o = value[idx];
+                    assign value[{write_index}] = o;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+}

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -24052,6 +24052,33 @@ fn combinational_loop_periodic_repeat_is_sparse_and_phase_precise() {
 }
 
 #[test]
+fn combinational_loop_nested_repeat_is_sparse_and_phase_precise() {
+    // Why these cases exist: nested array repeats are one Cartesian transfer,
+    // not one inner summary per outer element. Both axes must survive IR
+    // lowering while preserving the selected packed bit.
+    for (output_bit, expected) in [(0, true), (1, false)] {
+        assert_comb_loop_for_case(
+            "nested periodic axes retain only their matching packed phase",
+            &format!(
+                r#"
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic<2>;
+                    var passed  : logic<2> [100, 20];
+                    assign passed = '{{'{{feedback repeat 20}} repeat 100}};
+                    assign feedback[0] = passed[78][12][{output_bit}];
+                    assign feedback[1] = 0;
+                    assign o = passed[0][0][0];
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+}
+
+#[test]
 fn combinational_loop_review_uses_structural_selector_overlap() {
     // Why these cases exist: structural feedback compares each access's
     // independently possible region. Both `idx` and `~idx` can address

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10797,7 +10797,6 @@ fn combinational_loop_review_distinguishes_generic_module_specializations() {
 }
 
 #[test]
-#[ignore = "captured independent-review regression: constant ternary evaluates dead side effects"]
 fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
     // Why this case exists: IEEE 1800-2023 11.4.11 evaluates only the selected
     // ternary branch. touch(o) is in the constant-dead branch, so it cannot

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10723,7 +10723,6 @@ fn combinational_loop_review_preserves_instance_repeat_positions() {
 }
 
 #[test]
-#[ignore = "captured independent-review regression: generic module summaries ignore specialization"]
 fn combinational_loop_review_distinguishes_generic_module_specializations() {
     // Why this case exists: ENABLE: 1 elaborates Child into an identity even
     // though its declaration default is zero. Reusing the default summary for

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10993,6 +10993,77 @@ fn comb_loop_distinguishes_generic_module_specializations() {
 }
 
 #[test]
+fn comb_loop_analyzes_each_instantiated_generic_specialization() {
+    // Why this case exists: seeing one concrete child may suppress the
+    // redundant source-template pass, but it must not suppress a different
+    // concrete specialization. The disabled instance is intentionally first;
+    // the enabled instance still closes a real parent feedback path.
+    assert_comb_loop(
+        "each concrete generic-module specialization receives its own summary",
+        r#"
+        module Child #(
+            param ENABLE: u32 = 0,
+        )(
+            i: input  logic,
+            o: output logic,
+        ) {
+            if ENABLE :g_enabled {
+                assign o = i;
+            } else {
+                assign o = 0;
+            }
+        }
+        module Top (
+            o: output logic<2>,
+        ) {
+            var feedback: logic<2>;
+            var passed  : logic<2>;
+            inst disabled: Child #(
+                ENABLE: 0,
+            )(
+                i: feedback[0],
+                o: passed[0],
+            );
+            inst enabled: Child #(
+                ENABLE: 1,
+            )(
+                i: feedback[1],
+                o: passed[1],
+            );
+            assign feedback = passed;
+            assign o = feedback;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+fn comb_loop_analyzes_uninstantiated_modules() {
+    // Why this case exists: roots are analyzed first to reuse child summaries,
+    // but an uninstantiated source module is itself a root. Its internal loop
+    // remains an error even when another unrelated root is also present.
+    assert_comb_loop(
+        "an uninstantiated module retains its internal loop diagnostic",
+        r#"
+        module Uninstantiated (
+            x: output logic,
+            y: output logic,
+        ) {
+            assign x = y;
+            assign y = x;
+        }
+        module Top (
+            o: output logic,
+        ) {
+            assign o = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn comb_loop_short_circuits_instance_actual_side_effects() {
     // Why this case exists: IEEE 1800-2023 11.4.11 evaluates only the selected
     // ternary branch. touch(o) is in the constant-dead branch, so it cannot
@@ -13413,10 +13484,11 @@ fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
 
 #[test]
 fn comb_loop_child_definition_has_one_diagnostic_across_instances() {
-    // Why this case exists: a child graph is checked once as a declaration and
-    // again while each parent specialization requests its causal summary. An
-    // internal loop belongs to the child source definition, so repeated
-    // instantiation must not repeat the same source diagnostic.
+    // Why this case exists: parent-first analysis checks a concrete child and
+    // derives its causal summary in one graph build. Repeated instances must
+    // reuse that result, while the child's port-independent internal loop is
+    // still diagnosed exactly once rather than being lost with the standalone
+    // source-template pass.
     let detailed = analyze_comb_detailed(
         r#"
         module Child (

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10855,7 +10855,6 @@ fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
 }
 
 #[test]
-#[ignore = "captured final-review regression: logical operators evaluate dead RHS effects"]
 fn combinational_loop_review_short_circuits_logical_rhs_side_effects() {
     let case = |name: &str, expression: &str, expected: bool| {
         assert_comb_loop_for_case(

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9118,12 +9118,10 @@ fn unassignable_output() {
 }
 
 #[test]
-fn combinational_loop_oversized_array_underdetect() {
-    // Regression: a dynamic-index write to a very large array. The dynamic
-    // index makes `compute_assign_target` yield arr_idx = None, which routes
-    // through `comb_loop_detect`'s per-element expansion — O(elements) and a
-    // hang without the `OVERSIZED_ARRAY` guard. Analysis must finish and report
-    // no combinational loop.
+fn combinational_loop_oversized_array_is_sparse_and_complete() {
+    // Why this case exists: a sequential memory with a combinational read must
+    // remain loop-free, and its analysis cost must not scale with all 8M
+    // declared elements merely because both accesses use a dynamic index.
     let code = r#"
     module ModuleA (
         clk:  input  clock,
@@ -9152,6 +9150,76 @@ fn combinational_loop_oversized_array_underdetect() {
             .iter()
             .any(|e| matches!(e, AnalyzerError::CombinationalLoop { .. })),
         "oversized dynamic-index array must not be flagged as a comb loop",
+    );
+
+    // Why this case exists: the former size guard silently discarded every
+    // edge for arrays above 64K elements. A dynamic write can alias the exact
+    // element it reads, so the same sparse object-level analysis must still
+    // prove this real feedback path without enumerating 128K elements.
+    let code = r#"
+    module ModuleA (
+        idx: input  logic<17>,
+        rd:  output logic<32>,
+    ) {
+        var mem: logic<32> [131072];
+        always_comb {
+            mem[idx] = mem[0];
+            rd = mem[idx];
+        }
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "oversized arrays must retain proven dynamic/exact alias loops: {errors:#?}",
+    );
+
+    // Why this case exists: object-level aliasing must not invent a cycle when
+    // the dynamic store is fed only by an external input.
+    let code = r#"
+    module ModuleA (
+        idx: input  logic<17>,
+        wd:  input  logic<32>,
+        rd:  output logic<32>,
+    ) {
+        var mem: logic<32> [131072];
+        always_comb {
+            mem[idx] = wd;
+            rd = mem[idx];
+        }
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "oversized feed-forward dynamic stores must remain loop-free: {errors:#?}",
+    );
+
+    // Why this case exists: a dynamic read makes an object uncertain but does
+    // not turn a separate exact write into a dynamic write. Conflating the two
+    // would alias mem[1] back onto mem[0] and invent a self-loop.
+    let code = r#"
+    module ModuleA (
+        idx: input  logic<17>,
+        rd:  output logic<32>,
+    ) {
+        var mem: logic<32> [131072];
+        always_comb {
+            rd = mem[idx];
+            mem[1] = mem[0];
+        }
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "a dynamic read must not broaden an exact write: {errors:#?}",
     );
 }
 

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22003,7 +22003,6 @@ module M {
 }
 
 #[test]
-#[ignore = "captured third-review regression: context width loses extension positions"]
 fn combinational_loop_review_preserves_context_width_extension_positions() {
     // Why these cases exist: IEEE 1800-2023 11.8.2 zero-extends an unsigned
     // two-bit RHS to its four-bit assignment context. The new high bits are

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -11298,7 +11298,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
                 .contains(&veryl_causal::graph::IncompleteReason::InoutPort)
     }));
 
-    let unsupported_actual = detailed(
+    let function_actual_loop = detailed(
         r#"
         module Child (
             i: input  logic,
@@ -11323,16 +11323,93 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
         "#,
     );
     assert!(
-        unsupported_actual.errors.is_empty(),
-        "{:#?}",
-        unsupported_actual.errors
+        function_actual_loop
+            .errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "a function-call actual must not hide a proven child feedthrough loop: {:#?}",
+        function_actual_loop.errors
     );
-    assert!(unsupported_actual.incomplete.iter().any(|module| {
-        module.module == "Top"
-            && module
+    assert!(
+        function_actual_loop.incomplete.iter().all(|module| !module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::MalformedModel)),
+        "a legal function-call actual is not an unsupported causal model: {:#?}",
+        function_actual_loop.incomplete
+    );
+
+    let ignored_function_argument = detailed(
+        r#"
+        module Child (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            function constant_zero (ignored: input logic) -> logic {
+                return 0;
+            }
+            var feedback: logic;
+            inst u: Child (
+                i: constant_zero(feedback),
+                o: feedback,
+            );
+            assign o = feedback;
+        }
+        "#,
+    );
+    assert!(
+        ignored_function_argument.errors.is_empty(),
+        "an unused function argument must not create a stronger-than-source dependency: {:#?}",
+        ignored_function_argument.errors
+    );
+    assert!(
+        ignored_function_argument
+            .incomplete
+            .iter()
+            .all(|module| !module
                 .reasons
-                .contains(&veryl_causal::graph::IncompleteReason::UnsupportedSyntax)
-    }));
+                .contains(&veryl_causal::graph::IncompleteReason::MalformedModel)),
+        "a legal constant-returning function is fully modeled: {:#?}",
+        ignored_function_argument.incomplete
+    );
+}
+
+#[test]
+fn combinational_loop_incomplete_effect_does_not_erase_proven_edges() {
+    // A loop construct carries explicit coverage provenance until break and
+    // runtime iteration semantics are modeled completely. That uncertainty
+    // must not discard an independent, exact dependency from the same block.
+    let result = analyze(
+        r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {
+            var scratch: logic [1];
+            var a: logic;
+            var b: logic;
+            always_comb {
+                for index in 0..1 {
+                    scratch[index] = i;
+                }
+                a = b;
+                b = a;
+                o = b;
+            }
+        }
+        "#,
+    );
+    assert!(
+        result
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "an incomplete effect must not hide an unrelated proven loop: {result:#?}"
+    );
 }
 
 #[test]

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22745,3 +22745,91 @@ fn combinational_loop_review_maps_instance_actual_function_captures() {
         );
     }
 }
+
+#[test]
+fn combinational_loop_review_preserves_sparse_selector_regions() {
+    // Why these cases exist: for a one-bit two-state selector, `idx * 2` has
+    // the independently provable non-contiguous candidate set {0,2}. Element
+    // one is unreachable, while feedback into element two is a real loop.
+    for (name, target, expected) in [
+        (
+            "a non-contiguous selector excludes an unreachable array element",
+            1,
+            false,
+        ),
+        (
+            "a non-contiguous selector retains a reachable array element",
+            2,
+            true,
+        ),
+    ] {
+        let clears = (0..3)
+            .filter(|index| *index != target)
+            .map(|index| format!("assign mem[{index}] = 0;"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Top (
+                    idx: input  bit,
+                    o  : output logic,
+                ) {{
+                    var mem: logic [3];
+                    assign o = mem[idx * 2];
+                    assign mem[{target}] = o;
+                    {clears}
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
+    // Why these cases exist: an unpacked formal span is packed_width times
+    // element_count. Applying a non-position-preserving operator to element
+    // one must not make an instance actual's element zero overlap it.
+    for (name, target, expected) in [
+        (
+            "an unaligned unpacked instance input keeps element zero disjoint",
+            0,
+            false,
+        ),
+        (
+            "an unaligned unpacked instance input retains element one feedback",
+            1,
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Child (
+                    i: input  logic [2],
+                    o: output logic,
+                ) {{
+                    assign o = !i[1];
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var value : logic [2];
+                    var passed: logic;
+                    inst u: Child (
+                        i: value,
+                        o: passed,
+                    );
+                    assign value[{target}] = passed;
+                    assign value[{}] = 0;
+                    assign o = passed;
+                }}
+                "#,
+                1 - target
+            ),
+            expected,
+        );
+    }
+}

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10993,77 +10993,6 @@ fn comb_loop_distinguishes_generic_module_specializations() {
 }
 
 #[test]
-fn comb_loop_analyzes_each_instantiated_generic_specialization() {
-    // Why this case exists: seeing one concrete child may suppress the
-    // redundant source-template pass, but it must not suppress a different
-    // concrete specialization. The disabled instance is intentionally first;
-    // the enabled instance still closes a real parent feedback path.
-    assert_comb_loop(
-        "each concrete generic-module specialization receives its own summary",
-        r#"
-        module Child #(
-            param ENABLE: u32 = 0,
-        )(
-            i: input  logic,
-            o: output logic,
-        ) {
-            if ENABLE :g_enabled {
-                assign o = i;
-            } else {
-                assign o = 0;
-            }
-        }
-        module Top (
-            o: output logic<2>,
-        ) {
-            var feedback: logic<2>;
-            var passed  : logic<2>;
-            inst disabled: Child #(
-                ENABLE: 0,
-            )(
-                i: feedback[0],
-                o: passed[0],
-            );
-            inst enabled: Child #(
-                ENABLE: 1,
-            )(
-                i: feedback[1],
-                o: passed[1],
-            );
-            assign feedback = passed;
-            assign o = feedback;
-        }
-        "#,
-        true,
-    );
-}
-
-#[test]
-fn comb_loop_analyzes_uninstantiated_modules() {
-    // Why this case exists: roots are analyzed first to reuse child summaries,
-    // but an uninstantiated source module is itself a root. Its internal loop
-    // remains an error even when another unrelated root is also present.
-    assert_comb_loop(
-        "an uninstantiated module retains its internal loop diagnostic",
-        r#"
-        module Uninstantiated (
-            x: output logic,
-            y: output logic,
-        ) {
-            assign x = y;
-            assign y = x;
-        }
-        module Top (
-            o: output logic,
-        ) {
-            assign o = 0;
-        }
-        "#,
-        true,
-    );
-}
-
-#[test]
 fn comb_loop_short_circuits_instance_actual_side_effects() {
     // Why this case exists: IEEE 1800-2023 11.4.11 evaluates only the selected
     // ternary branch. touch(o) is in the constant-dead branch, so it cannot
@@ -13484,11 +13413,10 @@ fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
 
 #[test]
 fn comb_loop_child_definition_has_one_diagnostic_across_instances() {
-    // Why this case exists: parent-first analysis checks a concrete child and
-    // derives its causal summary in one graph build. Repeated instances must
-    // reuse that result, while the child's port-independent internal loop is
-    // still diagnosed exactly once rather than being lost with the standalone
-    // source-template pass.
+    // Why this case exists: a child graph is checked once as a declaration and
+    // again while each parent specialization requests its causal summary. An
+    // internal loop belongs to the child source definition, so repeated
+    // instantiation must not repeat the same source diagnostic.
     let detailed = analyze_comb_detailed(
         r#"
         module Child (

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13412,6 +13412,83 @@ fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
 }
 
 #[test]
+fn comb_loop_child_definition_has_one_diagnostic_across_instances() {
+    // Why this case exists: a child graph is checked once as a declaration and
+    // again while each parent specialization requests its causal summary. An
+    // internal loop belongs to the child source definition, so repeated
+    // instantiation must not repeat the same source diagnostic.
+    let detailed = analyze_comb_detailed(
+        r#"
+        module Child (
+            x: output logic,
+            y: output logic,
+        ) {
+            assign x = y;
+            assign y = x;
+        }
+
+        module Top (
+            x0: output logic,
+            y0: output logic,
+            x1: output logic,
+            y1: output logic,
+        ) {
+            inst u0: Child (x: x0, y: y0);
+            inst u1: Child (x: x1, y: y1);
+        }
+        "#,
+    );
+    let loop_count = detailed
+        .errors
+        .iter()
+        .filter(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }))
+        .count();
+    assert_eq!(loop_count, 1, "{detailed:#?}");
+}
+
+#[test]
+fn comb_loop_distinct_child_definitions_keep_distinct_diagnostics() {
+    // Why this case exists: diagnostic deduplication is source-backed, not a
+    // name- or shape-based approximation. Two definitions with the same port
+    // names and loop structure remain two actionable source diagnostics.
+    let detailed = analyze_comb_detailed(
+        r#"
+        module ChildA (
+            x: output logic,
+            y: output logic,
+        ) {
+            assign x = y;
+            assign y = x;
+        }
+
+        module ChildB (
+            x: output logic,
+            y: output logic,
+        ) {
+            assign x = y;
+            assign y = x;
+        }
+
+        module Top (
+            ax: output logic,
+            ay: output logic,
+            bx: output logic,
+            by: output logic,
+        ) {
+            inst a: ChildA (x: ax, y: ay);
+            inst b: ChildB (x: bx, y: by);
+        }
+        "#,
+    );
+    let loop_count = detailed
+        .errors
+        .iter()
+        .filter(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }))
+        .count();
+    assert_eq!(loop_count, 2, "{detailed:#?}");
+}
+
+#[test]
 fn comb_loop_diagnostic_uses_short_assignment_cycle_witness() {
     // Why this case exists: all four variables belong to one maximal SCC, and
     // `a` has two reaching assignments in different branches. The actionable

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13791,6 +13791,72 @@ fn combinational_loop_runtime_form_iterator_constants_prune_dead_edges() {
 }
 
 #[test]
+fn combinational_loop_runtime_form_iterator_constants_prune_dead_case_arms() {
+    // Why this case exists: case selection uses the same per-iteration SV
+    // value as if selection. A dead i==0 arm in a singleton i==1 loop cannot
+    // contribute a hard dependency merely because break prevented frontend
+    // unrolling.
+    assert_comb_loop_for_case(
+        "a runtime-form singleton prunes dead case arms",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var a: logic;
+            var b: logic;
+            always_comb {
+                for i in 1..2 {
+                    case i {
+                        0      : a = b;
+                        default: a = 0;
+                    }
+                    break;
+                }
+            }
+            assign b = a;
+            assign o = b;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+fn combinational_loop_over_limit_const_loop_does_not_prove_dead_edges() {
+    // Why this case exists: the same const iterator semantics apply above the
+    // compiler's expansion limit. If exact bounded lowering is deliberately
+    // skipped, its approximation is incomplete and cannot become a hard loop.
+    let detailed = analyze_comb_detailed(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var a: logic;
+            var b: logic;
+            always_comb {
+                for i in 1..2000000 {
+                    if i == 0 {
+                        a = b;
+                    } else {
+                        a = 0;
+                    }
+                    break;
+                }
+            }
+            assign b = a;
+            assign o = b;
+        }
+        "#,
+    );
+    assert!(detailed.errors.is_empty(), "{detailed:#?}");
+    assert!(detailed.incomplete.iter().any(|module| {
+        module
+            .reasons
+            .contains(&veryl_causal::graph::IncompleteReason::RuntimeLoop)
+    }));
+}
+
+#[test]
 fn combinational_loop_runtime_form_iterator_constants_preserve_must_write() {
     // Why this case exists: the two const iterations are i=0 and i=1, and the
     // only reachable break follows the i=1 assignment. Every exit is covered;
@@ -14417,9 +14483,11 @@ fn uncovered_branch() {
     "#;
 
     let errors = analyze(code);
-    assert!(errors
-        .iter()
-        .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })));
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+    );
 
     let code = r#"
     module ModuleA {
@@ -14440,9 +14508,11 @@ fn uncovered_branch() {
     "#;
 
     let errors = analyze(code);
-    assert!(errors
-        .iter()
-        .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })));
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+    );
 
     let code = r#"
     module ModuleA {
@@ -14463,9 +14533,11 @@ fn uncovered_branch() {
     // after existing assignment diagnostics, and their relative order is not
     // part of the analyzer contract.
     let errors = analyze(code);
-    assert!(errors
-        .iter()
-        .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })));
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+    );
 
     let code = r#"
     module ModuleA {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -11187,6 +11187,55 @@ fn combinational_loop_review_preserves_unpacked_port_element_positions() {
 }
 
 #[test]
+#[ignore = "captured final-review regression: unpacked function actual collapses elements"]
+fn combinational_loop_review_preserves_unpacked_function_actual_positions() {
+    // Why this case exists: high reads only unpacked element one. Feeding its
+    // result to value[0] is element-disjoint and must not fall back to reading
+    // the whole actual because packed width excludes the unpacked count.
+    assert_comb_loop_for_case(
+        "an unpacked function actual keeps disjoint elements loop-free",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function high (
+                x: input logic [2],
+            ) -> logic {
+                return x[1];
+            }
+            var value: logic [2];
+            assign o = high(value);
+            assign value[0] = o;
+            assign value[1] = 0;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: returning the function result to the same
+    // value[1] element closes the real function-boundary loop.
+    assert_comb_loop_for_case(
+        "an unpacked function actual detects same-element feedback",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function high (
+                x: input logic [2],
+            ) -> logic {
+                return x[1];
+            }
+            var value: logic [2];
+            assign o = high(value);
+            assign value[0] = 0;
+            assign value[1] = o;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 #[ignore = "captured final-review regression: local right shift loses zero-fill positions"]
 fn combinational_loop_review_preserves_local_right_shift_positions() {
     // Why this case exists: (value >> 1)[3] is an inserted zero. Returning

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -14350,6 +14350,152 @@ fn comb_loop_branch_weak_writes_share_one_coverage_diagnostic() {
 }
 
 #[test]
+fn comb_coverage_dynamic_if_respects_each_cond_type() {
+    // Why this case exists: cond_type historically suppresses incomplete-
+    // assignment diagnostics at the annotated branch. A constant condition
+    // would be folded before MemorySSA and would not exercise this contract.
+    for (cond_type, expect_uncovered) in [
+        ("unique", false),
+        ("unique0", false),
+        ("priority", false),
+        ("none", true),
+    ] {
+        let code = format!(
+            r#"
+            module Top (
+                sel: input  logic,
+                o  : output logic,
+            ) {{
+                always_comb {{
+                    #[cond_type({cond_type})]
+                    if sel {{
+                        o = 1;
+                    }}
+                }}
+            }}
+            "#
+        );
+        let errors = analyze(&code);
+        let uncovered = errors
+            .iter()
+            .filter(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+            .count();
+        assert_eq!(
+            uncovered,
+            usize::from(expect_uncovered),
+            "cond_type({cond_type}) produced unexpected coverage diagnostics: {errors:#?}"
+        );
+    }
+}
+
+#[test]
+fn comb_coverage_dynamic_case_respects_each_cond_type() {
+    // Why this case exists: case lowering has an implicit empty default path.
+    // Its dynamic target must retain the same cond_type suppression contract
+    // as if lowering, including cond_type(none) restoring the diagnostic.
+    for (cond_type, expect_uncovered) in [
+        ("unique", false),
+        ("unique0", false),
+        ("priority", false),
+        ("none", true),
+    ] {
+        let code = format!(
+            r#"
+            module Top (
+                sel: input  logic,
+                o  : output logic,
+            ) {{
+                always_comb {{
+                    #[cond_type({cond_type})]
+                    case sel {{
+                        0: o = 1;
+                    }}
+                }}
+            }}
+            "#
+        );
+        let errors = analyze(&code);
+        let uncovered = errors
+            .iter()
+            .filter(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+            .count();
+        assert_eq!(
+            uncovered,
+            usize::from(expect_uncovered),
+            "cond_type({cond_type}) produced unexpected coverage diagnostics: {errors:#?}"
+        );
+    }
+}
+
+#[test]
+fn comb_coverage_cond_type_suppression_is_join_local() {
+    // Why this case exists: dropping every write beneath cond_type from
+    // coverage would also deprive the ordinary outer join of its diagnostic
+    // source. Suppression belongs to the annotated CFG join, while retention
+    // introduced by another join remains diagnostic.
+    let errors = analyze(
+        r#"
+        module Top (
+            outer: input  logic,
+            inner: input  logic,
+            o    : output logic,
+        ) {
+            always_comb {
+                if outer {
+                    #[cond_type(priority)]
+                    if inner {
+                        o = 1;
+                    }
+                }
+            }
+        }
+        "#,
+    );
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|error| matches!(error, AnalyzerError::UncoveredBranch { .. }))
+            .count(),
+        1,
+        "the unannotated outer join must remain diagnostic: {errors:#?}"
+    );
+}
+
+#[test]
+fn comb_loop_cond_type_suppresses_coverage_without_erasing_feedback() {
+    // Why this case exists: cond_type affects only incomplete-assignment
+    // reporting. The retained value and explicit self-read remain in the
+    // causal summary, so a proven structural loop must still be rejected.
+    let errors = analyze(
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic,
+        ) {
+            always_comb {
+                #[cond_type(priority)]
+                if sel {
+                    o = o;
+                }
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "cond_type must not erase a proven feedback dependency: {errors:#?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|error| !matches!(error, AnalyzerError::UncoveredBranch { .. })),
+        "cond_type(priority) must still suppress its coverage diagnostic: {errors:#?}"
+    );
+}
+
+#[test]
 fn comb_loop_dynamic_loop_coverage_is_not_duplicated() {
     // Why this case exists: both legacy branch bookkeeping and MemorySSA can
     // observe the missing path inside a dynamic loop. Coverage ownership must

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22694,4 +22694,54 @@ fn combinational_loop_review_maps_instance_actual_function_captures() {
         "#,
         false,
     );
+
+    // Why these cases exist: an unaligned return still has a semantic
+    // function summary. Falling back to every syntactic actual would revive
+    // the unused `b`, while the used `a` remains a real feedthrough.
+    for (name, actual, expected) in [
+        (
+            "an unaligned function return ignores an unused actual",
+            "only_a(0, feedback)",
+            false,
+        ),
+        (
+            "an unaligned function return retains its used actual",
+            "only_a(feedback, 0)",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Child (
+                    i: input  logic,
+                    o: output logic,
+                ) {{
+                    assign o = i;
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic;
+                    var passed  : logic;
+                    function only_a (
+                        a: input logic,
+                        b: input logic,
+                    ) -> logic {{
+                        return !a;
+                    }}
+                    inst u: Child (
+                        i: {actual},
+                        o: passed,
+                    );
+                    assign feedback = passed;
+                    assign o = passed;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
 }

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -14417,7 +14417,9 @@ fn uncovered_branch() {
     "#;
 
     let errors = analyze(code);
-    assert!(matches!(errors[0], AnalyzerError::UncoveredBranch { .. }));
+    assert!(errors
+        .iter()
+        .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })));
 
     let code = r#"
     module ModuleA {
@@ -14438,7 +14440,9 @@ fn uncovered_branch() {
     "#;
 
     let errors = analyze(code);
-    assert!(matches!(errors[0], AnalyzerError::UncoveredBranch { .. }));
+    assert!(errors
+        .iter()
+        .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })));
 
     let code = r#"
     module ModuleA {
@@ -14455,8 +14459,13 @@ fn uncovered_branch() {
     }
     "#;
 
+    // Why this assertion does not use errors[0]: MemorySSA coverage is emitted
+    // after existing assignment diagnostics, and their relative order is not
+    // part of the analyzer contract.
     let errors = analyze(code);
-    assert!(matches!(errors[0], AnalyzerError::UncoveredBranch { .. }));
+    assert!(errors
+        .iter()
+        .any(|error| matches!(error, AnalyzerError::UncoveredBranch { .. })));
 
     let code = r#"
     module ModuleA {

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -13694,6 +13694,37 @@ fn combinational_loop_runtime_form_cardinality_variants() {
 }
 
 #[test]
+fn combinational_loop_finite_runtime_form_recurrence_is_not_feedback() {
+    // Why this case exists: a conditional break keeps a finite const loop in
+    // runtime-form IR. Its loop-carried value is a bounded combinational chain
+    // rooted at the dominating default, not an unbounded graph backedge.
+    let errors = analyze(
+        r#"
+        module Top (
+            stop: input  logic,
+            o   : output logic,
+        ) {
+            var value: logic;
+            always_comb {
+                value = 0;
+                for _index in 0..2 {
+                    value = !value;
+                    if stop {
+                        break;
+                    }
+                }
+                o = value;
+            }
+        }
+        "#,
+    );
+    assert!(
+        errors.is_empty(),
+        "a bounded recurrence with a dominating seed is feed-forward: {errors:#?}"
+    );
+}
+
+#[test]
 fn combinational_loop_function_output_weak_write_retains_coverage() {
     // Why this case exists: a function output argument is copied back to its
     // caller, but a dynamic write inside the function still leaves unselected

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22626,3 +22626,72 @@ fn combinational_loop_review_uses_structural_selector_overlap() {
         );
     }
 }
+
+#[test]
+fn combinational_loop_review_maps_instance_actual_function_captures() {
+    // Why this case exists: a function used as an instance input may read a
+    // module-scope variable without listing it as a formal. The function
+    // summary, rather than the call's empty syntactic argument list, must map
+    // that capture into the child feedthrough and retain the real loop.
+    assert_comb_loop_for_case(
+        "an instance actual function retains a module-scope capture",
+        r#"
+        module Child (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            var x     : logic;
+            var passed: logic;
+            function get_x () -> logic {
+                return x;
+            }
+            inst u: Child (
+                i: get_x(),
+                o: passed,
+            );
+            assign x = passed;
+            assign o = passed;
+        }
+        "#,
+        true,
+    );
+
+    // Why this control exists: an exact module capture keeps its selected bit
+    // position. Feeding the child output into another bit must remain
+    // loop-free instead of widening the capture to the whole object.
+    assert_comb_loop_for_case(
+        "an instance actual function keeps a disjoint captured bit loop-free",
+        r#"
+        module Child (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            var x     : logic<2>;
+            var passed: logic;
+            function get_high () -> logic {
+                return x[1];
+            }
+            inst u: Child (
+                i: get_high(),
+                o: passed,
+            );
+            assign x[0] = passed;
+            assign x[1] = 0;
+            assign o = passed;
+        }
+        "#,
+        false,
+    );
+}

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -24079,6 +24079,44 @@ fn combinational_loop_nested_repeat_is_sparse_and_phase_precise() {
 }
 
 #[test]
+fn combinational_loop_nested_repeat_actual_survives_module_boundary() {
+    // Why these cases exist: a repeated expression used as an instance actual
+    // carries periodic input coordinates into the child summary. Mapping only
+    // its first base span misses distant feedback; widening it loses packed
+    // phase and invents feedback through the adjacent bit.
+    for (output_bit, expected) in [(0, true), (1, false)] {
+        assert_comb_loop_for_case(
+            "nested actual axes cross a module boundary without losing phase",
+            &format!(
+                r#"
+                module Identity (
+                    i: input  logic<2> [100, 20],
+                    o: output logic<2> [100, 20],
+                ) {{
+                    assign o = i;
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic<2>;
+                    var passed  : logic<2> [100, 20];
+                    inst u: Identity (
+                        i: '{{'{{feedback repeat 20}} repeat 100}},
+                        o: passed,
+                    );
+                    assign feedback[0] = passed[78][12][{output_bit}];
+                    assign feedback[1] = 0;
+                    assign o = passed[0][0][0];
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+}
+
+#[test]
 fn combinational_loop_review_uses_structural_selector_overlap() {
     // Why these cases exist: structural feedback compares each access's
     // independently possible region. Both `idx` and `~idx` can address

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10855,6 +10855,146 @@ fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
 }
 
 #[test]
+#[ignore = "captured final-review regression: logical operators evaluate dead RHS effects"]
+fn combinational_loop_review_short_circuits_logical_rhs_side_effects() {
+    let case = |name: &str, expression: &str, expected: bool| {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Sink (
+                    i: input logic,
+                ) {{}}
+                module Top (
+                    o: output logic,
+                ) {{
+                    var x: logic;
+                    function touch (
+                        a: input logic,
+                    ) -> logic {{
+                        x = a;
+                        return 0;
+                    }}
+                    inst u: Sink (
+                        i: {expression},
+                    );
+                    assign o = x;
+                }}
+                "#
+            ),
+            expected,
+        );
+    };
+
+    // Why these cases exist: IEEE 1800-2023 11.4.7 evaluates the RHS of &&
+    // only when a constant LHS is true. touch(o) in the false-LHS case cannot
+    // write x; the true-LHS control proves the live RHS still forms feedback.
+    case(
+        "a false logical-and LHS suppresses RHS function side effects",
+        "1'b0 && touch(o)",
+        false,
+    );
+    case(
+        "a true logical-and LHS retains RHS function side effects",
+        "1'b1 && touch(o)",
+        true,
+    );
+
+    // Why these cases exist: || evaluates its RHS only when a constant LHS is
+    // false. The true-LHS case is dead, while the false-LHS control is a loop.
+    case(
+        "a true logical-or LHS suppresses RHS function side effects",
+        "1'b1 || touch(o)",
+        false,
+    );
+    case(
+        "a false logical-or LHS retains RHS function side effects",
+        "1'b0 || touch(o)",
+        true,
+    );
+}
+
+#[test]
+#[ignore = "captured final-review regression: nested ternary loses bit positions"]
+fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
+    // Why this case exists: bitwise negation does not change bit positions.
+    // The nested ternary still maps o[0] only from value[0] (or a constant),
+    // so broadcasting value[1] through the outer unary operator is fictitious.
+    assert_comb_loop_for_case(
+        "a nested vector ternary keeps a disjoint bit loop-free",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic<2>,
+        ) {
+            var value: logic<2>;
+            assign o = ~(if sel ? value : 0);
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: feeding o[0] back to its corresponding
+    // value[0] closes a real path through both ternary and negation.
+    assert_comb_loop_for_case(
+        "a nested vector ternary detects its corresponding-bit loop",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic<2>,
+        ) {
+            var value: logic<2>;
+            assign o = ~(if sel ? value : 0);
+            assign value[0] = o[0];
+            assign value[1] = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "captured final-review regression: local right shift loses zero-fill positions"]
+fn combinational_loop_review_preserves_local_right_shift_positions() {
+    // Why this case exists: (value >> 1)[3] is an inserted zero. Returning
+    // that discarded high bit to value[0] cannot form feedback.
+    assert_comb_loop_for_case(
+        "a local logical right shift keeps its inserted bit loop-free",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = value >> 1;
+            assign value[0] = o[3];
+            assign value[3:1] = 0;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: o[0] is value[1], so feeding it back to
+    // value[1] is the real shifted-bit SCC.
+    assert_comb_loop_for_case(
+        "a local logical right shift detects its live shifted bit",
+        r#"
+        module Top (
+            o: output logic<4>,
+        ) {
+            var value: logic<4>;
+            assign o = value >> 1;
+            assign value[0] = 0;
+            assign value[1] = o[0];
+            assign value[3:2] = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_review_preserves_function_actual_shift_positions() {
     // Why this case exists: (value << 1)[0] is an inserted zero. Passing the
     // shifted vector through a function must not broadcast value[1] to o.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9654,6 +9654,1688 @@ fn combinational_loop() {
 }
 
 #[test]
+fn combinational_loop_memory_ssa_procedural_order_and_observers() {
+    // An observer inside a writer process does not create a signal-value edge.
+    // In particular, IEEE 1800 always_comb sensitivity excludes variables
+    // written by the process; observing x[1] must not wire it back to x[0].
+    let code = r#"
+    module Top (
+        a: input  logic,
+        o: output logic,
+    ) {
+        var x: logic<2>;
+        var y: logic;
+        always_comb {
+            x[0] = a;
+            $display("x1=%d", x[1]);
+            o = x[1];
+        }
+        assign y = x[0];
+        assign x[1] = y;
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "observer-only read formed a false signal cycle: {errors:?}"
+    );
+
+    // A dominating procedural write supplies the later read. MemorySSA must
+    // resolve it to that definition, not LiveOnEntry(x[0]).
+    let code = r#"
+    module Top (
+        a: input  logic,
+        o: output logic,
+    ) {
+        var x: logic<2>;
+        always_comb {
+            x[0] = a;
+            x[1] = x[0];
+            o = x[1];
+        }
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "dominating procedural definition was treated as an entry read: {errors:?}"
+    );
+
+    // The converse is real: after x[0] consumes the entry value of x[1], the
+    // later write makes final x[1] depend on x[0], reducing to x[1] = x[1].
+    let code = r#"
+    module Top (
+        o: output logic<2>,
+    ) {
+        always_comb {
+            o[0] = o[1];
+            o[1] = o[0];
+        }
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "read-before-write feedback was not diagnosed: {errors:?}"
+    );
+
+    // Function summaries come from the specialized body. Merely evaluating an
+    // unused actual argument is not a signal-value dependency of the return.
+    let code = r#"
+    module Top (
+        o: output logic,
+    ) {
+        function ignore (
+            unused: input logic,
+        ) -> logic {
+            return 0;
+        }
+        var feedback: logic;
+        assign o = ignore(feedback);
+        assign feedback = o;
+    }
+    "#;
+    let errors = analyze(code);
+    assert!(
+        !errors
+            .iter()
+            .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. })),
+        "unused function argument formed a false loop: {errors:?}"
+    );
+}
+
+#[test]
+fn combinational_loop_memory_ssa_retains_dynamic_region_uncertainty() {
+    symbol_table::clear();
+    attribute_table::clear();
+    doc_comment_table::clear();
+
+    let code = r#"
+    module Top (
+        index: input  logic<2>,
+        data : input  logic,
+        o    : output logic,
+    ) {
+        var values: logic [4];
+        always_comb {
+            values[index] = data;
+            o = values[0];
+        }
+    }
+    "#;
+    let metadata = Metadata::create_default("prj").unwrap();
+    let parser = Parser::parse(code, &"").unwrap();
+    let analyzer = Analyzer::new(&metadata);
+    let mut context = Context::default();
+    let mut ir = Ir::default();
+    let pass1 = analyzer.analyze_pass1("prj", &parser.veryl);
+    assert!(pass1.is_empty(), "{pass1:?}");
+    let post1 = Analyzer::analyze_post_pass1();
+    assert!(post1.is_empty(), "{post1:?}");
+    let pass2 = analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
+    assert!(pass2.is_empty(), "{pass2:?}");
+
+    let result = crate::comb_loop_detect::check_detailed(&ir);
+    assert!(result.errors.is_empty(), "{:#?}", result.errors);
+    assert!(result.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::DynamicRegion)
+    }));
+}
+
+fn assert_comb_loop_for_case(case: &str, code: &str, expected: bool) {
+    let errors = analyze(code);
+    let actual = errors
+        .iter()
+        .any(|error| matches!(error, AnalyzerError::CombinationalLoop { .. }));
+    assert_eq!(actual, expected, "{case}: {errors:?}");
+}
+
+#[test]
+fn combinational_loop_memory_ssa_celox_regression_corpus() {
+    // Ported from celox/tests/basic.rs::test_always_comb_read_before_write_uses_previous_value.
+    assert_comb_loop_for_case(
+        "read before write observes LiveOnEntry",
+        r#"
+        module Top (
+            a: input  logic,
+            c: output logic,
+        ) {
+            var b: logic;
+            always_comb {
+                c = b;
+                b = a;
+            }
+        }
+        "#,
+        false,
+    );
+
+    // Ported from celox/tests/false_loop.rs::test_cross_bit_dependency_false_loop.
+    assert_comb_loop_for_case(
+        "opposite directions on disjoint bits",
+        r#"
+        module Top (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            var a: logic<2>;
+            var b: logic<2>;
+            always_comb {
+                a[0] = i[0];
+                b[0] = a[0];
+                b[1] = i[1];
+                a[1] = b[1];
+            }
+            assign o = {a[1], b[0]};
+        }
+        "#,
+        false,
+    );
+
+    // Ported from the multi-stage observer cases in celox/tests/comb_observer.rs.
+    assert_comb_loop_for_case(
+        "observer in a writer with a multi-stage assign chain",
+        r#"
+        module Top (
+            a: input  logic,
+            o: output logic,
+        ) {
+            var x: logic<4>;
+            always_comb {
+                x[0] = a;
+                $display("x3=%d", x[3]);
+                o = x[3];
+            }
+            assign x[1] = x[0];
+            assign x[2] = x[1];
+            assign x[3] = x[2];
+        }
+        "#,
+        false,
+    );
+
+    // Ported from the case/if matrix in celox/tests/case_switch.rs.
+    assert_comb_loop_for_case(
+        "case phi with complete definitions",
+        r#"
+        module Top (
+            sel: input  logic<2>,
+            a  : input  logic,
+            b  : input  logic,
+            o  : output logic,
+        ) {
+            var selected: logic;
+            always_comb {
+                case sel {
+                    2'd0: selected = a;
+                    2'd1: selected = b;
+                    default: selected = 0;
+                }
+                o = selected;
+            }
+        }
+        "#,
+        false,
+    );
+
+    // Ported from the indexed-local and partial-write function tests in basic.rs.
+    assert_comb_loop_for_case(
+        "function local partial writes are ordered",
+        r#"
+        module Top (
+            d: input  logic<8>,
+            q: output logic<8>,
+        ) {
+            function swap_nibbles (
+                x: input logic<8>,
+            ) -> logic<8> {
+                var tmp: logic<8>;
+                tmp[7:4] = x[3:0];
+                tmp[3:0] = x[7:4];
+                return tmp;
+            }
+            assign q = swap_nibbles(d);
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "one branch keeps an entry definition live",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic,
+        ) {
+            always_comb {
+                if sel {
+                    o = 0;
+                }
+                o = o;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "case without a covering default keeps entry live",
+        r#"
+        module Top (
+            sel: input  logic<2>,
+            o  : output logic,
+        ) {
+            always_comb {
+                case sel {
+                    2'd0: o = 0;
+                    2'd1: o = 1;
+                }
+                o = o;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "nested function summary preserves a real cycle",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function inner (x: input logic) -> logic {
+                return x;
+            }
+            function outer (x: input logic) -> logic {
+                return inner(x);
+            }
+            assign o = outer(o);
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
+    assert_comb_loop_for_case(
+        "blocking assignment chain uses the immediately preceding definition",
+        r#"
+        module Top (
+            a: input  logic<8>,
+            o: output logic<8>,
+        ) {
+            var tmp: logic<8>;
+            always_comb {
+                tmp = a;
+                tmp = tmp + 8'd1;
+                tmp = tmp << 1;
+                o = tmp;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a later full overwrite kills an earlier partial entry read",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            always_comb {
+                o[0] = o[1];
+                o = 0;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a full overwrite dominates a later partial read",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            always_comb {
+                o = 0;
+                o[0] = o[1];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "both branch arms define the value consumed after the merge",
+        r#"
+        module Top (
+            sel: input  logic,
+            a  : input  logic,
+            b  : input  logic,
+            o  : output logic,
+        ) {
+            var selected: logic;
+            always_comb {
+                if sel {
+                    selected = a;
+                } else {
+                    selected = b;
+                }
+                o = selected;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "function local copy retains bit precision at the return",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic<8>) -> logic {
+                var tmp: logic<8>;
+                tmp = x;
+                return tmp[0];
+            }
+            var value: logic<8>;
+            assign o = low(value);
+            assign value[7] = o;
+            assign value[6:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "function branch condition is a control dependency of its return",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function gated (x: input logic<8>) -> logic {
+                if x[7] {
+                    return x[0];
+                } else {
+                    return 0;
+                }
+            }
+            var value: logic<8>;
+            assign o = gated(value);
+            assign value[7] = o;
+            assign value[6:0] = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "function branch ignores a bit absent from value and control flow",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function gated (x: input logic<8>) -> logic {
+                if x[7] {
+                    return x[0];
+                } else {
+                    return 0;
+                }
+            }
+            var value: logic<8>;
+            assign o = gated(value);
+            assign value[6] = o;
+            assign value[7] = 0;
+            assign value[5:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "function output writeback participates in procedural order",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function copy (
+                x: input  logic,
+                y: output logic,
+            ) {
+                y = x;
+            }
+            var tmp: logic;
+            always_comb {
+                copy(o, tmp);
+                o = tmp;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "static array elements remain distinct regions",
+        r#"
+        module Top (
+            a: input  logic<8>,
+            o: output logic<8>,
+        ) {
+            var mem: logic<8> [2];
+            always_comb {
+                mem[0] = a;
+                mem[1] = mem[0];
+                o = mem[1];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "read-before-write across static array elements is a real loop",
+        r#"
+        module Top (
+            o: output logic<8>,
+        ) {
+            var mem: logic<8> [2];
+            always_comb {
+                mem[0] = mem[1];
+                mem[1] = mem[0];
+                o = mem[1];
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "static struct members remain distinct regions",
+        r#"
+        module Top (
+            a: input  logic<8>,
+            o: output logic<8>,
+        ) {
+            struct Pair {
+                low : logic<8>,
+                high: logic<8>,
+            }
+            var pair: Pair;
+            always_comb {
+                pair.low = a;
+                pair.high = pair.low;
+                o = pair.high;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "sparse accesses do not scale with a huge declared width",
+        r#"
+        module Top (
+            a: input  logic,
+            o: output logic,
+        ) {
+            var huge: logic<1000000>;
+            always_comb {
+                huge[0] = a;
+                o = huge[999999];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "dynamic same-object aliasing uses the whole longest static prefix",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            var values: logic [4];
+            always_comb {
+                values[index] = o;
+                o = values[0];
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
+    assert_comb_loop_for_case(
+        "function bit-select must not taint a disjoint actual bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_zero (x: input logic<8>) -> logic {
+                return x[0];
+            }
+            var value: logic<8>;
+            assign o = bit_zero(value);
+            assign value[0] = 0;
+            assign value[7] = o;
+            assign value[6:1] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "function bit-select must retain same-bit feedback",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_zero (x: input logic<8>) -> logic {
+                return x[0];
+            }
+            var value: logic<8>;
+            assign o = bit_zero(value);
+            assign value[0] = o;
+            assign value[7:1] = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "function bit-select through concatenation ignores high operands",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_zero (x: input logic<8>) -> logic {
+                return x[0];
+            }
+            var value: logic<7>;
+            assign o = bit_zero({value, 1'b0});
+            assign value[6] = o;
+            assign value[5:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "function bit-select through concatenation retains low operand",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_zero (x: input logic<8>) -> logic {
+                return x[0];
+            }
+            assign o = bit_zero({7'b0, o});
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "function bit-select through an actual slice uses its low bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_zero (x: input logic<8>) -> logic {
+                return x[0];
+            }
+            var value: logic<16>;
+            assign o = bit_zero(value[15:8]);
+            assign value[15] = o;
+            assign value[14:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "function bit-select through an actual slice retains its low-bit feedback",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_zero (x: input logic<8>) -> logic {
+                return x[0];
+            }
+            var value: logic<16>;
+            assign o = bit_zero(value[15:8]);
+            assign value[8] = o;
+            assign value[15:9] = 0;
+            assign value[7:0] = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "function region crossing a concatenation boundary retains both operands",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function middle (x: input logic<8>) -> logic<2> {
+                return x[4:3];
+            }
+            var high: logic<4>;
+            var low : logic<4>;
+            assign o = middle({high, low});
+            assign high[0] = o[1];
+            assign high[3:1] = 0;
+            assign low = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "local copy chains propagate bit identity through every hop",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_two (x: input logic<8>) -> logic {
+                var first : logic<8>;
+                var second: logic<8>;
+                first = x;
+                second = first;
+                return second[2];
+            }
+            var value: logic<8>;
+            assign o = bit_two(value);
+            assign value[7] = o;
+            assign value[6:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "local concatenation does not taint a constant low bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic<7>) -> logic {
+                var tmp: logic<8>;
+                tmp = {x, 1'b0};
+                return tmp[0];
+            }
+            var value: logic<7>;
+            assign o = low(value);
+            assign value[6] = o;
+            assign value[5:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "local concatenation retains a signal low bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic) -> logic {
+                var tmp: logic<8>;
+                tmp = {7'b0, x};
+                return tmp[0];
+            }
+            assign o = low(o);
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "same-width bitwise operators preserve positional provenance",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic<8>) -> logic {
+                var tmp: logic<8>;
+                tmp = x & 8'b00000001;
+                return tmp[0];
+            }
+            var value: logic<8>;
+            assign o = low(value);
+            assign value[7] = o;
+            assign value[6:0] = 0;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "same-width bitwise operators retain same-bit feedback",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic<8>) -> logic {
+                var tmp: logic<8>;
+                tmp = x | 8'b00000000;
+                return tmp[0];
+            }
+            var value: logic<8>;
+            assign o = low(value);
+            assign value[0] = o;
+            assign value[7:1] = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "structural dependence is not removed by Boolean cancellation",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic<8>) -> logic {
+                var tmp: logic<8>;
+                tmp = x & 8'b00000000;
+                return tmp[0];
+            }
+            var value: logic<8>;
+            assign o = low(value);
+            assign value[0] = o;
+            assign value[7:1] = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "reduction operators remain dependent on every operand bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function parity (x: input logic<8>) -> logic {
+                return ^x;
+            }
+            var value: logic<8>;
+            assign o = parity(value);
+            assign value[7] = o;
+            assign value[6:0] = 0;
+        }
+        "#,
+        true,
+    );
+
+    // Four-state arithmetic remains whole-expression dependent: an X/Z in a
+    // high operand bit can make the entire arithmetic result unknown. A
+    // future two-state transfer may be narrower, but must not leak into logic.
+    assert_comb_loop_for_case(
+        "four-state arithmetic depends on every operand bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (x: input logic<8>) -> logic {
+                var tmp: logic<8>;
+                tmp = x + 8'd1;
+                return tmp[0];
+            }
+            var value: logic<8>;
+            assign o = low(value);
+            assign value[7] = o;
+            assign value[6:0] = 0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "dynamic observer must not hide an unrelated proven loop",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic,
+        ) {
+            var observed: logic<4>;
+            always_comb {
+                $display("observed=%d", observed[index]);
+                o = o;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "dynamic write to one object must not hide another object's loop",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            data : input  logic,
+            o    : output logic,
+        ) {
+            var memory: logic [4];
+            always_comb {
+                memory[index] = data;
+                o = o;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "dominating full write kills partial branch feedback",
+        r#"
+        module Top (
+            sel: input  logic,
+            a  : input  logic,
+            o  : output logic<2>,
+        ) {
+            always_comb {
+                o = 0;
+                if sel {
+                    o[0] = a;
+                }
+                o[1] = o[0];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "phi on one bit cannot manufacture a cross-bit cycle",
+        r#"
+        module Top (
+            sel: input  logic,
+            a  : input  logic,
+            b  : input  logic,
+            o  : output logic<2>,
+        ) {
+            always_comb {
+                o = 0;
+                if sel {
+                    o[0] = a;
+                } else {
+                    o[1] = b;
+                }
+            }
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+fn combinational_loop_memory_ssa_malicious_structural_cases() {
+    assert_comb_loop_for_case(
+        "dynamic same-index read/write is structurally self-dependent",
+        r#"
+        module Top (
+            index: input logic<2>,
+            o    : output logic,
+        ) {
+            var values: logic [4];
+            always_comb {
+                values[index] = values[index];
+                o = values[0];
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "dynamic data write without an old-value read is feed-forward",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            data : input  logic,
+            o    : output logic,
+        ) {
+            var values: logic [4];
+            always_comb {
+                values[index] = data;
+                o = values[0];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a value controlling its own dynamic write address closes a loop",
+        r#"
+        module Top (
+            data: input  logic,
+            o   : output logic,
+        ) {
+            var index : logic<2>;
+            var values: logic [4];
+            always_comb {
+                index = {1'b0, values[0]};
+                values[index] = data;
+                o = values[0];
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "identical ternary arms do not cancel structural control dependence",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            assign o = if o ? 1'b0 : 1'b0;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "duplicate xor operands remain structural inputs",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            assign o = o ^ o;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "read-before-write across disjoint nibbles is acyclic without a return path",
+        r#"
+        module Top (
+            o: output logic<8>,
+        ) {
+            always_comb {
+                o[3:0] = o[7:4];
+                o[7:4] = 0;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "overlapping left shift is a directed acyclic bit chain",
+        r#"
+        module Top (
+            o: output logic<8>,
+        ) {
+            always_comb {
+                o[7:1] = o[6:0];
+                o[0] = 0;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "adding the wraparound bit turns a shift into a structural rotate loop",
+        r#"
+        module Top (
+            o: output logic<8>,
+        ) {
+            always_comb {
+                o[7:1] = o[6:0];
+                o[0] = o[7];
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "concatenation permutation preserves structural feedback",
+        r#"
+        module Top (
+            o: output logic<8>,
+        ) {
+            always_comb {
+                o = {o[3:0], o[7:4]};
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "complete overwrite after a rotate-shaped dead store kills the loop",
+        r#"
+        module Top (
+            o: output logic<8>,
+        ) {
+            always_comb {
+                o = {o[3:0], o[7:4]};
+                o = 0;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "identical function branches retain structural condition dependence",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function choose (condition: input logic) -> logic {
+                if condition {
+                    return 0;
+                } else {
+                    return 0;
+                }
+            }
+            assign o = choose(o);
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "observer-only duplicate reads do not manufacture value feedback",
+        r#"
+        module Top (
+            a: input  logic,
+            o: output logic,
+        ) {
+            always_comb {
+                $display("o=%d %d", o, o);
+                o = a;
+            }
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
+    assert_comb_loop_for_case(
+        "a full write after a dynamic self-store kills the dead feedback",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[index] = o[index];
+                o = 0;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a dominating full write kills a later dynamic read of the old value",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o = 0;
+                o[index] = o[index];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "an unrelated exact bit write cannot kill dynamic feedback",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[index] = o[index];
+                o[0] = 0;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "all branch exits overwriting the object kill earlier dynamic feedback",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            sel  : input  logic,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[index] = o[index];
+                if sel {
+                    o = 0;
+                } else {
+                    o = 1;
+                }
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "one branch preserving a dynamic self-store preserves feedback",
+        r#"
+        module Top (
+            index: input  logic<2>,
+            sel  : input  logic,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[index] = o[index];
+                if sel {
+                    o = 0;
+                }
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "dynamic writes to separate objects do not alias",
+        r#"
+        module Top (
+            left_index : input  logic<2>,
+            right_index: input  logic<2>,
+            data       : input  logic,
+            o          : output logic,
+        ) {
+            var left : logic<4>;
+            var right: logic<4>;
+            always_comb {
+                left[left_index] = data;
+                right[right_index] = left[left_index];
+                o = right[0];
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "two object-local dynamic aliases can close a cross-object cycle",
+        r#"
+        module Top (
+            left_index : input  logic<2>,
+            right_index: input  logic<2>,
+            o          : output logic,
+        ) {
+            var left : logic<4>;
+            var right: logic<4>;
+            always_comb {
+                left[left_index] = right[right_index];
+                right[right_index] = left[left_index];
+                o = right[0];
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "a dominating value write also kills a self-derived dynamic address",
+        r#"
+        module Top (
+            data: input  logic,
+            o   : output logic<4>,
+        ) {
+            always_comb {
+                o = 0;
+                o[o[1:0]] = data;
+            }
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "an undominated value driving its own dynamic address is feedback",
+        r#"
+        module Top (
+            data: input  logic,
+            o   : output logic<4>,
+        ) {
+            always_comb {
+                o[o[1:0]] = data;
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+fn combinational_loop_memory_ssa_malicious_dynamic_domain_cases() {
+    assert_comb_loop_for_case(
+        "a dynamic select aliases its whole longest static prefix",
+        r#"
+        module Top (
+            index: input  logic,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[1:0] = 0;
+                o[index] = o[3];
+                o[3] = o[2];
+                o[2] = 0;
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "a one-bit dynamic domain still aliases both representable bits",
+        r#"
+        module Top (
+            index: input  logic,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[index] = o[1];
+            }
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "a representable dynamic target can close a cycle through a high bit",
+        r#"
+        module Top (
+            index: input  logic,
+            o    : output logic<4>,
+        ) {
+            always_comb {
+                o[index] = o[3];
+                o[3] = o[0];
+            }
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+fn combinational_loop_malicious_module_boundary_cases() {
+    assert_comb_loop_for_case(
+        "a child port summary must not turn bit-disjoint feedthrough into a loop",
+        r#"
+        module Child (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            assign o[0] = i[1];
+            assign o[1] = 0;
+        }
+
+        module Top (
+            o: output logic<2>,
+        ) {
+            var child_i: logic<2>;
+            var child_o: logic<2>;
+            inst u: Child (
+                i: child_i,
+                o: child_o,
+            );
+            assign child_i[0] = child_o[0];
+            assign child_i[1] = 0;
+            assign o = child_o;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a region-preserving child feedthrough still reports a real loop",
+        r#"
+        module Child (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            assign o[0] = i[0];
+            assign o[1] = 0;
+        }
+
+        module Top (
+            o: output logic<2>,
+        ) {
+            var child_i: logic<2>;
+            var child_o: logic<2>;
+            inst u: Child (
+                i: child_i,
+                o: child_o,
+            );
+            assign child_i[0] = child_o[0];
+            assign child_i[1] = 0;
+            assign o = child_o;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "an opaque SystemVerilog component cannot prove a hard loop",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var into_sv : logic;
+            var from_sv : logic;
+            inst u: $sv::Ext (
+                i_data: into_sv,
+                o_data: from_sv,
+            );
+            assign into_sv = from_sv;
+            assign o = from_sv;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a top input-to-output path has no inferred environment return edge",
+        r#"
+        module Top (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "bit precision survives two module boundaries",
+        r#"
+        module Leaf (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            assign o[0] = i[1];
+            assign o[1] = 0;
+        }
+
+        module Middle (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            inst u_leaf: Leaf (
+                i: i,
+                o: o,
+            );
+        }
+
+        module Top (
+            o: output logic<2>,
+        ) {
+            var middle_i: logic<2>;
+            var middle_o: logic<2>;
+            inst u_middle: Middle (
+                i: middle_i,
+                o: middle_o,
+            );
+            assign middle_i[0] = middle_o[0];
+            assign middle_i[1] = 0;
+            assign o = middle_o;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a real loop survives two region-preserving summaries",
+        r#"
+        module Leaf (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            assign o[0] = i[0];
+            assign o[1] = 0;
+        }
+
+        module Middle (
+            i: input  logic<2>,
+            o: output logic<2>,
+        ) {
+            inst u_leaf: Leaf (
+                i: i,
+                o: o,
+            );
+        }
+
+        module Top (
+            o: output logic<2>,
+        ) {
+            var middle_i: logic<2>;
+            var middle_o: logic<2>;
+            inst u_middle: Middle (
+                i: middle_i,
+                o: middle_o,
+            );
+            assign middle_i[0] = middle_o[0];
+            assign middle_i[1] = 0;
+            assign o = middle_o;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "a concatenated instance input preserves its low-bit source",
+        r#"
+        module Child (
+            i: input  logic<2>,
+            o: output logic,
+        ) {
+            assign o = i[0];
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            var high    : logic;
+            var low     : logic;
+            var child_o : logic;
+            inst u: Child (
+                i: {high, low},
+                o: child_o,
+            );
+            assign high = child_o;
+            assign low = 0;
+            assign o = child_o;
+        }
+        "#,
+        false,
+    );
+
+    assert_comb_loop_for_case(
+        "a concatenated instance input does not hide a real low-bit loop",
+        r#"
+        module Child (
+            i: input  logic<2>,
+            o: output logic,
+        ) {
+            assign o = i[0];
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            var high    : logic;
+            var low     : logic;
+            var child_o : logic;
+            inst u: Child (
+                i: {high, low},
+                o: child_o,
+            );
+            assign high = 0;
+            assign low = child_o;
+            assign o = child_o;
+        }
+        "#,
+        true,
+    );
+
+    assert_comb_loop_for_case(
+        "a static slice connection does not contaminate its sibling bit",
+        r#"
+        module Child (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Top (
+            o: output logic<2>,
+        ) {
+            var bus: logic<2>;
+            inst u: Child (
+                i: bus[1],
+                o: bus[0],
+            );
+            assign bus[1] = 0;
+            assign o = bus;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
+    fn detailed(code: &str) -> crate::comb_loop_detect::CombAnalysisResult {
+        symbol_table::clear();
+        attribute_table::clear();
+        doc_comment_table::clear();
+
+        let metadata = Metadata::create_default("prj").unwrap();
+        let parser = Parser::parse(code, &"").unwrap();
+        let analyzer = Analyzer::new(&metadata);
+        let mut context = Context::default();
+        let mut ir = Ir::default();
+        let pass1 = analyzer.analyze_pass1("prj", &parser.veryl);
+        assert!(pass1.is_empty(), "{pass1:?}");
+        let post1 = Analyzer::analyze_post_pass1();
+        assert!(post1.is_empty(), "{post1:?}");
+        let pass2 = analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
+        assert!(pass2.is_empty(), "{pass2:?}");
+        crate::comb_loop_detect::check_detailed(&ir)
+    }
+
+    let external = detailed(
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            var into_sv : logic;
+            var from_sv : logic;
+            inst u: $sv::Ext (
+                i_data: into_sv,
+                o_data: from_sv,
+            );
+            assign into_sv = from_sv;
+            assign o = from_sv;
+        }
+        "#,
+    );
+    assert!(external.errors.is_empty(), "{:#?}", external.errors);
+    assert!(external.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::ExternalComponent)
+    }));
+
+    let inout = detailed(
+        r#"
+        module Top (
+            io: inout tri logic,
+        ) {}
+        "#,
+    );
+    assert!(inout.errors.is_empty(), "{:#?}", inout.errors);
+    assert!(inout.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::InoutPort)
+    }));
+
+    let unsupported_actual = detailed(
+        r#"
+        module Child (
+            i: input  logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Top (
+            o: output logic,
+        ) {
+            function passthrough (x: input logic) -> logic {
+                return x;
+            }
+            var feedback: logic;
+            inst u: Child (
+                i: passthrough(feedback),
+                o: feedback,
+            );
+            assign o = feedback;
+        }
+        "#,
+    );
+    assert!(
+        unsupported_actual.errors.is_empty(),
+        "{:#?}",
+        unsupported_actual.errors
+    );
+    assert!(unsupported_actual.incomplete.iter().any(|module| {
+        module.module == "Top"
+            && module
+                .reasons
+                .contains(&veryl_causal::graph::IncompleteReason::UnsupportedSyntax)
+    }));
+}
+
+#[test]
 fn comb_loop_ifstmt_feed_forward_array() {
     // False positive: an always_comb for-loop over cross-coupled arrays that
     // reads index i and writes i+1 (a feed-forward / acyclic CORDIC-style

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22339,6 +22339,56 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
         );
     }
 
+    // Why these cases exist: the same named-member projection must survive a
+    // module boundary; otherwise the instance fallback re-taints all members.
+    for (name, constructor, expected) in [
+        (
+            "a structure actual keeps an unrelated member loop-free",
+            "Types::Pair'{a: 0, b: feedback}",
+            false,
+        ),
+        (
+            "a structure actual retains corresponding-member feedback",
+            "Types::Pair'{a: feedback, b: 0}",
+            true,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                package Types {{
+                    struct Pair {{
+                        a: logic,
+                        b: logic,
+                    }}
+                }}
+
+                module Pick (
+                    i: input  Types::Pair,
+                    o: output logic,
+                ) {{
+                    assign o = i.a;
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic;
+                    var passed  : logic;
+                    inst u: Pick (
+                        i: {constructor},
+                        o: passed,
+                    );
+                    assign feedback = passed;
+                    assign o = passed;
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+
     // Why these cases exist: IEEE 1800-2023 10.9.1 maps array-pattern
     // expressions element by element. The module reads only element zero, so
     // an actual dependency in element one is disjoint while element-zero

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10942,7 +10942,6 @@ fn combinational_loop_review_preserves_vector_ternary_positions() {
 }
 
 #[test]
-#[ignore = "captured independent-review regression: function concat output loses destinations"]
 fn combinational_loop_review_preserves_function_concat_output_positions() {
     // Why this case exists: y = x copied into {o[1], o[0]} still maps x[0]
     // only to o[0]. Treating the concatenated output actual as all-to-all

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10602,7 +10602,6 @@ fn combinational_loop_review_preserves_repeat_concatenation_positions() {
 }
 
 #[test]
-#[ignore = "known bug: instance actual mapping ignores constant shift positions"]
 fn combinational_loop_review_preserves_instance_shift_positions() {
     // Why this case exists: (value << 1)[0] is an inserted constant zero.
     // Falling back to every operand creates a fictitious value[1] path.
@@ -10663,7 +10662,6 @@ fn combinational_loop_review_preserves_instance_shift_positions() {
 }
 
 #[test]
-#[ignore = "known bug: instance actual mapping ignores repeat-concat positions"]
 fn combinational_loop_review_preserves_instance_repeat_positions() {
     // Why this case exists: {high repeat 2, low}[2] is high. Treating every
     // operand as a source invents a low -> child_o -> low feedback path.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10294,7 +10294,6 @@ fn combinational_loop_review_aliases_overlapping_unknown_regions() {
 }
 
 #[test]
-#[ignore = "known bug: module summaries discard aligned bit coordinates"]
 fn combinational_loop_review_preserves_module_summary_positions() {
     // Why this case exists: Child is a bitwise identity. child_o[1] is driven
     // by the constant child_i[1], so feeding it to child_i[0] is acyclic.

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -9138,7 +9138,7 @@ fn unassignable_output() {
 }
 
 #[test]
-fn combinational_loop_oversized_array_is_sparse_and_complete() {
+fn comb_loop_oversized_array_is_sparse_and_complete() {
     // Why this case exists: a sequential memory with a combinational read must
     // remain loop-free even when its declared index space is too large for the
     // analyzer's ordinary elaboration limit.
@@ -9244,7 +9244,7 @@ fn combinational_loop_oversized_array_is_sparse_and_complete() {
 }
 
 #[test]
-fn combinational_loop() {
+fn comb_loop_core_semantics_and_region_regressions() {
     // 2-block ring: assign b = c + a; assign c = b + 1
     let code = r#"
     module ModuleA (
@@ -9742,7 +9742,7 @@ fn combinational_loop() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_procedural_order_and_observers() {
+fn comb_loop_statement_order_and_observer_semantics() {
     // An observer inside a writer process does not create a signal-value edge.
     // In particular, IEEE 1800 always_comb sensitivity excludes variables
     // written by the process; observing x[1] must not wire it back to x[0].
@@ -9839,7 +9839,7 @@ fn combinational_loop_memory_ssa_procedural_order_and_observers() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_retains_dynamic_region_uncertainty() {
+fn comb_loop_dynamic_write_reports_region_uncertainty() {
     symbol_table::clear();
     attribute_table::clear();
     doc_comment_table::clear();
@@ -9896,7 +9896,7 @@ fn combinational_loop_memory_ssa_retains_dynamic_region_uncertainty() {
     );
 }
 
-fn assert_comb_loop_for_case(case: &str, code: &str, expected: bool) {
+fn assert_comb_loop(case: &str, code: &str, expected: bool) {
     let errors = analyze(code);
     let actual = errors
         .iter()
@@ -9921,11 +9921,11 @@ fn assert_incomplete_assignment_without_comb_loop(case: &str, code: &str) {
 }
 
 #[test]
-fn combinational_loop_review_preserves_longest_static_prefix() {
+fn comb_loop_dynamic_select_is_confined_to_static_prefix() {
     // Why this case exists: IEEE 1800-2023 11.5.3 confines buff[0][idx]
     // to the statically selected row. Aliasing it with buff[1] rejects legal,
     // bit-disjoint SystemVerilog and makes the analyzer stronger than the LRM.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a dynamic suffix aliases only its longest static prefix",
         r#"
         module Top (
@@ -9949,11 +9949,11 @@ fn combinational_loop_review_preserves_longest_static_prefix() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_function_global_read() {
+fn comb_loop_function_global_read_contributes_value_dependency() {
     // Why this case exists: IEEE 1800-2023 9.2.2.2.1 includes variables read
     // by a called function in always_comb. A global capture is not a formal
     // argument, but it is still a real x -> o dependency and closes this loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a called function retains a captured module-scope read",
         r#"
         module Top (
@@ -9976,7 +9976,7 @@ fn combinational_loop_review_keeps_function_global_read() {
 
     // Why this control exists: a captured read alone is not feedback. Its
     // source may be driven independently from an input without a return path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a captured function read remains feed-forward without a return path",
         r#"
         module Top (
@@ -10000,11 +10000,11 @@ fn combinational_loop_review_keeps_function_global_read() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_function_global_write() {
+fn comb_loop_function_global_write_contributes_procedural_effect() {
     // Why this case exists: IEEE 1800-2023 9.2.2.2 treats a variable written
     // by a called function as written by the always_comb process. Side effects
     // on module scope must therefore survive function-summary projection.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a called function retains a captured module-scope write",
         r#"
         module Top (
@@ -10029,7 +10029,7 @@ fn combinational_loop_review_keeps_function_global_write() {
 
     // Why this control exists: a captured function write from an independent
     // input is a normal feed-forward side effect, not a loop by itself.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a captured function write remains feed-forward without a return path",
         r#"
         module Top (
@@ -10055,11 +10055,11 @@ fn combinational_loop_review_keeps_function_global_write() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_dynamic_region_across_modules() {
+fn comb_loop_dynamic_region_survives_module_summary() {
     // Why this case exists: an instance port is a SystemVerilog data path, so
     // a child wildcard output must remain a wildcard through every summary.
     // For idx == 0 the Top-level feedback path is realizable and structural.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a dynamic child output preserves feedback across two summaries",
         r#"
         module Leaf (
@@ -10100,10 +10100,10 @@ fn combinational_loop_review_keeps_dynamic_region_across_modules() {
 }
 
 #[test]
-fn combinational_loop_review_drops_unreachable_statements_after_break() {
+fn comb_loop_drops_unreachable_statements_after_break() {
     // Why this case exists: IEEE 1800-2023 12.8 makes break jump to the loop
     // exit. Statements after it are unreachable and cannot prove a hard SCC.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "unreachable statements after break do not form a loop",
         r#"
         module Top (
@@ -10127,11 +10127,11 @@ fn combinational_loop_review_drops_unreachable_statements_after_break() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_vector_function_return_bits() {
+fn comb_loop_preserves_vector_function_return_bits() {
     // Why this case exists: identity(value)[0] depends only on value[0].
     // Collapsing a vector return to an object-wide dependency invents the
     // value[1] -> o[0] -> value[1] cycle rejected by the current analyzer.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector function return preserves bit identity",
         r#"
         module Top (
@@ -10153,7 +10153,7 @@ fn combinational_loop_review_preserves_vector_function_return_bits() {
 
     // Why this control exists: output bit zero corresponds to input bit zero
     // through identity. Feeding that same bit back must remain a real loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector function return retains same-bit feedback",
         r#"
         module Top (
@@ -10175,11 +10175,11 @@ fn combinational_loop_review_preserves_vector_function_return_bits() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_concatenated_lhs_bits() {
+fn comb_loop_preserves_concatenated_lhs_bits() {
     // Why this case exists: {o[1], o[0]} = value maps each destination bit to
     // one RHS bit. Broadcasting all RHS dependencies to both destinations
     // invents a value[1] -> o[0] -> value[1] cycle.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated assignment destination preserves bit identity",
         r#"
         module Top (
@@ -10197,7 +10197,7 @@ fn combinational_loop_review_preserves_concatenated_lhs_bits() {
     // Why this control exists: o[0] is mapped from value[0], so feeding o[0]
     // back into value[0] is a real same-bit cycle that aligned lowering must
     // retain while removing the disjoint-bit false positive above.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated assignment retains same-bit feedback",
         r#"
         module Top (
@@ -10214,11 +10214,11 @@ fn combinational_loop_review_preserves_concatenated_lhs_bits() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_constant_shift_positions() {
+fn comb_loop_preserves_constant_shift_positions() {
     // Why this case exists: the low bit of a logical left shift is constant
     // zero. Treating every result bit as dependent on every operand bit
     // invents a value[1] -> o[0] -> value[1] cycle.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a constant left shift preserves its zero-filled low bit",
         r#"
         module Top (
@@ -10236,7 +10236,7 @@ fn combinational_loop_review_preserves_constant_shift_positions() {
 
     // Why this control exists: after a one-bit left shift, o[1] is value[0].
     // Returning o[1] to value[0] is therefore a real positional cycle.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a constant left shift retains displaced same-bit feedback",
         r#"
         module Top (
@@ -10253,11 +10253,11 @@ fn combinational_loop_review_preserves_constant_shift_positions() {
 }
 
 #[test]
-fn combinational_loop_review_dynamic_write_is_a_weak_update() {
+fn comb_loop_dynamic_write_is_a_weak_update() {
     // Why this case exists: o[idx] writes exactly one candidate. For idx != 1,
     // the old o[1] remains live through o[0] = o[1]; o[1] = o[0], so a real
     // structural self-dependency must not be killed by the dynamic store.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a dynamic store cannot kill every candidate definition",
         r#"
         module Top (
@@ -10276,7 +10276,7 @@ fn combinational_loop_review_dynamic_write_is_a_weak_update() {
 
     // Why this control exists: a full-width write really does kill every
     // candidate before the assignment chain and must remain loop-free.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a full store still kills every candidate definition",
         r#"
         module Top (
@@ -10294,11 +10294,11 @@ fn combinational_loop_review_dynamic_write_is_a_weak_update() {
 }
 
 #[test]
-fn combinational_loop_review_aliases_overlapping_unknown_regions() {
+fn comb_loop_aliases_overlapping_unknown_regions() {
     // Why this case exists: mem[i][j] and mem[0][k] can denote the same
     // element when i == 0 and j == k. Region::may_alias already says these
     // bounded regions overlap, so the graph must preserve that realizable SCC.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "overlapping dynamic prefixes retain realizable feedback",
         r#"
         module Top (
@@ -10323,7 +10323,7 @@ fn combinational_loop_review_aliases_overlapping_unknown_regions() {
 
     // Why this control exists: statically disjoint row one cannot alias row
     // zero, even though both have a dynamic suffix.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "disjoint dynamic prefixes remain independent",
         r#"
         module Top (
@@ -10347,11 +10347,11 @@ fn combinational_loop_review_aliases_overlapping_unknown_regions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_module_summary_positions() {
+fn comb_loop_preserves_module_summary_positions() {
     // Why this case exists: Child is a bitwise identity. child_o[1] is driven
     // by the constant child_i[1], so feeding it to child_i[0] is acyclic.
     // A module summary must not collapse the identity into an all-to-all edge.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector identity module preserves disjoint bit positions",
         r#"
         module Child (
@@ -10379,7 +10379,7 @@ fn combinational_loop_review_preserves_module_summary_positions() {
 
     // Why this control exists: returning child_o[0] to its corresponding
     // child_i[0] is a real same-bit loop across the instance boundary.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector identity module retains same-bit feedback",
         r#"
         module Child (
@@ -10407,11 +10407,11 @@ fn combinational_loop_review_preserves_module_summary_positions() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_instance_output_address_dependency() {
+fn comb_loop_instance_output_address_contributes_dependency() {
     // Why this case exists: idx selects the instance output destination and
     // is itself read from one candidate destination. This is the same address
     // feedback already detected for a procedural bus[idx] assignment.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a dynamic instance output retains address feedback",
         r#"
         module Child (
@@ -10439,11 +10439,11 @@ fn combinational_loop_review_keeps_instance_output_address_dependency() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_dependency_free_function_write() {
+fn comb_loop_function_write_without_value_dependency_is_recorded() {
     // Why this case exists: clear_x writes x even though the written value has
     // no signal dependency. That write kills LiveOnEntry before o reads x;
     // omitting it invents x -> o -> x feedback.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a constant captured function write participates in procedural order",
         r#"
         module Top (
@@ -10465,11 +10465,11 @@ fn combinational_loop_review_keeps_dependency_free_function_write() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_observer_function_side_effect() {
+fn comb_loop_observer_function_side_effect_is_recorded() {
     // Why this case exists: IEEE 1800-2023 11.3.5 preserves side effects of
     // evaluated expressions. touch(o) is evaluated as a display argument, and
     // 9.2.2.2 makes its captured x write part of the always_comb procedure.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a display argument retains a called function global write",
         r#"
         module Top (
@@ -10495,11 +10495,11 @@ fn combinational_loop_review_keeps_observer_function_side_effect() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_instance_actual_function_side_effect() {
+fn comb_loop_instance_actual_function_side_effect_is_recorded() {
     // Why this case exists: IEEE 1800-2023 4.9.6 models an input connection as
     // an implicit continuous assignment. Its actual expression is evaluated
     // even when the child has no output feedthrough, so touch(o) still writes x.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance input actual retains a called function global write",
         r#"
         module Sink (
@@ -10526,11 +10526,11 @@ fn combinational_loop_review_keeps_instance_actual_function_side_effect() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_instance_selector_function_side_effect() {
+fn comb_loop_instance_input_selector_side_effect_is_recorded() {
     // Why this case exists: an otherwise plain instance actual still evaluates
     // the expressions in its selectors. Skipping the observer for mem[touch(o)]
     // would lose touch's module-scope write and hide the x -> o -> x cycle.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance input selector retains a called function global write",
         r#"
         module Sink (
@@ -10558,11 +10558,11 @@ fn combinational_loop_review_keeps_instance_selector_function_side_effect() {
 }
 
 #[test]
-fn combinational_loop_review_keeps_instance_output_selector_function_side_effect() {
+fn comb_loop_instance_output_selector_side_effect_is_recorded() {
     // Why this case exists: an output connection evaluates the selector in its
     // destination. The observer must retain touch(o)'s module-scope write even
     // though the child output value itself is constant.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance output selector retains a called function global write",
         r#"
         module Source (
@@ -10592,10 +10592,10 @@ fn combinational_loop_review_keeps_instance_output_selector_function_side_effect
 }
 
 #[test]
-fn combinational_loop_review_preserves_vector_function_output_bits() {
+fn comb_loop_preserves_vector_function_output_bits() {
     // Why this case exists: output argument y is a vector identity of x.
     // Broadcasting all x bits to all y bits invents value[1] -> o[0] feedback.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector function output argument preserves bit identity",
         r#"
         module Top (
@@ -10620,10 +10620,10 @@ fn combinational_loop_review_preserves_vector_function_output_bits() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_split_function_return_bits() {
+fn comb_loop_preserves_split_function_return_bits() {
     // Why this case exists: {high, low}[0] is low. Returning o[0] to high is
     // acyclic when low is constant, even though the return uses two regions.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated function return preserves each source bit",
         r#"
         module Top (
@@ -10647,7 +10647,7 @@ fn combinational_loop_review_preserves_split_function_return_bits() {
 }
 
 #[test]
-fn combinational_loop_review_distinguishes_generic_function_specializations() {
+fn comb_loop_distinguishes_generic_function_specializations() {
     // Why this case exists: recurse::<2> and recurse::<1> are distinct finite
     // specializations. Elaboration reduces the call to passed = feedback, so
     // treating the second specialization as infinite recursion hides a real SCC.
@@ -10684,10 +10684,10 @@ fn combinational_loop_review_distinguishes_generic_function_specializations() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_repeat_concatenation_positions() {
+fn comb_loop_preserves_repeat_concatenation_positions() {
     // Why this case exists: {value repeat 2} is {value, value}, so o[0]
     // depends only on value[0]. Broadcasting value[1] to o[0] invents a loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "repeat concatenation keeps a disjoint low-bit path loop-free",
         r#"
         module Top (
@@ -10704,7 +10704,7 @@ fn combinational_loop_review_preserves_repeat_concatenation_positions() {
 
     // Why this control exists: feeding o[0] back to value[0] selects the
     // corresponding repeated bit and therefore is a real structural SCC.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "repeat concatenation still detects a corresponding-bit loop",
         r#"
         module Top (
@@ -10721,10 +10721,10 @@ fn combinational_loop_review_preserves_repeat_concatenation_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_instance_shift_positions() {
+fn comb_loop_preserves_instance_shift_positions() {
     // Why this case exists: (value << 1)[0] is an inserted constant zero.
     // Falling back to every operand creates a fictitious value[1] path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance actual left shift keeps its inserted bit loop-free",
         r#"
         module Child (
@@ -10753,7 +10753,7 @@ fn combinational_loop_review_preserves_instance_shift_positions() {
 
     // Why this control exists: passed[1] is value[0], so feeding it back to
     // value[0] is the corresponding shifted-bit SCC and must remain detected.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance actual left shift detects its live shifted bit",
         r#"
         module Child (
@@ -10781,10 +10781,10 @@ fn combinational_loop_review_preserves_instance_shift_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_instance_repeat_positions() {
+fn comb_loop_preserves_instance_repeat_positions() {
     // Why this case exists: {high repeat 2, low}[2] is high. Treating every
     // operand as a source invents a low -> child_o -> low feedback path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance repeat actual keeps an unrelated operand loop-free",
         r#"
         module Child (
@@ -10813,7 +10813,7 @@ fn combinational_loop_review_preserves_instance_repeat_positions() {
 
     // Why this control exists: feeding child_o back to high closes the actual
     // i[2] path and must remain a real loop after positional mapping.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance repeat actual detects its selected repeated operand",
         r#"
         module Child (
@@ -10842,11 +10842,11 @@ fn combinational_loop_review_preserves_instance_repeat_positions() {
 }
 
 #[test]
-fn combinational_loop_review_distinguishes_generic_module_specializations() {
+fn comb_loop_distinguishes_generic_module_specializations() {
     // Why this case exists: ENABLE: 1 elaborates Child into an identity even
     // though its declaration default is zero. Reusing the default summary for
     // the specialization hides the real feedback through this instance.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an enabled generic-module specialization retains its feedthrough",
         r#"
         module Child #(
@@ -10881,7 +10881,7 @@ fn combinational_loop_review_distinguishes_generic_module_specializations() {
 
     // Why this control exists: ENABLE: 0 elaborates the output to a constant
     // even though the declaration default is one, so there is no return path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a disabled generic-module specialization does not inherit feedthrough",
         r#"
         module Child #(
@@ -10916,11 +10916,11 @@ fn combinational_loop_review_distinguishes_generic_module_specializations() {
 }
 
 #[test]
-fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
+fn comb_loop_short_circuits_instance_actual_side_effects() {
     // Why this case exists: IEEE 1800-2023 11.4.11 evaluates only the selected
     // ternary branch. touch(o) is in the constant-dead branch, so it cannot
     // write x or form an o -> x -> o feedback path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a constant-dead instance actual branch has no function side effect",
         r#"
         module Sink (
@@ -10947,7 +10947,7 @@ fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
 
     // Why this control exists: choosing the touch branch evaluates the call,
     // so its captured write closes the real o -> x -> o path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a constant-taken instance actual branch retains its function side effect",
         r#"
         module Sink (
@@ -10974,9 +10974,9 @@ fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
 }
 
 #[test]
-fn combinational_loop_review_short_circuits_logical_rhs_side_effects() {
+fn comb_loop_short_circuits_logical_rhs_side_effects() {
     let case = |name: &str, expression: &str, expected: bool| {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -11033,9 +11033,9 @@ fn combinational_loop_review_short_circuits_logical_rhs_side_effects() {
 }
 
 #[test]
-fn combinational_loop_review_short_circuits_instance_logical_actuals() {
+fn comb_loop_short_circuits_instance_logical_actuals() {
     let case = |name: &str, expression: &str, expected: bool| {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -11092,11 +11092,11 @@ fn combinational_loop_review_short_circuits_instance_logical_actuals() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
+fn comb_loop_preserves_nested_vector_ternary_positions() {
     // Why this case exists: bitwise negation does not change bit positions.
     // The nested ternary still maps o[0] only from value[0] (or a constant),
     // so broadcasting value[1] through the outer unary operator is fictitious.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a nested vector ternary keeps a disjoint bit loop-free",
         r#"
         module Top (
@@ -11114,7 +11114,7 @@ fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
 
     // Why this control exists: feeding o[0] back to its corresponding
     // value[0] closes a real path through both ternary and negation.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a nested vector ternary detects its corresponding-bit loop",
         r#"
         module Top (
@@ -11132,11 +11132,11 @@ fn combinational_loop_review_preserves_nested_vector_ternary_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
+fn comb_loop_preserves_ternary_positions_across_boundaries() {
     // Why this case exists: low reads only bit zero of its formal. A ternary
     // actual preserves that bit position, so feedback into value[1] is
     // disjoint even when the mapping crosses a function-call boundary.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a function ternary actual keeps a disjoint bit loop-free",
         r#"
         module Top (
@@ -11159,7 +11159,7 @@ fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
 
     // Why this control exists: returning the selected bit to value[0] closes
     // the function actual's real corresponding-bit path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a function ternary actual detects its corresponding-bit loop",
         r#"
         module Top (
@@ -11182,7 +11182,7 @@ fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
 
     // Why this case exists: the same positional rule must survive a module
     // port boundary; child output o depends only on actual bit zero.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance ternary actual keeps a disjoint bit loop-free",
         r#"
         module Low (
@@ -11211,7 +11211,7 @@ fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
 
     // Why this control exists: feeding the child result back to actual bit
     // zero is a real loop through the instance boundary.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance ternary actual detects its corresponding-bit loop",
         r#"
         module Low (
@@ -11240,11 +11240,11 @@ fn combinational_loop_review_preserves_ternary_positions_across_boundaries() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_unpacked_port_element_positions() {
+fn comb_loop_preserves_unpacked_port_element_positions() {
     // Why this case exists: Child is an element-wise identity over an unpacked
     // array. Returning child_o[1] to child_i[0] crosses distinct elements and
     // must not be widened to whole-array feedback at the instance boundary.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an unpacked-array module port keeps disjoint elements loop-free",
         r#"
         module Child (
@@ -11273,7 +11273,7 @@ fn combinational_loop_review_preserves_unpacked_port_element_positions() {
 
     // Why this control exists: returning child_o[0] to the corresponding
     // child_i[0] element is a real instance-boundary SCC.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an unpacked-array module port detects same-element feedback",
         r#"
         module Child (
@@ -11302,11 +11302,11 @@ fn combinational_loop_review_preserves_unpacked_port_element_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_unpacked_function_actual_positions() {
+fn comb_loop_preserves_unpacked_function_actual_positions() {
     // Why this case exists: high reads only unpacked element one. Feeding its
     // result to value[0] is element-disjoint and must not fall back to reading
     // the whole actual because packed width excludes the unpacked count.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an unpacked function actual keeps disjoint elements loop-free",
         r#"
         module Top (
@@ -11328,7 +11328,7 @@ fn combinational_loop_review_preserves_unpacked_function_actual_positions() {
 
     // Why this control exists: returning the function result to the same
     // value[1] element closes the real function-boundary loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an unpacked function actual detects same-element feedback",
         r#"
         module Top (
@@ -11350,10 +11350,10 @@ fn combinational_loop_review_preserves_unpacked_function_actual_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_local_right_shift_positions() {
+fn comb_loop_preserves_local_right_shift_positions() {
     // Why this case exists: (value >> 1)[3] is an inserted zero. Returning
     // that discarded high bit to value[0] cannot form feedback.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a local logical right shift keeps its inserted bit loop-free",
         r#"
         module Top (
@@ -11370,7 +11370,7 @@ fn combinational_loop_review_preserves_local_right_shift_positions() {
 
     // Why this control exists: o[0] is value[1], so feeding it back to
     // value[1] is the real shifted-bit SCC.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a local logical right shift detects its live shifted bit",
         r#"
         module Top (
@@ -11388,11 +11388,11 @@ fn combinational_loop_review_preserves_local_right_shift_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_arithmetic_right_shift_positions() {
+fn comb_loop_preserves_arithmetic_right_shift_positions() {
     // Why this case exists: for a one-bit arithmetic right shift, o[0] is
     // value[1]; discarded value[0] cannot influence it. Whole-vector fallback
     // invents value[0] -> o[0] feedback.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an arithmetic right shift keeps a discarded bit loop-free",
         r#"
         module Top (
@@ -11409,7 +11409,7 @@ fn combinational_loop_review_preserves_arithmetic_right_shift_positions() {
 
     // Why this control exists: o[0] is the live source value[1], so returning
     // it to value[1] is a real shifted-bit SCC.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an arithmetic right shift detects its live shifted bit",
         r#"
         module Top (
@@ -11427,7 +11427,7 @@ fn combinational_loop_review_preserves_arithmetic_right_shift_positions() {
 
     // Why this control exists: the vacated MSB is a replication of the sign
     // bit, so sign feedback remains a real (non-positional) dependency.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an arithmetic right shift retains sign-fill feedback",
         r#"
         module Top (
@@ -11444,10 +11444,10 @@ fn combinational_loop_review_preserves_arithmetic_right_shift_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_function_actual_shift_positions() {
+fn comb_loop_preserves_function_actual_shift_positions() {
     // Why this case exists: (value << 1)[0] is an inserted zero. Passing the
     // shifted vector through a function must not broadcast value[1] to o.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a function actual left shift keeps its inserted bit loop-free",
         r#"
         module Top (
@@ -11470,7 +11470,7 @@ fn combinational_loop_review_preserves_function_actual_shift_positions() {
 
     // Why this control exists: shifted bit one is value[0], so returning it to
     // value[0] is a real corresponding-bit loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a function actual left shift detects its live shifted bit",
         r#"
         module Top (
@@ -11492,10 +11492,10 @@ fn combinational_loop_review_preserves_function_actual_shift_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_vector_ternary_positions() {
+fn comb_loop_preserves_vector_ternary_positions() {
     // Why this case exists: both branches preserve vector bit positions, so
     // o[0] can read only value[0] (or the constant), never value[1].
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector ternary keeps a disjoint bit loop-free",
         r#"
         module Top (
@@ -11513,7 +11513,7 @@ fn combinational_loop_review_preserves_vector_ternary_positions() {
 
     // Why this control exists: returning o[0] to value[0] closes the selected
     // branch's real same-bit path and must remain detected.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a vector ternary detects its corresponding-bit loop",
         r#"
         module Top (
@@ -11531,11 +11531,11 @@ fn combinational_loop_review_preserves_vector_ternary_positions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_function_concat_output_positions() {
+fn comb_loop_preserves_function_concat_output_positions() {
     // Why this case exists: y = x copied into {o[1], o[0]} still maps x[0]
     // only to o[0]. Treating the concatenated output actual as all-to-all
     // invents value[1] -> o[0] feedback.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated function output keeps a disjoint bit loop-free",
         r#"
         module Top (
@@ -11560,7 +11560,7 @@ fn combinational_loop_review_preserves_function_concat_output_positions() {
 
     // Why this control exists: value[0] copied to o[0] and fed back to the
     // same bit is a real loop through the concatenated output destination.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated function output detects its corresponding-bit loop",
         r#"
         module Top (
@@ -11585,9 +11585,9 @@ fn combinational_loop_review_preserves_function_concat_output_positions() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_celox_regression_corpus() {
+fn comb_loop_statement_order_and_control_flow_regressions() {
     // Ported from celox/tests/basic.rs::test_always_comb_read_before_write_uses_previous_value.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "read before write observes LiveOnEntry",
         r#"
         module Top (
@@ -11605,7 +11605,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
     );
 
     // Ported from celox/tests/false_loop.rs::test_cross_bit_dependency_false_loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "opposite directions on disjoint bits",
         r#"
         module Top (
@@ -11627,7 +11627,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
     );
 
     // Ported from the multi-stage observer cases in celox/tests/comb_observer.rs.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "observer in a writer with a multi-stage assign chain",
         r#"
         module Top (
@@ -11649,7 +11649,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
     );
 
     // Ported from the case/if matrix in celox/tests/case_switch.rs.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "case phi with complete definitions",
         r#"
         module Top (
@@ -11673,7 +11673,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
     );
 
     // Ported from the indexed-local and partial-write function tests in basic.rs.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function local partial writes are ordered",
         r#"
         module Top (
@@ -11694,7 +11694,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "one branch keeps an entry definition live",
         r#"
         module Top (
@@ -11712,7 +11712,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "case without a covering default keeps entry live",
         r#"
         module Top (
@@ -11731,7 +11731,7 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "nested function summary preserves a real cycle",
         r#"
         module Top (
@@ -11751,8 +11751,8 @@ fn combinational_loop_memory_ssa_celox_regression_corpus() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
-    assert_comb_loop_for_case(
+fn comb_loop_region_and_function_mapping_regressions() {
+    assert_comb_loop(
         "blocking assignment chain uses the immediately preceding definition",
         r#"
         module Top (
@@ -11771,7 +11771,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a later full overwrite kills an earlier partial entry read",
         r#"
         module Top (
@@ -11786,7 +11786,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a full overwrite dominates a later partial read",
         r#"
         module Top (
@@ -11801,7 +11801,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "both branch arms define the value consumed after the merge",
         r#"
         module Top (
@@ -11824,7 +11824,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function local copy retains bit precision at the return",
         r#"
         module Top (
@@ -11844,7 +11844,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function branch condition is a control dependency of its return",
         r#"
         module Top (
@@ -11866,7 +11866,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function branch ignores a bit absent from value and control flow",
         r#"
         module Top (
@@ -11889,7 +11889,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function output writeback participates in procedural order",
         r#"
         module Top (
@@ -11911,7 +11911,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "static array elements remain distinct regions",
         r#"
         module Top (
@@ -11929,7 +11929,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "read-before-write across static array elements is a real loop",
         r#"
         module Top (
@@ -11946,7 +11946,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "static struct members remain distinct regions",
         r#"
         module Top (
@@ -11968,7 +11968,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "sparse accesses do not scale with a huge declared width",
         r#"
         module Top (
@@ -11985,7 +11985,7 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "dynamic same-object aliasing uses the whole longest static prefix",
         r#"
         module Top (
@@ -12004,8 +12004,8 @@ fn combinational_loop_memory_ssa_extended_celox_regression_corpus() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
-    assert_comb_loop_for_case(
+fn comb_loop_alias_and_opaque_effect_boundaries() {
+    assert_comb_loop(
         "function bit-select must not taint a disjoint actual bit",
         r#"
         module Top (
@@ -12024,7 +12024,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function bit-select must retain same-bit feedback",
         r#"
         module Top (
@@ -12042,7 +12042,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function bit-select through concatenation ignores high operands",
         r#"
         module Top (
@@ -12060,7 +12060,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function bit-select through concatenation retains low operand",
         r#"
         module Top (
@@ -12075,7 +12075,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function bit-select through an actual slice uses its low bit",
         r#"
         module Top (
@@ -12093,7 +12093,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function bit-select through an actual slice retains its low-bit feedback",
         r#"
         module Top (
@@ -12112,7 +12112,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "function region crossing a concatenation boundary retains both operands",
         r#"
         module Top (
@@ -12132,7 +12132,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "local copy chains propagate bit identity through every hop",
         r#"
         module Top (
@@ -12154,7 +12154,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "local concatenation does not taint a constant low bit",
         r#"
         module Top (
@@ -12174,7 +12174,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "local concatenation retains a signal low bit",
         r#"
         module Top (
@@ -12191,7 +12191,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "same-width bitwise operators preserve positional provenance",
         r#"
         module Top (
@@ -12211,7 +12211,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "same-width bitwise operators retain same-bit feedback",
         r#"
         module Top (
@@ -12231,7 +12231,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "structural dependence is not removed by Boolean cancellation",
         r#"
         module Top (
@@ -12251,7 +12251,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "reduction operators remain dependent on every operand bit",
         r#"
         module Top (
@@ -12272,7 +12272,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
     // Four-state arithmetic remains whole-expression dependent: an X/Z in a
     // high operand bit can make the entire arithmetic result unknown. A
     // future two-state transfer may be narrower, but must not leak into logic.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "four-state arithmetic depends on every operand bit",
         r#"
         module Top (
@@ -12292,7 +12292,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "dynamic observer must not hide an unrelated proven loop",
         r#"
         module Top (
@@ -12309,7 +12309,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "dynamic write to one object must not hide another object's loop",
         r#"
         module Top (
@@ -12327,7 +12327,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "dominating full write kills partial branch feedback",
         r#"
         module Top (
@@ -12347,7 +12347,7 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "phi on one bit cannot manufacture a cross-bit cycle",
         r#"
         module Top (
@@ -12371,8 +12371,8 @@ fn combinational_loop_memory_ssa_adversarial_alias_and_effect_boundaries() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_malicious_structural_cases() {
-    assert_comb_loop_for_case(
+fn comb_loop_structural_dependency_semantics() {
+    assert_comb_loop(
         "dynamic same-index read/write is structurally self-dependent",
         r#"
         module Top (
@@ -12389,7 +12389,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "dynamic data write without an old-value read is feed-forward",
         r#"
         module Top (
@@ -12407,7 +12407,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a value controlling its own dynamic write address closes a loop",
         r#"
         module Top (
@@ -12426,7 +12426,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "identical ternary arms do not cancel structural control dependence",
         r#"
         module Top (
@@ -12438,7 +12438,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "duplicate xor operands remain structural inputs",
         r#"
         module Top (
@@ -12450,7 +12450,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "read-before-write across disjoint nibbles is acyclic without a return path",
         r#"
         module Top (
@@ -12465,7 +12465,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "overlapping left shift is a directed acyclic bit chain",
         r#"
         module Top (
@@ -12480,7 +12480,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "adding the wraparound bit turns a shift into a structural rotate loop",
         r#"
         module Top (
@@ -12495,7 +12495,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "concatenation permutation preserves structural feedback",
         r#"
         module Top (
@@ -12509,7 +12509,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "complete overwrite after a rotate-shaped dead store kills the loop",
         r#"
         module Top (
@@ -12524,7 +12524,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "identical function branches retain structural condition dependence",
         r#"
         module Top (
@@ -12543,7 +12543,7 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "observer-only duplicate reads do not manufacture value feedback",
         r#"
         module Top (
@@ -12561,8 +12561,8 @@ fn combinational_loop_memory_ssa_malicious_structural_cases() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
-    assert_comb_loop_for_case(
+fn comb_loop_dynamic_write_kill_semantics() {
+    assert_comb_loop(
         "a full write after a dynamic self-store kills the dead feedback",
         r#"
         module Top (
@@ -12578,7 +12578,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a dominating full write kills a later dynamic read of the old value",
         r#"
         module Top (
@@ -12594,7 +12594,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an unrelated exact bit write cannot kill dynamic feedback",
         r#"
         module Top (
@@ -12610,7 +12610,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "all branch exits overwriting the object kill earlier dynamic feedback",
         r#"
         module Top (
@@ -12631,7 +12631,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "one branch preserving a dynamic self-store preserves feedback",
         r#"
         module Top (
@@ -12650,7 +12650,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "dynamic writes to separate objects do not alias",
         r#"
         module Top (
@@ -12671,7 +12671,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "two object-local dynamic aliases can close a cross-object cycle",
         r#"
         module Top (
@@ -12691,7 +12691,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a dominating value write also kills a self-derived dynamic address",
         r#"
         module Top (
@@ -12707,7 +12707,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an undominated value driving its own dynamic address is feedback",
         r#"
         module Top (
@@ -12724,8 +12724,8 @@ fn combinational_loop_memory_ssa_malicious_dynamic_kill_cases() {
 }
 
 #[test]
-fn combinational_loop_memory_ssa_malicious_dynamic_domain_cases() {
-    assert_comb_loop_for_case(
+fn comb_loop_dynamic_select_alias_domain() {
+    assert_comb_loop(
         "a dynamic select aliases its whole longest static prefix",
         r#"
         module Top (
@@ -12743,7 +12743,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_domain_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a one-bit dynamic domain still aliases both representable bits",
         r#"
         module Top (
@@ -12758,7 +12758,7 @@ fn combinational_loop_memory_ssa_malicious_dynamic_domain_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a representable dynamic target can close a cycle through a high bit",
         r#"
         module Top (
@@ -12776,8 +12776,8 @@ fn combinational_loop_memory_ssa_malicious_dynamic_domain_cases() {
 }
 
 #[test]
-fn combinational_loop_malicious_module_boundary_cases() {
-    assert_comb_loop_for_case(
+fn comb_loop_module_boundary_region_mapping() {
+    assert_comb_loop(
         "a child port summary must not turn bit-disjoint feedthrough into a loop",
         r#"
         module Child (
@@ -12805,7 +12805,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a region-preserving child feedthrough still reports a real loop",
         r#"
         module Child (
@@ -12833,7 +12833,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an opaque SystemVerilog component cannot prove a hard loop",
         r#"
         module Top (
@@ -12852,7 +12852,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a top input-to-output path has no inferred environment return edge",
         r#"
         module Top (
@@ -12865,7 +12865,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "bit precision survives two module boundaries",
         r#"
         module Leaf (
@@ -12903,7 +12903,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a real loop survives two region-preserving summaries",
         r#"
         module Leaf (
@@ -12941,7 +12941,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated instance input preserves its low-bit source",
         r#"
         module Child (
@@ -12969,7 +12969,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         false,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a concatenated instance input does not hide a real low-bit loop",
         r#"
         module Child (
@@ -12997,7 +12997,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
         true,
     );
 
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a static slice connection does not contaminate its sibling bit",
         r#"
         module Child (
@@ -13024,7 +13024,7 @@ fn combinational_loop_malicious_module_boundary_cases() {
 }
 
 #[test]
-fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
+fn comb_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
     let external = analyze_comb_detailed(
         r#"
         module Top (
@@ -13258,7 +13258,7 @@ fn combinational_loop_opaque_boundaries_are_incomplete_without_hard_errors() {
 }
 
 #[test]
-fn combinational_loop_incomplete_effect_does_not_erase_proven_edges() {
+fn comb_loop_incomplete_effect_does_not_erase_proven_edges() {
     // Why this case exists: a nonconstant bound prevents frontend unrolling,
     // so the causal adapter must retain RuntimeLoop coverage provenance. That
     // uncertainty must not discard an independent, exact dependency from the
@@ -13307,7 +13307,7 @@ fn combinational_loop_incomplete_effect_does_not_erase_proven_edges() {
 }
 
 #[test]
-fn combinational_loop_diagnostic_uses_exact_minimal_assignment_witness() {
+fn comb_loop_diagnostic_uses_short_assignment_cycle_witness() {
     // Why this case exists: all four variables belong to one maximal SCC, and
     // `a` has two reaching assignments in different branches. The actionable
     // witness is the short a/b cycle; reporting a=d, c=b, or d=c would expose
@@ -13376,7 +13376,7 @@ fn combinational_loop_diagnostic_uses_exact_minimal_assignment_witness() {
 }
 
 #[test]
-fn combinational_loop_runtime_zero_trip_retention_is_not_feedback() {
+fn comb_loop_dynamic_loop_zero_trip_retention_is_not_feedback() {
     // Why this case exists: a runtime loop can execute zero times. The value
     // retained on that path infers state, but it is not a same-evaluation read
     // from `held` and therefore must not become a combinational self-loop.
@@ -13400,7 +13400,7 @@ fn combinational_loop_runtime_zero_trip_retention_is_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_dynamic_element_retention_is_not_feedback() {
+fn comb_loop_dynamic_element_retention_is_not_feedback() {
     // Why this case exists: one dynamic element write leaves every other
     // candidate element unchanged. May-write coverage must not masquerade as
     // must-write coverage, and the preserved elements are latch state rather
@@ -13423,7 +13423,7 @@ fn combinational_loop_dynamic_element_retention_is_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_oversized_dynamic_retention_is_sparse_and_not_feedback() {
+fn comb_loop_oversized_dynamic_retention_is_sparse_and_not_feedback() {
     // Why this case exists: the legacy assignment table skips arrays above its
     // enumeration limit. Retention coverage must stay declaration-width
     // independent instead of either disappearing or expanding 131072 elements,
@@ -13446,7 +13446,7 @@ fn combinational_loop_oversized_dynamic_retention_is_sparse_and_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_missing_if_arm_retention_is_not_feedback() {
+fn comb_loop_missing_if_arm_retention_is_not_feedback() {
     // Why this case exists: the existing uncovered-branch checker already
     // identifies this latch. The causal graph must not add a second and
     // semantically incorrect combinational-loop diagnosis for the same
@@ -13471,7 +13471,7 @@ fn combinational_loop_missing_if_arm_retention_is_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_missing_switch_default_retention_is_not_feedback() {
+fn comb_loop_missing_switch_default_retention_is_not_feedback() {
     // Why this case exists: n-way control flow reaches the same entry-state
     // phi as an uncovered if. Missing-default retention must receive the same
     // latch diagnosis without being reclassified as combinational feedback.
@@ -13495,7 +13495,7 @@ fn combinational_loop_missing_switch_default_retention_is_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_retention_does_not_hide_cross_variable_feedback() {
+fn comb_loop_retention_does_not_hide_cross_variable_feedback() {
     // Why this case exists: retention itself is diagnosed as incomplete
     // assignment, but it must not erase the explicit held -> o -> enable
     // value/control dependencies. Those dependencies form proven structural
@@ -13532,7 +13532,7 @@ fn combinational_loop_retention_does_not_hide_cross_variable_feedback() {
 }
 
 #[test]
-fn combinational_loop_explicit_self_read_remains_feedback() {
+fn comb_loop_explicit_self_read_remains_feedback() {
     // Why this case exists: removing entry-state retention edges wholesale
     // would also hide a real source read. The fix must distinguish an implicit
     // preserve path from the explicit `value = value` dependency.
@@ -13558,7 +13558,7 @@ fn combinational_loop_explicit_self_read_remains_feedback() {
 }
 
 #[test]
-fn combinational_loop_default_before_runtime_loop_kills_retention() {
+fn comb_loop_default_before_dynamic_loop_kills_retention() {
     // Why this case exists: a dominating full assignment removes the entry
     // state before a possibly-zero-trip loop. This is the positive control for
     // both coverage and loop analysis and must remain diagnostic-free.
@@ -13586,7 +13586,7 @@ fn combinational_loop_default_before_runtime_loop_kills_retention() {
 }
 
 #[test]
-fn combinational_loop_full_write_after_runtime_loop_kills_retention() {
+fn comb_loop_full_write_after_dynamic_loop_kills_retention() {
     // Why this case exists: incomplete-assignment coverage is a property of
     // the procedure exit, not of an intermediate statement. A later full
     // write kills the zero-trip entry value left by the runtime loop.
@@ -13614,7 +13614,7 @@ fn combinational_loop_full_write_after_runtime_loop_kills_retention() {
 }
 
 #[test]
-fn combinational_loop_nonempty_runtime_form_loop_has_no_zero_trip_path() {
+fn comb_loop_nonempty_const_loop_has_no_zero_trip_path() {
     // Why this case exists: `break` keeps a constant loop in runtime-form IR,
     // but 0..1 still enters its body exactly once. Runtime representation does
     // not by itself imply that a zero-trip path is reachable.
@@ -13641,7 +13641,7 @@ fn combinational_loop_nonempty_runtime_form_loop_has_no_zero_trip_path() {
 }
 
 #[test]
-fn combinational_loop_empty_runtime_form_loop_has_no_body_path() {
+fn comb_loop_empty_const_loop_has_no_body_path() {
     // Why this case exists: `break` keeps this const-evaluable empty range in
     // runtime-form IR, but its body is still unreachable. Treating "empty" as
     // merely "possibly empty" invents both a write and a hard cycle.
@@ -13673,7 +13673,7 @@ fn combinational_loop_empty_runtime_form_loop_has_no_body_path() {
 }
 
 #[test]
-fn combinational_loop_break_before_write_retains_coverage() {
+fn comb_loop_break_before_write_retains_coverage() {
     // Why this case exists: a const singleton loop is guaranteed to enter its
     // body, but a conditional break can still bypass a later assignment. The
     // missed write is a coverage error, not a zero-trip path or comb feedback.
@@ -13700,7 +13700,7 @@ fn combinational_loop_break_before_write_retains_coverage() {
 }
 
 #[test]
-fn combinational_loop_runtime_form_cardinality_variants() {
+fn comb_loop_const_range_forms_preserve_cardinality() {
     // Why this case exists: inclusive, reverse, and stepped ranges share the
     // same source-level cardinality rules even when break prevents unrolling.
     // Singleton bodies have an early-break coverage path; empty bodies have no
@@ -13760,11 +13760,11 @@ fn combinational_loop_runtime_form_cardinality_variants() {
 }
 
 #[test]
-fn combinational_loop_runtime_form_iterator_constants_prune_dead_edges() {
+fn comb_loop_const_iterator_prunes_dead_if_edges() {
     // Why this case exists: break keeps the singleton loop in runtime-form IR,
     // but its sole iterator value is still the constant 1. The unreachable
     // i==0 assignment must not create a stronger-than-SV a -> b -> a loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a runtime-form singleton retains its iterator constant",
         r#"
         module Top (
@@ -13791,12 +13791,12 @@ fn combinational_loop_runtime_form_iterator_constants_prune_dead_edges() {
 }
 
 #[test]
-fn combinational_loop_runtime_form_iterator_constants_prune_dead_case_arms() {
+fn comb_loop_const_iterator_prunes_dead_case_arms() {
     // Why this case exists: case selection uses the same per-iteration SV
     // value as if selection. A dead i==0 arm in a singleton i==1 loop cannot
     // contribute a hard dependency merely because break prevented frontend
     // unrolling.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a runtime-form singleton prunes dead case arms",
         r#"
         module Top (
@@ -13822,7 +13822,7 @@ fn combinational_loop_runtime_form_iterator_constants_prune_dead_case_arms() {
 }
 
 #[test]
-fn combinational_loop_over_limit_const_loop_does_not_prove_dead_edges() {
+fn comb_loop_over_limit_const_loop_does_not_prove_dead_edges() {
     // Why this case exists: the same const iterator semantics apply above the
     // compiler's expansion limit. If exact bounded lowering is deliberately
     // skipped, its approximation is incomplete and cannot become a hard loop.
@@ -13857,7 +13857,7 @@ fn combinational_loop_over_limit_const_loop_does_not_prove_dead_edges() {
 }
 
 #[test]
-fn combinational_loop_runtime_form_iterator_constants_preserve_must_write() {
+fn comb_loop_const_iterator_preserves_must_write_paths() {
     // Why this case exists: the two const iterations are i=0 and i=1, and the
     // only reachable break follows the i=1 assignment. Every exit is covered;
     // collapsing both iterations into one unknown body invents retention.
@@ -13889,7 +13889,7 @@ fn combinational_loop_runtime_form_iterator_constants_preserve_must_write() {
 }
 
 #[test]
-fn combinational_loop_singleton_break_is_not_runtime_incomplete() {
+fn comb_loop_singleton_break_is_fully_analyzed() {
     // Why this case exists: break makes this const singleton use the compact
     // runtime-form CFG, but there is no loop backedge and therefore no
     // RuntimeLoop uncertainty to expose through check_detailed.
@@ -13918,7 +13918,7 @@ fn combinational_loop_singleton_break_is_not_runtime_incomplete() {
 }
 
 #[test]
-fn combinational_loop_finite_runtime_form_recurrence_is_not_feedback() {
+fn comb_loop_seeded_finite_recurrence_is_feed_forward() {
     // Why this case exists: a conditional break keeps a finite const loop in
     // runtime-form IR. Its loop-carried value is a bounded combinational chain
     // rooted at the dominating default, not an unbounded graph backedge.
@@ -13949,11 +13949,11 @@ fn combinational_loop_finite_runtime_form_recurrence_is_not_feedback() {
 }
 
 #[test]
-fn combinational_loop_finite_runtime_form_explicit_self_read_is_feedback() {
+fn comb_loop_unseeded_finite_recurrence_is_feedback() {
     // Why this case exists: bounded lowering must remove only loop-carried
     // pseudo-feedback. Without a dominating seed, the first iteration's
     // explicit value read still forms real combinational self-feedback.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a finite runtime-form loop retains its first explicit self-read",
         r#"
         module Top (
@@ -13977,7 +13977,7 @@ fn combinational_loop_finite_runtime_form_explicit_self_read_is_feedback() {
 }
 
 #[test]
-fn combinational_loop_function_output_weak_write_retains_coverage() {
+fn comb_loop_function_output_weak_write_retains_coverage() {
     // Why this case exists: a function output argument is copied back to its
     // caller, but a dynamic write inside the function still leaves unselected
     // packed bits without a definition. Function summarization must preserve
@@ -14006,7 +14006,7 @@ fn combinational_loop_function_output_weak_write_retains_coverage() {
 }
 
 #[test]
-fn combinational_loop_function_capture_coverage_obeys_caller_order() {
+fn comb_loop_function_capture_coverage_obeys_caller_order() {
     // Why this case exists: a function's module-scope write is part of its
     // caller procedure. A dominating default or a later full write supplies
     // every preserved bit, so function-local weak-write coverage must not be
@@ -14039,7 +14039,7 @@ fn combinational_loop_function_capture_coverage_obeys_caller_order() {
 }
 
 #[test]
-fn combinational_loop_function_capture_without_default_retains_coverage() {
+fn comb_loop_function_capture_without_default_retains_coverage() {
     // Why this case exists: the caller-order kill controls above need a
     // positive control. Without a caller default, a captured dynamic write
     // still leaves unselected bits unassigned at the always_comb exit.
@@ -14066,7 +14066,7 @@ fn combinational_loop_function_capture_without_default_retains_coverage() {
 }
 
 #[test]
-fn combinational_loop_uncalled_function_still_checks_output_coverage() {
+fn comb_loop_uncalled_function_still_checks_output_coverage() {
     // Why this case exists: output-argument completeness is a property of the
     // function definition, not of whether an always_comb happens to call it.
     // A runtime loop may execute zero times and leave the output unassigned.
@@ -14091,7 +14091,7 @@ fn combinational_loop_uncalled_function_still_checks_output_coverage() {
 }
 
 #[test]
-fn combinational_loop_function_summary_fanout_is_memoized() {
+fn comb_loop_function_summary_fanout_is_memoized() {
     // Why this case exists: each function calls the previous specialization
     // twice, so per-call recursive analysis grows as 2^N. The source contains
     // only N unique function bodies and must be analyzed in O(N) summaries.
@@ -14134,7 +14134,7 @@ fn combinational_loop_function_summary_fanout_is_memoized() {
 }
 
 #[test]
-fn combinational_loop_rejected_periodic_run_is_scanned_once() {
+fn comb_loop_rejected_periodic_run_is_scanned_once() {
     // Why this case exists: a long run with one source but the same exact
     // destination is legal sequential overwrite, not a periodic transfer.
     // Rejecting the candidate must not sort every remaining suffix again.
@@ -14160,7 +14160,7 @@ fn combinational_loop_rejected_periodic_run_is_scanned_once() {
 }
 
 #[test]
-fn combinational_loop_malformed_effect_is_a_causal_barrier() {
+fn comb_loop_malformed_effect_is_a_causal_barrier() {
     // Why this case exists: a rejected statement may have unknown side
     // effects, so a cycle which crosses it is not proven. The malformed
     // procedure must not suppress a separate exact cycle in another procedure.
@@ -14200,7 +14200,7 @@ fn combinational_loop_malformed_effect_is_a_causal_barrier() {
 }
 
 #[test]
-fn combinational_loop_branch_weak_writes_share_one_coverage_diagnostic() {
+fn comb_loop_branch_weak_writes_share_one_coverage_diagnostic() {
     // Why this case exists: distinct weak writes can reach the same retained
     // object through different branches. Coverage reporting should present one
     // coherent variable diagnostic containing both assignment sites.
@@ -14245,7 +14245,7 @@ fn combinational_loop_branch_weak_writes_share_one_coverage_diagnostic() {
 }
 
 #[test]
-fn combinational_loop_dynamic_runtime_coverage_is_not_duplicated() {
+fn comb_loop_dynamic_loop_coverage_is_not_duplicated() {
     // Why this case exists: both legacy branch bookkeeping and MemorySSA can
     // observe the missing path inside a dynamic loop. Coverage ownership must
     // produce one warning rather than appending the same warning twice.
@@ -14279,7 +14279,7 @@ fn combinational_loop_dynamic_runtime_coverage_is_not_duplicated() {
 }
 
 #[test]
-fn combinational_loop_runtime_coverage_sites_stay_region_local() {
+fn comb_loop_dynamic_loop_coverage_sites_stay_region_local() {
     // Why this case exists: value[1] is fully defined even though it is also
     // written in a runtime loop. Its loop assignment must not be reported as a
     // covered site for the independently retained value[0].
@@ -14321,7 +14321,7 @@ fn combinational_loop_runtime_coverage_sites_stay_region_local() {
 }
 
 #[test]
-fn combinational_loop_captured_coverage_sites_stay_region_local() {
+fn comb_loop_captured_coverage_sites_stay_region_local() {
     // Why this case exists: function summary coverage is mapped back into the
     // caller one captured region at a time. A caller default for value[1] must
     // prevent that bit's function assignment from appearing in value[0]'s
@@ -14369,7 +14369,7 @@ fn combinational_loop_captured_coverage_sites_stay_region_local() {
 }
 
 #[test]
-fn comb_loop_ifstmt_feed_forward_array() {
+fn comb_loop_if_assignment_to_array_is_feed_forward() {
     // False positive: an always_comb for-loop over cross-coupled arrays that
     // reads index i and writes i+1 (a feed-forward / acyclic CORDIC-style
     // chain) written with an `if`/`else` STATEMENT was wrongly rejected. The
@@ -23308,7 +23308,7 @@ module M {
 }
 
 #[test]
-fn combinational_loop_review_preserves_context_width_extension_positions() {
+fn comb_loop_preserves_context_width_extension_positions() {
     // Why these cases exist: IEEE 1800-2023 11.8.2 zero-extends an unsigned
     // two-bit RHS to its four-bit assignment context. The new high bits are
     // constants, while the low-bit control remains a real feedback path.
@@ -23324,7 +23324,7 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23353,7 +23353,7 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
         ),
         ("signed extension retains its replicated sign bit", 1, true),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23375,7 +23375,7 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
     // Why this case exists: conditional operands are extended to the result
     // width before selection (11.4.11); the control dependency does not turn
     // an unsigned zero-fill bit into data feedthrough.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a ternary preserves unsigned zero extension",
         r#"
         module Top (
@@ -23393,7 +23393,7 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
 
     // Why these cases exist: formal argument coercion uses the same unsigned
     // extension at function and module boundaries; a high formal bit is zero.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a function formal high bit does not read an unsigned short actual",
         r#"
         module Top (
@@ -23412,7 +23412,7 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
         "#,
         false,
     );
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a module formal high bit does not read an unsigned short actual",
         r#"
         module High (
@@ -23438,7 +23438,7 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
 }
 
 #[test]
-fn combinational_loop_review_uses_structural_dynamic_selector_regions() {
+fn comb_loop_uses_structural_dynamic_selector_regions() {
     // Why these cases exist: a nonconstant selector is analyzed structurally
     // from its longest static prefix. The selector's runtime value domain does
     // not narrow the region, so `idx + 2` overlaps both elements zero and two.
@@ -23459,7 +23459,7 @@ fn combinational_loop_review_uses_structural_dynamic_selector_regions() {
             2 => "assign value[0] = 0; assign value[1] = 0; assign value[3] = 0;",
             _ => unreachable!(),
         };
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23498,7 +23498,7 @@ fn combinational_loop_review_uses_structural_dynamic_selector_regions() {
             3 => "assign value[0] = 0; assign value[1] = 0; assign value[2] = 0;",
             _ => unreachable!(),
         };
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23519,7 +23519,7 @@ fn combinational_loop_review_uses_structural_dynamic_selector_regions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_expression_coercions() {
+fn comb_loop_preserves_expression_coercions() {
     // Why these cases exist: both ternary operands are signed and four bits
     // wide after context sizing. Its high result bit depends only on the
     // two-bit value's sign bit, not on value[0].
@@ -23535,7 +23535,7 @@ fn combinational_loop_review_preserves_expression_coercions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23596,7 +23596,7 @@ fn combinational_loop_review_preserves_expression_coercions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23616,7 +23616,7 @@ fn combinational_loop_review_preserves_expression_coercions() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_assignment_pattern_positions() {
+fn comb_loop_preserves_assignment_pattern_positions() {
     // Why these cases exist: IEEE 1800-2023 10.9.2 evaluates each structure
     // constructor expression in the assignment context of its named member.
     // A dependency supplying `b` must not be widened to the unrelated `a`.
@@ -23632,7 +23632,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23667,7 +23667,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23719,7 +23719,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23781,7 +23781,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23827,7 +23827,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23859,7 +23859,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
     // Why this case exists: projecting only the constructor member consumed
     // as a value must not remove effects of a function called in another
     // member. The function writes `state`, closing a real loop through `o`.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a structure constructor retains effects from an unobserved member",
         r#"
         module Top (
@@ -23884,7 +23884,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
 
     // Why this case exists: a sparse query through a large replication should
     // inspect only the selected copy, not materialize every declared element.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a large array repeat remains sparse and bit-precise",
         r#"
         module Pick (
@@ -23913,7 +23913,7 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
 }
 
 #[test]
-fn combinational_loop_whole_unpacked_instance_is_sparse_and_precise() {
+fn comb_loop_whole_unpacked_instance_is_sparse_and_precise() {
     // Why these cases exist: a whole-array module connection must not create
     // one graph node per declared element. A sparse access far inside a
     // 200,000-element array still has to meet its positionally corresponding
@@ -23926,7 +23926,7 @@ fn combinational_loop_whole_unpacked_instance_is_sparse_and_precise() {
             false,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -23957,7 +23957,7 @@ fn combinational_loop_whole_unpacked_instance_is_sparse_and_precise() {
 }
 
 #[test]
-fn combinational_loop_periodic_repeat_is_sparse_and_phase_precise() {
+fn comb_loop_periodic_repeat_is_sparse_and_phase_precise() {
     // Why these cases exist: Veryl elaborates a succinct array repeat into one
     // assignment per element. Causal summaries must recover one periodic
     // transfer whose size is independent of 200,000 copies, while retaining
@@ -24007,7 +24007,7 @@ fn combinational_loop_periodic_repeat_is_sparse_and_phase_precise() {
             "assign passed = '{feedback repeat COUNT};"
         }
         .replace("COUNT", &count.to_string());
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -24039,7 +24039,7 @@ fn combinational_loop_periodic_repeat_is_sparse_and_phase_precise() {
     // must retain both the sparse phase partition and the regular transfer for
     // the next module boundary.
     for (output_bit, expected) in [(0, true), (1, false)] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             "a periodic phase survives two module summaries",
             &format!(
                 r#"
@@ -24078,12 +24078,12 @@ fn combinational_loop_periodic_repeat_is_sparse_and_phase_precise() {
 }
 
 #[test]
-fn combinational_loop_nested_repeat_is_sparse_and_phase_precise() {
+fn comb_loop_nested_repeat_is_sparse_and_phase_precise() {
     // Why these cases exist: nested array repeats are one Cartesian transfer,
     // not one inner summary per outer element. Both axes must survive IR
     // lowering while preserving the selected packed bit.
     for (output_bit, expected) in [(0, true), (1, false)] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             "nested periodic axes retain only their matching packed phase",
             &format!(
                 r#"
@@ -24105,13 +24105,13 @@ fn combinational_loop_nested_repeat_is_sparse_and_phase_precise() {
 }
 
 #[test]
-fn combinational_loop_nested_repeat_actual_survives_module_boundary() {
+fn comb_loop_nested_repeat_actual_survives_module_boundary() {
     // Why these cases exist: a repeated expression used as an instance actual
     // carries periodic input coordinates into the child summary. Mapping only
     // its first base span misses distant feedback; widening it loses packed
     // phase and invents feedback through the adjacent bit.
     for (output_bit, expected) in [(0, true), (1, false)] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             "nested actual axes cross a module boundary without losing phase",
             &format!(
                 r#"
@@ -24143,12 +24143,12 @@ fn combinational_loop_nested_repeat_actual_survives_module_boundary() {
 }
 
 #[test]
-fn combinational_loop_periodic_output_maps_concatenated_actual() {
+fn comb_loop_periodic_output_maps_concatenated_actual() {
     // Why this case exists: a child periodic output may legally connect to a
     // concatenated parent lvalue. Each output fragment must be clipped in the
     // child's coordinates; requiring one whole destination silently drops the
     // real a -> child.o[0] -> a feedback path.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "a periodic child output survives a concatenated parent destination",
         r#"
         module Fanout (
@@ -24175,7 +24175,7 @@ fn combinational_loop_periodic_output_maps_concatenated_actual() {
 }
 
 #[test]
-fn combinational_loop_review_uses_structural_selector_overlap() {
+fn comb_loop_uses_structural_selector_overlap() {
     // Why these cases exist: structural feedback compares each access's
     // independently possible region. Both `idx` and `~idx` can address
     // elements {0,1}, so their regions overlap without relational selector
@@ -24184,7 +24184,7 @@ fn combinational_loop_review_uses_structural_selector_overlap() {
         ("complementary selectors retain structural overlap", "~idx"),
         ("identical selectors retain structural overlap", "idx"),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -24204,12 +24204,12 @@ fn combinational_loop_review_uses_structural_selector_overlap() {
 }
 
 #[test]
-fn combinational_loop_review_maps_instance_actual_function_captures() {
+fn comb_loop_maps_instance_actual_function_captures() {
     // Why this case exists: a function used as an instance input may read a
     // module-scope variable without listing it as a formal. The function
     // summary, rather than the call's empty syntactic argument list, must map
     // that capture into the child feedthrough and retain the real loop.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance actual function retains a module-scope capture",
         r#"
         module Child (
@@ -24241,7 +24241,7 @@ fn combinational_loop_review_maps_instance_actual_function_captures() {
     // Why this control exists: an exact module capture keeps its selected bit
     // position. Feeding the child output into another bit must remain
     // loop-free instead of widening the capture to the whole object.
-    assert_comb_loop_for_case(
+    assert_comb_loop(
         "an instance actual function keeps a disjoint captured bit loop-free",
         r#"
         module Child (
@@ -24286,7 +24286,7 @@ fn combinational_loop_review_maps_instance_actual_function_captures() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -24323,7 +24323,7 @@ fn combinational_loop_review_maps_instance_actual_function_captures() {
 }
 
 #[test]
-fn combinational_loop_review_uses_structural_selector_regions() {
+fn comb_loop_uses_structural_selector_regions() {
     // Why these cases exist: dependency analysis must not infer a sparse
     // runtime value set such as {0,2} for `idx * 2`. As a nonconstant selector,
     // it structurally overlaps both elements one and two.
@@ -24344,7 +24344,7 @@ fn combinational_loop_review_uses_structural_selector_regions() {
             .map(|index| format!("assign mem[{index}] = 0;"))
             .collect::<Vec<_>>()
             .join("\n");
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"
@@ -24378,7 +24378,7 @@ fn combinational_loop_review_uses_structural_selector_regions() {
             true,
         ),
     ] {
-        assert_comb_loop_for_case(
+        assert_comb_loop(
             name,
             &format!(
                 r#"

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22133,17 +22133,21 @@ fn combinational_loop_review_preserves_context_width_extension_positions() {
 }
 
 #[test]
-fn combinational_loop_review_bounds_dynamic_selector_values() {
-    // Why these cases exist: a two-state one-bit selector has exactly the
-    // values {0,1}. Adding two therefore reaches only elements {2,3}; element
-    // zero is disjoint, while element two is a real candidate.
+fn combinational_loop_review_uses_structural_dynamic_selector_regions() {
+    // Why these cases exist: a nonconstant selector is analyzed structurally
+    // from its longest static prefix. The selector's runtime value domain does
+    // not narrow the region, so `idx + 2` overlaps both elements zero and two.
     for (name, target, expected) in [
         (
-            "a shifted one-bit index cannot reach element zero",
+            "a shifted dynamic index structurally overlaps element zero",
             0,
-            false,
+            true,
         ),
-        ("a shifted one-bit index can reach element two", 2, true),
+        (
+            "a shifted dynamic index structurally overlaps element two",
+            2,
+            true,
+        ),
     ] {
         let clears = match target {
             0 => "assign value[1] = 0; assign value[2] = 0; assign value[3] = 0;",
@@ -22169,15 +22173,20 @@ fn combinational_loop_review_bounds_dynamic_selector_values() {
         );
     }
 
-    // Why these cases exist: an indexed part-select with base {0,1} and width
-    // two reaches only bits 0..2. Bit three is disjoint; bit zero is reachable.
+    // Why these cases exist: a nonconstant indexed part-select base retains
+    // its enclosing packed region. Inferring the base's runtime values would
+    // incorrectly make bit three structurally disjoint.
     for (name, target, expected) in [
         (
-            "a bounded indexed part-select cannot reach bit three",
+            "a dynamic indexed part-select structurally overlaps bit three",
             3,
-            false,
+            true,
         ),
-        ("a bounded indexed part-select can reach bit zero", 0, true),
+        (
+            "a dynamic indexed part-select structurally overlaps bit zero",
+            0,
+            true,
+        ),
     ] {
         let clears = match target {
             0 => "assign value[1] = 0; assign value[2] = 0; assign value[3] = 0;",
@@ -22912,18 +22921,18 @@ fn combinational_loop_review_maps_instance_actual_function_captures() {
 }
 
 #[test]
-fn combinational_loop_review_preserves_sparse_selector_regions() {
-    // Why these cases exist: for a one-bit two-state selector, `idx * 2` has
-    // the independently provable non-contiguous candidate set {0,2}. Element
-    // one is unreachable, while feedback into element two is a real loop.
+fn combinational_loop_review_uses_structural_selector_regions() {
+    // Why these cases exist: dependency analysis must not infer a sparse
+    // runtime value set such as {0,2} for `idx * 2`. As a nonconstant selector,
+    // it structurally overlaps both elements one and two.
     for (name, target, expected) in [
         (
-            "a non-contiguous selector excludes an unreachable array element",
+            "a multiplied dynamic index structurally overlaps element one",
             1,
-            false,
+            true,
         ),
         (
-            "a non-contiguous selector retains a reachable array element",
+            "a multiplied dynamic index structurally overlaps element two",
             2,
             true,
         ),

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -22599,6 +22599,50 @@ fn combinational_loop_review_preserves_assignment_pattern_positions() {
 }
 
 #[test]
+fn combinational_loop_whole_unpacked_instance_is_sparse_and_precise() {
+    // Why these cases exist: a whole-array module connection must not create
+    // one graph node per declared element. A sparse access far inside a
+    // 200,000-element array still has to meet its positionally corresponding
+    // feedthrough, while two different positions must remain disjoint.
+    for (name, output_index, expected) in [
+        ("a distant matching element retains feedback", 123_456, true),
+        (
+            "distant disjoint elements remain independent",
+            65_432,
+            false,
+        ),
+    ] {
+        assert_comb_loop_for_case(
+            name,
+            &format!(
+                r#"
+                module Identity (
+                    i: input  logic [200000],
+                    o: output logic [200000],
+                ) {{
+                    assign o = i;
+                }}
+
+                module Top (
+                    o: output logic,
+                ) {{
+                    var feedback: logic [200000];
+                    var passed  : logic [200000];
+                    inst u: Identity (
+                        i: feedback,
+                        o: passed,
+                    );
+                    assign feedback[123456] = passed[{output_index}];
+                    assign o = passed[0];
+                }}
+                "#
+            ),
+            expected,
+        );
+    }
+}
+
+#[test]
 fn combinational_loop_review_uses_structural_selector_overlap() {
     // Why these cases exist: structural feedback compares each access's
     // independently possible region. Both `idx` and `~idx` can address

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -10723,6 +10723,284 @@ fn combinational_loop_review_preserves_instance_repeat_positions() {
 }
 
 #[test]
+#[ignore = "captured independent-review regression: generic module summaries ignore specialization"]
+fn combinational_loop_review_distinguishes_generic_module_specializations() {
+    // Why this case exists: ENABLE: 1 elaborates Child into an identity even
+    // though its declaration default is zero. Reusing the default summary for
+    // the specialization hides the real feedback through this instance.
+    assert_comb_loop_for_case(
+        "an enabled generic-module specialization retains its feedthrough",
+        r#"
+        module Child #(
+            param ENABLE: u32 = 0,
+        )(
+            i: input  logic,
+            o: output logic,
+        ) {
+            if ENABLE :g_enabled {
+                assign o = i;
+            } else {
+                assign o = 0;
+            }
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var feedback: logic;
+            var passed: logic;
+            inst u: Child #(
+                ENABLE: 1,
+            )(
+                i: feedback,
+                o: passed,
+            );
+            assign feedback = passed;
+            assign o = feedback;
+        }
+        "#,
+        true,
+    );
+
+    // Why this control exists: ENABLE: 0 elaborates the output to a constant
+    // even though the declaration default is one, so there is no return path.
+    assert_comb_loop_for_case(
+        "a disabled generic-module specialization does not inherit feedthrough",
+        r#"
+        module Child #(
+            param ENABLE: u32 = 1,
+        )(
+            i: input  logic,
+            o: output logic,
+        ) {
+            if ENABLE :g_enabled {
+                assign o = i;
+            } else {
+                assign o = 0;
+            }
+        }
+        module Top (
+            o: output logic,
+        ) {
+            var feedback: logic;
+            var passed: logic;
+            inst u: Child #(
+                ENABLE: 0,
+            )(
+                i: feedback,
+                o: passed,
+            );
+            assign feedback = passed;
+            assign o = feedback;
+        }
+        "#,
+        false,
+    );
+}
+
+#[test]
+#[ignore = "captured independent-review regression: constant ternary evaluates dead side effects"]
+fn combinational_loop_review_short_circuits_instance_actual_side_effects() {
+    // Why this case exists: IEEE 1800-2023 11.4.11 evaluates only the selected
+    // ternary branch. touch(o) is in the constant-dead branch, so it cannot
+    // write x or form an o -> x -> o feedback path.
+    assert_comb_loop_for_case(
+        "a constant-dead instance actual branch has no function side effect",
+        r#"
+        module Sink (
+            i: input logic,
+        ) {}
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function touch (
+                a: input logic,
+            ) -> logic {
+                x = a;
+                return 0;
+            }
+            inst u: Sink (
+                i: if 1'b1 ? 0 : touch(o),
+            );
+            assign o = x;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: choosing the touch branch evaluates the call,
+    // so its captured write closes the real o -> x -> o path.
+    assert_comb_loop_for_case(
+        "a constant-taken instance actual branch retains its function side effect",
+        r#"
+        module Sink (
+            i: input logic,
+        ) {}
+        module Top (
+            o: output logic,
+        ) {
+            var x: logic;
+            function touch (
+                a: input logic,
+            ) -> logic {
+                x = a;
+                return 0;
+            }
+            inst u: Sink (
+                i: if 1'b0 ? 0 : touch(o),
+            );
+            assign o = x;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "captured independent-review regression: function actual shift loses bit positions"]
+fn combinational_loop_review_preserves_function_actual_shift_positions() {
+    // Why this case exists: (value << 1)[0] is an inserted zero. Passing the
+    // shifted vector through a function must not broadcast value[1] to o.
+    assert_comb_loop_for_case(
+        "a function actual left shift keeps its inserted bit loop-free",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function low (
+                x: input logic<4>,
+            ) -> logic {
+                return x[0];
+            }
+            var value: logic<4>;
+            assign o = low(value << 1);
+            assign value[0] = 0;
+            assign value[1] = o;
+            assign value[3:2] = 0;
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: shifted bit one is value[0], so returning it to
+    // value[0] is a real corresponding-bit loop.
+    assert_comb_loop_for_case(
+        "a function actual left shift detects its live shifted bit",
+        r#"
+        module Top (
+            o: output logic,
+        ) {
+            function bit_one (
+                x: input logic<4>,
+            ) -> logic {
+                return x[1];
+            }
+            var value: logic<4>;
+            assign o = bit_one(value << 1);
+            assign value[0] = o;
+            assign value[3:1] = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "captured independent-review regression: vector ternary loses bit positions"]
+fn combinational_loop_review_preserves_vector_ternary_positions() {
+    // Why this case exists: both branches preserve vector bit positions, so
+    // o[0] can read only value[0] (or the constant), never value[1].
+    assert_comb_loop_for_case(
+        "a vector ternary keeps a disjoint bit loop-free",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic<2>,
+        ) {
+            var value: logic<2>;
+            assign o = if sel ? value : 0;
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: returning o[0] to value[0] closes the selected
+    // branch's real same-bit path and must remain detected.
+    assert_comb_loop_for_case(
+        "a vector ternary detects its corresponding-bit loop",
+        r#"
+        module Top (
+            sel: input  logic,
+            o  : output logic<2>,
+        ) {
+            var value: logic<2>;
+            assign o = if sel ? value : 0;
+            assign value[0] = o[0];
+            assign value[1] = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "captured independent-review regression: function concat output loses destinations"]
+fn combinational_loop_review_preserves_function_concat_output_positions() {
+    // Why this case exists: y = x copied into {o[1], o[0]} still maps x[0]
+    // only to o[0]. Treating the concatenated output actual as all-to-all
+    // invents value[1] -> o[0] feedback.
+    assert_comb_loop_for_case(
+        "a concatenated function output keeps a disjoint bit loop-free",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function copy (
+                x: input  logic<2>,
+                y: output logic<2>,
+            ) {
+                y = x;
+            }
+            var value: logic<2>;
+            always_comb {
+                copy(value, {o[1], o[0]});
+            }
+            assign value[0] = 0;
+            assign value[1] = o[0];
+        }
+        "#,
+        false,
+    );
+
+    // Why this control exists: value[0] copied to o[0] and fed back to the
+    // same bit is a real loop through the concatenated output destination.
+    assert_comb_loop_for_case(
+        "a concatenated function output detects its corresponding-bit loop",
+        r#"
+        module Top (
+            o: output logic<2>,
+        ) {
+            function copy (
+                x: input  logic<2>,
+                y: output logic<2>,
+            ) {
+                y = x;
+            }
+            var value: logic<2>;
+            always_comb {
+                copy(value, {o[1], o[0]});
+            }
+            assign value[0] = o[0];
+            assign value[1] = 0;
+        }
+        "#,
+        true,
+    );
+}
+
+#[test]
 fn combinational_loop_memory_ssa_celox_regression_corpus() {
     // Ported from celox/tests/basic.rs::test_always_comb_read_before_write_uses_previous_value.
     assert_comb_loop_for_case(

--- a/crates/analyzer/src/tests.rs
+++ b/crates/analyzer/src/tests.rs
@@ -14316,6 +14316,61 @@ fn comb_loop_function_summary_fanout_is_memoized() {
 }
 
 #[test]
+fn comb_loop_instance_summary_region_mapping_is_reused() {
+    // Why this case exists: every child output depends on every child input,
+    // so its summary contains a Cartesian product with the same input and
+    // output regions repeated many times. Mapping those regions into the
+    // parent's actuals must be proportional to the distinct regions, while
+    // the exact all-to-all dependencies still retain the feedback below.
+    const WIDTH: usize = 32;
+    let reduction = (0..WIDTH)
+        .map(|index| format!("x[{index}]"))
+        .collect::<Vec<_>>()
+        .join(" ^ ");
+    let outputs = (0..WIDTH)
+        .map(|index| format!("assign o[{index}] = mix(i);"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let clears = (1..WIDTH)
+        .map(|index| format!("assign feedback[{index}] = 0;"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert_comb_loop(
+        "an instance summary Cartesian product retains parent feedback",
+        &format!(
+            r#"
+            module Child (
+                i: input  logic<{WIDTH}>,
+                o: output logic<{WIDTH}>,
+            ) {{
+                function mix (
+                    x: input logic<{WIDTH}>,
+                ) -> logic {{
+                    return {reduction};
+                }}
+                {outputs}
+            }}
+
+            module Top (
+                o: output logic<{WIDTH}>,
+            ) {{
+                var feedback: logic<{WIDTH}>;
+                var passed  : logic<{WIDTH}>;
+                inst u: Child (
+                    i: feedback,
+                    o: passed,
+                );
+                assign feedback[0] = passed[0];
+                {clears}
+                assign o = passed;
+            }}
+            "#
+        ),
+        true,
+    );
+}
+
+#[test]
 fn comb_loop_rejected_periodic_run_is_scanned_once() {
     // Why this case exists: a long run with one source but the same exact
     // destination is legal sequential overwrite, not a periodic transfer.

--- a/crates/causal/Cargo.toml
+++ b/crates/causal/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name                  = "veryl-causal"
+version               = "0.20.3"
+publish               = false
+authors.workspace     = true
+repository.workspace  = true
+license.workspace     = true
+description           = "IR-independent sparse causal and MemorySSA analyses"
+edition.workspace     = true

--- a/crates/causal/README.md
+++ b/crates/causal/README.md
@@ -8,7 +8,7 @@ references.
 The Veryl analyzer's user-visible acceptance bounds are specified in
 [`crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md`](../analyzer/COMBINATIONAL_LOOP_ANALYSIS.md).
 
-The design has three constraints:
+The design has four constraints:
 
 - Region endpoints form the version domain. Analysis cost depends on accesses,
   definitions, phis and CFG edges, not on a signal's declared bit width or an

--- a/crates/causal/README.md
+++ b/crates/causal/README.md
@@ -1,0 +1,54 @@
+# veryl-causal
+
+This crate contains IR-independent control-flow, SSA, MemorySSA, interval and
+causal graph algorithms. A front end lowers one procedure into dense immutable
+tables; the tables own no parser resources, symbol-table locks or Veryl IR
+references.
+
+The design has three constraints:
+
+- Region endpoints form the version domain. Analysis cost depends on accesses,
+  definitions, phis and CFG edges, not on a signal's declared bit width or an
+  array's element count.
+- Exact and unknown dependencies stay distinct. Only exact/proven paths are
+  eligible for a hard combinational-loop diagnostic; dynamic aliases, external
+  components, hierarchy, timed effects and unsupported syntax are retained as
+  explicit incomplete reasons.
+- Procedures are independent work items. Their summaries are deterministic and
+  immutable, so callers may build them concurrently and merge them in source or
+  module-topology order.
+
+The procedure summary also supports sparse positional transfers. A copy or
+concatenation relates source and destination spans, and access boundaries are
+propagated through the transfer graph. This preserves bit provenance through
+copy chains without expanding a wide vector into individual bits. The Veryl
+adapter currently uses this for exact copies, concatenations, unary bitwise
+not/plus, and equal-width pointwise bitwise operators. Four-state behavior and
+context-determined widths are part of the eligibility check; unsupported
+expressions retain their conservative all-to-all dependency.
+
+The graph represents **structural dependence**, not Boolean functional
+dependence and not `always_comb` sensitivity. LRM-defined bit placement may
+split an operator into positional region transfers, but algebraic cancellation
+does not remove an input edge: for example, `x & '0` remains structurally
+dependent on the corresponding bits of `x`. Observer-only reads affect SV
+sensitivity but do not define a signal value and therefore create no value
+edge here.
+
+## Follow-up work
+
+These are intentionally separate transfer kinds rather than approximations of
+the positional transfer:
+
+- two-state add/sub prefix dependencies (output bit `n` depends on operand bits
+  `0..=n`), while four-state arithmetic remains whole-expression dependent;
+- constant shifts, including vacated constant spans and signed arithmetic-right
+  fill dependencies;
+- width/sign casts and context extension/truncation;
+- repeated concatenations and other statically expanded aggregate expressions.
+
+Each should land with paired positive/negative loop tests across `bit` and
+`logic`, plus a declared-width-independent cost test.
+
+The initial implementation was adapted from Celox's `celox-analysis` crate.
+Both projects use the same `MIT OR Apache-2.0` license.

--- a/crates/causal/README.md
+++ b/crates/causal/README.md
@@ -13,10 +13,11 @@ The design has three constraints:
 - Region endpoints form the version domain. Analysis cost depends on accesses,
   definitions, phis and CFG edges, not on a signal's declared bit width or an
   array's element count.
-- Exact and unknown dependencies stay distinct. Only exact/proven paths are
-  eligible for a hard combinational-loop diagnostic; dynamic aliases, external
-  components, hierarchy, timed effects and unsupported syntax are retained as
-  explicit incomplete reasons.
+- Dependencies within known expressions and unknown external effects stay
+  distinct. Conservative transfers within a known expression remain eligible
+  for a hard combinational-loop diagnostic; external components, hierarchy,
+  timed effects and unsupported syntax are retained as explicit incomplete
+  reasons rather than guessed as feedthrough.
 - Procedures are independent work items. Their summaries are deterministic and
   immutable, so callers may build them concurrently and merge them in source or
   module-topology order.

--- a/crates/causal/README.md
+++ b/crates/causal/README.md
@@ -34,21 +34,3 @@ does not remove an input edge: for example, `x & '0` remains structurally
 dependent on the corresponding bits of `x`. Observer-only reads affect SV
 sensitivity but do not define a signal value and therefore create no value
 edge here.
-
-## Follow-up work
-
-These are intentionally separate transfer kinds rather than approximations of
-the positional transfer:
-
-- two-state add/sub prefix dependencies (output bit `n` depends on operand bits
-  `0..=n`), while four-state arithmetic remains whole-expression dependent;
-- constant shifts, including vacated constant spans and signed arithmetic-right
-  fill dependencies;
-- width/sign casts and context extension/truncation;
-- repeated concatenations and other statically expanded aggregate expressions.
-
-Each should land with paired positive/negative loop tests across `bit` and
-`logic`, plus a declared-width-independent cost test.
-
-The initial implementation was adapted from Celox's `celox-analysis` crate.
-Both projects use the same `MIT OR Apache-2.0` license.

--- a/crates/causal/README.md
+++ b/crates/causal/README.md
@@ -18,6 +18,9 @@ The design has three constraints:
   for a hard combinational-loop diagnostic; external components, hierarchy,
   timed effects and unsupported syntax are retained as explicit incomplete
   reasons rather than guessed as feedthrough.
+- Incomplete reasons distinguish opaque input boundaries from behavior which
+  is available but was not resolved by the current analysis. Malformed causal
+  IR is an analysis failure, not an incomplete boundary.
 - Procedures are independent work items. Their summaries are deterministic and
   immutable, so callers may build them concurrently and merge them in source or
   module-topology order.

--- a/crates/causal/README.md
+++ b/crates/causal/README.md
@@ -5,6 +5,9 @@ causal graph algorithms. A front end lowers one procedure into dense immutable
 tables; the tables own no parser resources, symbol-table locks or Veryl IR
 references.
 
+The Veryl analyzer's user-visible acceptance bounds are specified in
+[`crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md`](../analyzer/COMBINATIONAL_LOOP_ANALYSIS.md).
+
 The design has three constraints:
 
 - Region endpoints form the version domain. Analysis cost depends on accesses,

--- a/crates/causal/src/cfg.rs
+++ b/crates/causal/src/cfg.rs
@@ -1,0 +1,913 @@
+//! Deterministic control-flow analysis over dense, IR-independent block IDs.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+/// A malformed dense control-flow graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CfgError {
+    Empty,
+    InvalidRoot {
+        root: usize,
+        blocks: usize,
+    },
+    EdgeOutOfRange {
+        source: usize,
+        target: usize,
+        blocks: usize,
+    },
+    Unreachable(Vec<usize>),
+    InvalidGraph(&'static str),
+}
+
+impl fmt::Display for CfgError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("control-flow graph is empty"),
+            Self::InvalidRoot { root, blocks } => {
+                write!(formatter, "CFG root {root} is outside {blocks} blocks")
+            }
+            Self::EdgeOutOfRange {
+                source,
+                target,
+                blocks,
+            } => write!(
+                formatter,
+                "CFG edge {source} -> {target} is outside {blocks} blocks"
+            ),
+            Self::Unreachable(blocks) => {
+                formatter.write_str("CFG contains unreachable blocks:")?;
+                for block in blocks {
+                    write!(formatter, " {block}")?;
+                }
+                Ok(())
+            }
+            Self::InvalidGraph(message) => write!(formatter, "invalid CFG: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for CfgError {}
+
+/// Immediate dominators and constant-time dominance intervals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DominatorTree {
+    pub idom: Vec<Option<usize>>,
+    pub children: Vec<Vec<usize>>,
+    enter: Vec<usize>,
+    exit: Vec<usize>,
+    depth: Vec<usize>,
+}
+
+impl DominatorTree {
+    fn compute(successors: &[Vec<usize>], root: usize) -> Result<Self, CfgError> {
+        let idom = lengauer_tarjan(successors, root)?;
+        Self::from_idom(idom, root)
+    }
+
+    /// Construct dominance intervals from an independently supplied idom tree.
+    pub fn from_idom(idom: Vec<Option<usize>>, root: usize) -> Result<Self, CfgError> {
+        if root >= idom.len() {
+            return Err(CfgError::InvalidRoot {
+                root,
+                blocks: idom.len(),
+            });
+        }
+        let mut children = vec![Vec::new(); idom.len()];
+        for (block, parent) in idom.iter().copied().enumerate() {
+            if block == root {
+                if parent.is_some() {
+                    return Err(CfgError::InvalidGraph(
+                        "dominator root has an immediate dominator",
+                    ));
+                }
+                continue;
+            }
+            if let Some(parent) = parent {
+                let Some(parent_children) = children.get_mut(parent) else {
+                    return Err(CfgError::InvalidGraph(
+                        "immediate dominator is out of range",
+                    ));
+                };
+                parent_children.push(block);
+            }
+        }
+        for block_children in &mut children {
+            block_children.sort_unstable();
+        }
+
+        enum Event {
+            Enter(usize, usize),
+            Exit(usize),
+        }
+        let mut enter = vec![usize::MAX; idom.len()];
+        let mut exit = vec![usize::MAX; idom.len()];
+        let mut depth = vec![usize::MAX; idom.len()];
+        let mut time = 0usize;
+        let mut events = vec![Event::Enter(root, 0)];
+        while let Some(event) = events.pop() {
+            match event {
+                Event::Enter(block, block_depth) => {
+                    if enter[block] != usize::MAX {
+                        return Err(CfgError::InvalidGraph(
+                            "immediate-dominator links contain a cycle",
+                        ));
+                    }
+                    enter[block] = time;
+                    depth[block] = block_depth;
+                    time += 1;
+                    events.push(Event::Exit(block));
+                    events.extend(
+                        children[block]
+                            .iter()
+                            .rev()
+                            .copied()
+                            .map(|child| Event::Enter(child, block_depth + 1)),
+                    );
+                }
+                Event::Exit(block) => {
+                    exit[block] = time;
+                    time += 1;
+                }
+            }
+        }
+        Ok(Self {
+            idom,
+            children,
+            enter,
+            exit,
+            depth,
+        })
+    }
+
+    #[must_use]
+    pub fn dominates(&self, dominator: usize, block: usize) -> bool {
+        let (Some(&dominator_enter), Some(&dominator_exit), Some(&block_enter), Some(&block_exit)) = (
+            self.enter.get(dominator),
+            self.exit.get(dominator),
+            self.enter.get(block),
+            self.exit.get(block),
+        ) else {
+            return false;
+        };
+        dominator_enter != usize::MAX
+            && block_enter != usize::MAX
+            && dominator_enter <= block_enter
+            && block_exit <= dominator_exit
+    }
+
+    #[must_use]
+    pub fn lca(&self, left: usize, right: usize) -> Option<usize> {
+        let (Some(&left_depth), Some(&right_depth)) = (self.depth.get(left), self.depth.get(right))
+        else {
+            return None;
+        };
+        if left_depth == usize::MAX || right_depth == usize::MAX {
+            return None;
+        }
+        let mut left = left;
+        let mut right = right;
+        while self.depth[left] > self.depth[right] {
+            left = self.idom[left]?;
+        }
+        while self.depth[right] > self.depth[left] {
+            right = self.idom[right]?;
+        }
+        while left != right {
+            left = self.idom[left]?;
+            right = self.idom[right]?;
+        }
+        Some(left)
+    }
+}
+
+/// Post-dominance tree rooted at a synthetic common exit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostDominatorTree {
+    tree: DominatorTree,
+    virtual_exit: usize,
+    original_blocks: usize,
+}
+
+impl PostDominatorTree {
+    #[must_use]
+    pub fn postdominates(&self, postdominator: usize, block: usize) -> bool {
+        postdominator < self.original_blocks
+            && block < self.original_blocks
+            && self.tree.dominates(postdominator, block)
+    }
+
+    #[must_use]
+    pub fn common_postdominator(&self, left: usize, right: usize) -> Option<usize> {
+        let candidate = self.tree.lca(left, right)?;
+        (candidate != self.virtual_exit && candidate < self.original_blocks).then_some(candidate)
+    }
+
+    #[must_use]
+    pub fn immediate_postdominator(&self, block: usize) -> Option<usize> {
+        let parent = *self.tree.idom.get(block)?.as_ref()?;
+        (parent != self.virtual_exit && parent < self.original_blocks).then_some(parent)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StronglyConnectedRegion {
+    pub blocks: Vec<usize>,
+    pub entries: Vec<usize>,
+    pub cyclic: bool,
+    pub reducible_header: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NaturalLoop {
+    pub header: usize,
+    pub blocks: BTreeSet<usize>,
+    pub parent: Option<usize>,
+}
+
+/// Complete analysis of one reachable dense CFG.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlFlowGraph {
+    pub root: usize,
+    pub predecessors: Vec<Vec<usize>>,
+    pub successors: Vec<Vec<usize>>,
+    pub dominators: DominatorTree,
+    pub dominance_frontier: Vec<Vec<usize>>,
+    pub postdominators: PostDominatorTree,
+    pub postdominance_frontier: Vec<Vec<usize>>,
+    pub controllers: Vec<Vec<usize>>,
+    pub control_dependents: Vec<Vec<usize>>,
+    pub sccs: Vec<StronglyConnectedRegion>,
+    pub scc_for_block: Vec<usize>,
+    pub loops: Vec<NaturalLoop>,
+}
+
+/// Forward-only CFG analysis used by SSA construction and machine backends.
+///
+/// Unlike [`ControlFlowGraph`], this does not construct postdominators or
+/// control dependence. SCC membership is retained because loop-sensitive
+/// placement needs to reject irreducible cycles without materializing the
+/// potentially dense reverse/control-dependence graphs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardControlFlowGraph {
+    pub root: usize,
+    pub predecessors: Vec<Vec<usize>>,
+    pub successors: Vec<Vec<usize>>,
+    pub dominators: DominatorTree,
+    pub dominance_frontier: Vec<Vec<usize>>,
+    pub sccs: Vec<StronglyConnectedRegion>,
+    pub scc_for_block: Vec<usize>,
+    pub loops: Vec<NaturalLoop>,
+}
+
+impl ForwardControlFlowGraph {
+    /// Analyze the forward properties of a graph without changing block IDs.
+    pub fn analyze(successors: Vec<Vec<usize>>, root: usize) -> Result<Self, CfgError> {
+        Self::analyze_impl(successors, root, true)
+    }
+
+    /// Analyze dominance, loops, and SCCs without constructing a dominance
+    /// frontier.
+    ///
+    /// This is for placement clients which issue dominance queries but do not
+    /// construct SSA. The returned frontier table has one empty entry per
+    /// block so accidental frontier use is explicit in tests and diagnostics.
+    pub fn analyze_structure(successors: Vec<Vec<usize>>, root: usize) -> Result<Self, CfgError> {
+        Self::analyze_impl(successors, root, false)
+    }
+
+    fn analyze_impl(
+        mut successors: Vec<Vec<usize>>,
+        root: usize,
+        include_frontier: bool,
+    ) -> Result<Self, CfgError> {
+        validate_edges(&successors, root)?;
+        for outgoing in &mut successors {
+            let mut seen = BTreeSet::new();
+            outgoing.retain(|successor| seen.insert(*successor));
+        }
+        let order = reverse_postorder(&successors, root)?;
+        if order.len() != successors.len() {
+            let reached = order.into_iter().collect::<BTreeSet<_>>();
+            return Err(CfgError::Unreachable(
+                (0..successors.len())
+                    .filter(|block| !reached.contains(block))
+                    .collect(),
+            ));
+        }
+
+        let mut predecessors = vec![Vec::new(); successors.len()];
+        for (block, outgoing) in successors.iter().enumerate() {
+            for &successor in outgoing {
+                predecessors[successor].push(block);
+            }
+        }
+        for incoming in &mut predecessors {
+            incoming.sort_unstable();
+            incoming.dedup();
+        }
+
+        let dominators = DominatorTree::compute(&successors, root)?;
+        if dominators
+            .idom
+            .iter()
+            .enumerate()
+            .any(|(block, parent)| block != root && parent.is_none())
+        {
+            return Err(CfgError::InvalidGraph(
+                "reachable block has no immediate dominator",
+            ));
+        }
+        let dominance_frontier = if include_frontier {
+            dominance_frontiers(&successors, &dominators, root)
+        } else {
+            vec![Vec::new(); successors.len()]
+        };
+        let loops = natural_loops(&predecessors, &successors, &dominators)?;
+        let (sccs, scc_for_block) =
+            strongly_connected_regions(&predecessors, &successors, &dominators, root);
+
+        Ok(Self {
+            root,
+            predecessors,
+            successors,
+            dominators,
+            dominance_frontier,
+            sccs,
+            scc_for_block,
+            loops,
+        })
+    }
+}
+
+impl ControlFlowGraph {
+    /// Analyze a graph without changing the caller's block numbering.
+    pub fn analyze(successors: Vec<Vec<usize>>, root: usize) -> Result<Self, CfgError> {
+        let forward = ForwardControlFlowGraph::analyze(successors, root)?;
+        Self::finish(forward, true)
+    }
+
+    /// Analyze dominance, post-dominance, loops, and SCCs without constructing
+    /// either dominance frontier or the potentially dense control-dependence
+    /// relation.
+    ///
+    /// Placement clients which only need legal region boundaries should use
+    /// this mode. Its graph tables remain linear in the input CFG size.
+    pub fn analyze_structure(successors: Vec<Vec<usize>>, root: usize) -> Result<Self, CfgError> {
+        let forward = ForwardControlFlowGraph::analyze_structure(successors, root)?;
+        Self::finish(forward, false)
+    }
+
+    fn finish(forward: ForwardControlFlowGraph, include_frontiers: bool) -> Result<Self, CfgError> {
+        let (postdominators, postdominance_frontier) = build_postdominators(
+            &forward.predecessors,
+            &forward.successors,
+            include_frontiers,
+        )?;
+        let controllers = postdominance_frontier.clone();
+        let mut control_dependents = vec![Vec::new(); forward.successors.len()];
+        if include_frontiers {
+            for (dependent, dependent_controllers) in controllers.iter().enumerate() {
+                for &controller in dependent_controllers {
+                    control_dependents[controller].push(dependent);
+                }
+            }
+            for dependents in &mut control_dependents {
+                dependents.sort_unstable();
+                dependents.dedup();
+            }
+        }
+        Ok(Self {
+            root: forward.root,
+            predecessors: forward.predecessors,
+            successors: forward.successors,
+            dominators: forward.dominators,
+            dominance_frontier: forward.dominance_frontier,
+            postdominators,
+            postdominance_frontier,
+            controllers,
+            control_dependents,
+            sccs: forward.sccs,
+            scc_for_block: forward.scc_for_block,
+            loops: forward.loops,
+        })
+    }
+}
+
+fn validate_edges(successors: &[Vec<usize>], root: usize) -> Result<(), CfgError> {
+    if successors.is_empty() {
+        return Err(CfgError::Empty);
+    }
+    if root >= successors.len() {
+        return Err(CfgError::InvalidRoot {
+            root,
+            blocks: successors.len(),
+        });
+    }
+    for (source, outgoing) in successors.iter().enumerate() {
+        if let Some(&target) = outgoing.iter().find(|&&target| target >= successors.len()) {
+            return Err(CfgError::EdgeOutOfRange {
+                source,
+                target,
+                blocks: successors.len(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Iterative DFS reverse postorder in the caller's block-number domain.
+pub fn reverse_postorder(successors: &[Vec<usize>], root: usize) -> Result<Vec<usize>, CfgError> {
+    validate_edges(successors, root)?;
+    let mut visited = vec![false; successors.len()];
+    let mut postorder = Vec::with_capacity(successors.len());
+    visited[root] = true;
+    let mut stack = vec![(root, 0usize)];
+    while let Some((block, next_successor)) = stack.last_mut() {
+        if *next_successor == successors[*block].len() {
+            postorder.push(*block);
+            stack.pop();
+            continue;
+        }
+        let successor = successors[*block][*next_successor];
+        *next_successor += 1;
+        if !visited[successor] {
+            visited[successor] = true;
+            stack.push((successor, 0));
+        }
+    }
+    postorder.reverse();
+    Ok(postorder)
+}
+
+/// Lengauer--Tarjan immediate dominators over a dense graph.
+fn lengauer_tarjan(successors: &[Vec<usize>], root: usize) -> Result<Vec<Option<usize>>, CfgError> {
+    validate_edges(successors, root)?;
+    let mut dfs_number = vec![0usize; successors.len()];
+    let mut vertex = vec![usize::MAX];
+    let mut parent = vec![0usize; successors.len() + 1];
+    dfs_number[root] = 1;
+    vertex.push(root);
+    let mut stack = vec![(root, 0usize)];
+    while let Some((block, next_successor)) = stack.last_mut() {
+        if *next_successor == successors[*block].len() {
+            stack.pop();
+            continue;
+        }
+        let successor = successors[*block][*next_successor];
+        *next_successor += 1;
+        if dfs_number[successor] == 0 {
+            let number = vertex.len();
+            dfs_number[successor] = number;
+            vertex.push(successor);
+            parent[number] = dfs_number[*block];
+            stack.push((successor, 0));
+        }
+    }
+
+    let reachable = vertex.len() - 1;
+    let mut predecessors = vec![Vec::new(); reachable + 1];
+    for (source, outgoing) in successors.iter().enumerate() {
+        let source_number = dfs_number[source];
+        if source_number == 0 {
+            continue;
+        }
+        for &target in outgoing {
+            let target_number = dfs_number[target];
+            if target_number != 0 {
+                predecessors[target_number].push(source_number);
+            }
+        }
+    }
+
+    let mut semi = (0..=reachable).collect::<Vec<_>>();
+    let mut idom_number = vec![0usize; reachable + 1];
+    let mut ancestor = vec![0usize; reachable + 1];
+    let mut label = (0..=reachable).collect::<Vec<_>>();
+    let mut bucket = vec![Vec::<usize>::new(); reachable + 1];
+
+    fn eval(value: usize, ancestor: &mut [usize], label: &mut [usize], semi: &[usize]) -> usize {
+        if ancestor[value] == 0 {
+            return label[value];
+        }
+        let mut path = Vec::new();
+        let mut current = value;
+        while ancestor[current] != 0 && ancestor[ancestor[current]] != 0 {
+            path.push(current);
+            current = ancestor[current];
+        }
+        for node in path.into_iter().rev() {
+            let parent = ancestor[node];
+            if semi[label[parent]] < semi[label[node]] {
+                label[node] = label[parent];
+            }
+            ancestor[node] = ancestor[parent];
+        }
+        label[value]
+    }
+
+    for block in (2..=reachable).rev() {
+        for &predecessor in &predecessors[block] {
+            let representative = eval(predecessor, &mut ancestor, &mut label, &semi);
+            semi[block] = semi[block].min(semi[representative]);
+        }
+        bucket[semi[block]].push(block);
+        let block_parent = parent[block];
+        if block_parent == 0 {
+            return Err(CfgError::InvalidGraph("non-root DFS node has no parent"));
+        }
+        ancestor[block] = block_parent;
+        let pending = std::mem::take(&mut bucket[block_parent]);
+        for candidate in pending {
+            let representative = eval(candidate, &mut ancestor, &mut label, &semi);
+            idom_number[candidate] = if semi[representative] < semi[candidate] {
+                representative
+            } else {
+                block_parent
+            };
+        }
+    }
+    for block in 2..=reachable {
+        if idom_number[block] != semi[block] {
+            let parent = idom_number[block];
+            if parent == 0 {
+                return Err(CfgError::InvalidGraph(
+                    "dominator correction references no parent",
+                ));
+            }
+            idom_number[block] = idom_number[parent];
+        }
+    }
+
+    let mut result = vec![None; successors.len()];
+    for block in 2..=reachable {
+        let parent = idom_number[block];
+        if parent == 0 || parent >= vertex.len() {
+            return Err(CfgError::InvalidGraph(
+                "computed immediate dominator is out of range",
+            ));
+        }
+        result[vertex[block]] = Some(vertex[parent]);
+    }
+    Ok(result)
+}
+
+fn dominance_frontiers(
+    successors: &[Vec<usize>],
+    dominators: &DominatorTree,
+    root: usize,
+) -> Vec<Vec<usize>> {
+    let mut frontiers = vec![BTreeSet::<usize>::new(); successors.len()];
+    let mut tree_postorder = Vec::with_capacity(successors.len());
+    let mut stack = vec![(root, false)];
+    while let Some((block, expanded)) = stack.pop() {
+        if expanded {
+            tree_postorder.push(block);
+            continue;
+        }
+        stack.push((block, true));
+        stack.extend(
+            dominators.children[block]
+                .iter()
+                .rev()
+                .copied()
+                .map(|child| (child, false)),
+        );
+    }
+    for block in tree_postorder {
+        for &successor in &successors[block] {
+            if dominators.idom[successor] != Some(block) {
+                frontiers[block].insert(successor);
+            }
+        }
+        for &child in &dominators.children[block] {
+            let child_frontier = frontiers[child].iter().copied().collect::<Vec<_>>();
+            for member in child_frontier {
+                if dominators.idom[member] != Some(block) {
+                    frontiers[block].insert(member);
+                }
+            }
+        }
+    }
+    frontiers
+        .into_iter()
+        .map(|frontier| frontier.into_iter().collect())
+        .collect()
+}
+
+fn build_postdominators(
+    predecessors: &[Vec<usize>],
+    successors: &[Vec<usize>],
+    include_frontier: bool,
+) -> Result<(PostDominatorTree, Vec<Vec<usize>>), CfgError> {
+    let original_blocks = successors.len();
+    let virtual_exit = original_blocks;
+    let mut reverse_successors = vec![Vec::new(); original_blocks + 1];
+    reverse_successors[virtual_exit] = successors
+        .iter()
+        .enumerate()
+        .filter_map(|(block, outgoing)| outgoing.is_empty().then_some(block))
+        .collect();
+    for (block, incoming) in predecessors.iter().enumerate() {
+        reverse_successors[block] = incoming.clone();
+    }
+    let tree = DominatorTree::compute(&reverse_successors, virtual_exit)?;
+    let frontiers = if include_frontier {
+        let mut frontiers = dominance_frontiers(&reverse_successors, &tree, virtual_exit);
+        frontiers.truncate(original_blocks);
+        for frontier in &mut frontiers {
+            frontier.retain(|block| *block < original_blocks);
+        }
+        frontiers
+    } else {
+        vec![Vec::new(); original_blocks]
+    };
+    Ok((
+        PostDominatorTree {
+            tree,
+            virtual_exit,
+            original_blocks,
+        },
+        frontiers,
+    ))
+}
+
+fn strongly_connected_regions(
+    predecessors: &[Vec<usize>],
+    successors: &[Vec<usize>],
+    dominators: &DominatorTree,
+    root: usize,
+) -> (Vec<StronglyConnectedRegion>, Vec<usize>) {
+    let mut visited = vec![false; successors.len()];
+    let mut postorder = Vec::with_capacity(successors.len());
+    for seed in std::iter::once(root).chain((0..successors.len()).filter(|block| *block != root)) {
+        if visited[seed] {
+            continue;
+        }
+        visited[seed] = true;
+        let mut stack = vec![(seed, 0usize)];
+        while let Some((block, next_successor)) = stack.last_mut() {
+            if *next_successor == successors[*block].len() {
+                postorder.push(*block);
+                stack.pop();
+                continue;
+            }
+            let successor = successors[*block][*next_successor];
+            *next_successor += 1;
+            if !visited[successor] {
+                visited[successor] = true;
+                stack.push((successor, 0));
+            }
+        }
+    }
+
+    let mut component = vec![usize::MAX; successors.len()];
+    let mut raw_components = Vec::<Vec<usize>>::new();
+    for seed in postorder.into_iter().rev() {
+        if component[seed] != usize::MAX {
+            continue;
+        }
+        let component_id = raw_components.len();
+        component[seed] = component_id;
+        let mut members = Vec::new();
+        let mut stack = vec![seed];
+        while let Some(block) = stack.pop() {
+            members.push(block);
+            for &predecessor in predecessors[block].iter().rev() {
+                if component[predecessor] == usize::MAX {
+                    component[predecessor] = component_id;
+                    stack.push(predecessor);
+                }
+            }
+        }
+        members.sort_unstable();
+        raw_components.push(members);
+    }
+
+    let regions = raw_components
+        .iter()
+        .enumerate()
+        .map(|(component_id, members)| {
+            let mut entries = BTreeSet::new();
+            for &block in members {
+                if block == root
+                    || predecessors[block]
+                        .iter()
+                        .any(|predecessor| component[*predecessor] != component_id)
+                {
+                    entries.insert(block);
+                }
+            }
+            let cyclic = members.len() > 1
+                || members
+                    .first()
+                    .is_some_and(|block| successors[*block].contains(block));
+            let reducible_header = if entries.len() == 1 {
+                entries.iter().next().copied().filter(|header| {
+                    members
+                        .iter()
+                        .all(|block| dominators.dominates(*header, *block))
+                })
+            } else {
+                None
+            };
+            StronglyConnectedRegion {
+                blocks: members.clone(),
+                entries: entries.into_iter().collect(),
+                cyclic,
+                reducible_header,
+            }
+        })
+        .collect();
+    (regions, component)
+}
+
+fn natural_loops(
+    predecessors: &[Vec<usize>],
+    successors: &[Vec<usize>],
+    dominators: &DominatorTree,
+) -> Result<Vec<NaturalLoop>, CfgError> {
+    let mut by_header = vec![None::<BTreeSet<usize>>; successors.len()];
+    for (tail, outgoing) in successors.iter().enumerate() {
+        for &header in outgoing {
+            if !dominators.dominates(header, tail) {
+                continue;
+            }
+            let blocks = by_header[header].get_or_insert_with(BTreeSet::new);
+            blocks.insert(header);
+            let mut stack = vec![tail];
+            while let Some(block) = stack.pop() {
+                if blocks.insert(block) {
+                    stack.extend(predecessors[block].iter().copied());
+                }
+            }
+        }
+    }
+    let mut loops = by_header
+        .into_iter()
+        .enumerate()
+        .filter_map(|(header, blocks)| {
+            blocks.map(|blocks| NaturalLoop {
+                header,
+                blocks,
+                parent: None,
+            })
+        })
+        .collect::<Vec<_>>();
+    loops.sort_by_key(|natural_loop| (natural_loop.blocks.len(), natural_loop.header));
+
+    let mut innermost_for_block = vec![None::<usize>; successors.len()];
+    for child in (0..loops.len()).rev() {
+        let parent = innermost_for_block[loops[child].header];
+        if parent.is_some_and(|parent| !loops[parent].blocks.is_superset(&loops[child].blocks)) {
+            return Err(CfgError::InvalidGraph(
+                "natural loops overlap without nesting",
+            ));
+        }
+        loops[child].parent = parent;
+        for &block in &loops[child].blocks {
+            innermost_for_block[block] = Some(child);
+        }
+    }
+    Ok(loops)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_graph() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1], vec![2], vec![]], 0).unwrap();
+        assert_eq!(cfg.dominators.idom, vec![None, Some(0), Some(1)]);
+        assert!(cfg.dominators.dominates(0, 2));
+        assert!(cfg.postdominators.postdominates(2, 0));
+    }
+
+    #[test]
+    fn diamond_frontier_and_control_dependence() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![3], vec![3], vec![]], 0).unwrap();
+        assert_eq!(cfg.dominance_frontier[1], vec![3]);
+        assert_eq!(cfg.dominance_frontier[2], vec![3]);
+        assert_eq!(cfg.controllers[1], vec![0]);
+        assert_eq!(cfg.controllers[2], vec![0]);
+        assert_eq!(cfg.control_dependents[0], vec![1, 2]);
+    }
+
+    #[test]
+    fn multiple_exits_use_virtual_postdominator() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![], vec![]], 0).unwrap();
+        assert_eq!(cfg.postdominators.common_postdominator(1, 2), None);
+        assert!(!cfg.postdominators.postdominates(1, 0));
+    }
+
+    #[test]
+    fn natural_and_irreducible_regions() {
+        let natural =
+            ControlFlowGraph::analyze(vec![vec![1], vec![2, 3], vec![1], vec![]], 0).unwrap();
+        assert_eq!(natural.loops.len(), 1);
+        assert_eq!(natural.loops[0].header, 1);
+
+        let irreducible =
+            ControlFlowGraph::analyze(vec![vec![1, 2], vec![2], vec![1, 3], vec![]], 0).unwrap();
+        let region = irreducible
+            .sccs
+            .iter()
+            .find(|region| region.cyclic && region.blocks.len() == 2)
+            .unwrap();
+        assert_eq!(region.entries, vec![1, 2]);
+        assert_eq!(region.reducible_header, None);
+    }
+
+    #[test]
+    fn forward_analysis_retains_sccs_without_control_dependence() {
+        let successors = vec![vec![1, 2], vec![2], vec![1, 3], vec![]];
+        let full = ControlFlowGraph::analyze(successors.clone(), 0).unwrap();
+        let forward = ForwardControlFlowGraph::analyze(successors.clone(), 0).unwrap();
+        let structure = ForwardControlFlowGraph::analyze_structure(successors, 0).unwrap();
+        assert_eq!(forward.dominators, full.dominators);
+        assert_eq!(forward.dominance_frontier, full.dominance_frontier);
+        assert_eq!(forward.sccs, full.sccs);
+        assert_eq!(forward.scc_for_block, full.scc_for_block);
+        assert_eq!(forward.loops, full.loops);
+        assert_eq!(structure.dominators, full.dominators);
+        assert_eq!(structure.sccs, full.sccs);
+        assert!(structure.dominance_frontier.iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn bidirectional_structure_retains_postdominators_without_control_dependence() {
+        let successors = vec![vec![1, 2], vec![3], vec![3], vec![]];
+        let full = ControlFlowGraph::analyze(successors.clone(), 0).unwrap();
+        let structure = ControlFlowGraph::analyze_structure(successors, 0).unwrap();
+        assert_eq!(structure.dominators, full.dominators);
+        assert_eq!(structure.postdominators, full.postdominators);
+        assert_eq!(structure.sccs, full.sccs);
+        assert!(structure.dominance_frontier.iter().all(Vec::is_empty));
+        assert!(structure.postdominance_frontier.iter().all(Vec::is_empty));
+        assert!(structure.controllers.iter().all(Vec::is_empty));
+        assert!(structure.control_dependents.iter().all(Vec::is_empty));
+    }
+
+    #[test]
+    fn multiple_backedges_to_one_header_form_their_union() {
+        let cfg =
+            ControlFlowGraph::analyze(vec![vec![1], vec![2, 3], vec![1], vec![1]], 0).unwrap();
+
+        assert_eq!(cfg.loops.len(), 1);
+        assert_eq!(cfg.loops[0].header, 1);
+        assert_eq!(cfg.loops[0].blocks, BTreeSet::from([1, 2, 3]));
+        assert_eq!(cfg.loops[0].parent, None);
+    }
+
+    #[test]
+    fn deeply_nested_loop_forest_has_direct_parents() {
+        const DEPTH: usize = 128;
+        const BLOCKS: usize = DEPTH + 1;
+        let mut successors = vec![Vec::new(); BLOCKS];
+        for (block, outgoing) in successors.iter_mut().enumerate().take(DEPTH) {
+            outgoing.push(block + 1);
+        }
+        for header in 1..=DEPTH {
+            successors[DEPTH].push(header);
+        }
+
+        let cfg = ControlFlowGraph::analyze(successors, 0).unwrap();
+
+        assert_eq!(cfg.loops.len(), DEPTH);
+        for (child, loop_info) in cfg.loops.iter().enumerate().take(DEPTH - 1) {
+            assert_eq!(loop_info.parent, Some(child + 1));
+            assert_eq!(loop_info.header, DEPTH - child);
+        }
+        assert_eq!(cfg.loops[DEPTH - 1].header, 1);
+        assert_eq!(cfg.loops[DEPTH - 1].parent, None);
+    }
+
+    #[test]
+    fn reports_bad_edges_and_unreachable_blocks() {
+        assert_eq!(
+            ControlFlowGraph::analyze(vec![vec![2], vec![]], 0).unwrap_err(),
+            CfgError::EdgeOutOfRange {
+                source: 0,
+                target: 2,
+                blocks: 2,
+            }
+        );
+        assert_eq!(
+            ControlFlowGraph::analyze(vec![vec![], vec![]], 0).unwrap_err(),
+            CfgError::Unreachable(vec![1])
+        );
+    }
+
+    #[test]
+    fn deep_graph_is_iterative() {
+        const BLOCKS: usize = 20_000;
+        let mut successors = vec![Vec::new(); BLOCKS];
+        for (block, outgoing) in successors.iter_mut().enumerate().take(BLOCKS - 1) {
+            outgoing.push(block + 1);
+        }
+        let cfg = ControlFlowGraph::analyze(successors, 0).unwrap();
+        assert!(cfg.dominators.dominates(0, BLOCKS - 1));
+        assert!(cfg.postdominators.postdominates(BLOCKS - 1, 0));
+    }
+}

--- a/crates/causal/src/graph.rs
+++ b/crates/causal/src/graph.rs
@@ -13,21 +13,47 @@ pub enum EdgeKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IncompleteReason {
+    /// The analysis input does not expose enough behavior to establish a
+    /// dependency across this boundary.
+    Opaque(OpaqueBoundary),
+    /// The behavior is defined and available, but this analysis run did not
+    /// derive its dependency relation.
+    Analysis(AnalysisGap),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum OpaqueBoundary {
     /// A dynamic access could not be bounded to a known object or static
-    /// prefix. Bounded dynamic accesses are conservative but complete.
-    DynamicRegion,
+    /// prefix. Bounded dynamic accesses are conservative and complete.
+    UnboundedRegion,
     ExternalComponent,
-    HierarchicalReference,
     InoutPort,
-    RecursiveCall,
-    RuntimeLoop,
     TimedOrEventEffect,
-    /// The frontend produced an IR shape which violates the causal adapter's
-    /// invariants. This is an analyzer defect, not a user-language feature
-    /// which callers may silently leave unsupported.
-    MalformedModel,
-    /// Generic elaboration could not determine the concrete module shape.
+    /// Generic elaboration did not produce a concrete module shape.
     UnevaluatedGeneric,
+    /// Earlier conversion retained a source construct without a causal model.
+    UnsupportedConstruct,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AnalysisGap {
+    UnresolvedHierarchy,
+    RecursiveCall,
+    Loop(LoopAnalysisGap),
+    RegionMapping,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LoopAnalysisGap {
+    DynamicTripCount,
+    ExpansionLimit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AnalysisFailure {
+    /// The frontend produced an IR shape which violates the causal adapter's
+    /// invariants. This is an analyzer defect, not analysis incompleteness.
+    MalformedModel,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -120,6 +146,9 @@ mod tests {
 
     #[test]
     fn definite_paths_win_over_conservative_paths() {
+        // Why both reasons are present: completeness is one predicate, while
+        // clients still need to distinguish missing input behavior from a
+        // dependency the current analysis declined to derive.
         let graph = CausalGraph::from_parts(
             [
                 Edge {
@@ -138,9 +167,24 @@ mod tests {
                     kind: EdgeKind::Control,
                 },
             ],
-            [IncompleteReason::ExternalComponent],
+            [
+                IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent),
+                IncompleteReason::Analysis(AnalysisGap::Loop(LoopAnalysisGap::ExpansionLimit)),
+            ],
         );
         assert_eq!(graph.reaches(0, 1), Reachability::Proven);
-        assert_eq!(graph.incomplete().len(), 1);
+        assert_eq!(graph.incomplete().len(), 2);
+        assert!(
+            graph
+                .incomplete()
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::ExternalComponent))
+        );
+        assert!(
+            graph
+                .incomplete()
+                .contains(&IncompleteReason::Analysis(AnalysisGap::Loop(
+                    LoopAnalysisGap::ExpansionLimit
+                )))
+        );
     }
 }

--- a/crates/causal/src/graph.rs
+++ b/crates/causal/src/graph.rs
@@ -20,7 +20,12 @@ pub enum IncompleteReason {
     RecursiveCall,
     RuntimeLoop,
     TimedOrEventEffect,
-    UnsupportedSyntax,
+    /// The frontend produced an IR shape which violates the causal adapter's
+    /// invariants. This is an analyzer defect, not a user-language feature
+    /// which callers may silently leave unsupported.
+    MalformedModel,
+    /// Generic elaboration could not determine the concrete module shape.
+    UnevaluatedGeneric,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/causal/src/graph.rs
+++ b/crates/causal/src/graph.rs
@@ -13,6 +13,8 @@ pub enum EdgeKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IncompleteReason {
+    /// A dynamic access could not be bounded to a known object or static
+    /// prefix. Bounded dynamic accesses are conservative but complete.
     DynamicRegion,
     ExternalComponent,
     HierarchicalReference,

--- a/crates/causal/src/graph.rs
+++ b/crates/causal/src/graph.rs
@@ -1,0 +1,139 @@
+//! Deterministic causal graphs with explicit uncertainty provenance.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EdgeKind {
+    Value,
+    Control,
+    Address,
+    /// A conservative dependency introduced by an unresolved effect or alias.
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum IncompleteReason {
+    DynamicRegion,
+    ExternalComponent,
+    HierarchicalReference,
+    InoutPort,
+    RecursiveCall,
+    RuntimeLoop,
+    TimedOrEventEffect,
+    UnsupportedSyntax,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Edge<N> {
+    pub from: N,
+    pub to: N,
+    pub kind: EdgeKind,
+}
+
+/// Immutable result of one independently buildable unit (procedure/module).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CausalGraph<N> {
+    edges: Vec<Edge<N>>,
+    successors: BTreeMap<N, Vec<(N, EdgeKind)>>,
+    incomplete: BTreeSet<IncompleteReason>,
+}
+
+impl<N: Copy + Ord> CausalGraph<N> {
+    #[must_use]
+    pub fn from_parts(
+        edges: impl IntoIterator<Item = Edge<N>>,
+        incomplete: impl IntoIterator<Item = IncompleteReason>,
+    ) -> Self {
+        let mut edges = edges.into_iter().collect::<Vec<_>>();
+        edges.sort_unstable();
+        edges.dedup();
+        let mut successors = BTreeMap::<N, Vec<(N, EdgeKind)>>::new();
+        for edge in &edges {
+            successors
+                .entry(edge.from)
+                .or_default()
+                .push((edge.to, edge.kind));
+        }
+        Self {
+            edges,
+            successors,
+            incomplete: incomplete.into_iter().collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn edges(&self) -> &[Edge<N>] {
+        &self.edges
+    }
+
+    #[must_use]
+    pub fn incomplete(&self) -> &BTreeSet<IncompleteReason> {
+        &self.incomplete
+    }
+
+    /// Reachability with uncertainty tracked separately from a proven path.
+    #[must_use]
+    pub fn reaches(&self, from: N, to: N) -> Reachability {
+        let mut stack = vec![(from, false)];
+        let mut visited = BTreeSet::new();
+        let mut unknown_path = false;
+        while let Some((node, used_unknown)) = stack.pop() {
+            if !visited.insert((node, used_unknown)) {
+                continue;
+            }
+            if node == to && node != from {
+                if used_unknown {
+                    unknown_path = true;
+                } else {
+                    return Reachability::Proven;
+                }
+            }
+            for &(next, kind) in self.successors.get(&node).map_or(&[][..], Vec::as_slice) {
+                stack.push((next, used_unknown || kind == EdgeKind::Unknown));
+            }
+        }
+        if unknown_path {
+            Reachability::Unknown
+        } else {
+            Reachability::Disproven
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reachability {
+    Proven,
+    Disproven,
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definite_paths_win_over_conservative_paths() {
+        let graph = CausalGraph::from_parts(
+            [
+                Edge {
+                    from: 0,
+                    to: 1,
+                    kind: EdgeKind::Unknown,
+                },
+                Edge {
+                    from: 0,
+                    to: 2,
+                    kind: EdgeKind::Value,
+                },
+                Edge {
+                    from: 2,
+                    to: 1,
+                    kind: EdgeKind::Control,
+                },
+            ],
+            [IncompleteReason::ExternalComponent],
+        );
+        assert_eq!(graph.reaches(0, 1), Reachability::Proven);
+        assert_eq!(graph.incomplete().len(), 1);
+    }
+}

--- a/crates/causal/src/interval.rs
+++ b/crates/causal/src/interval.rs
@@ -1,0 +1,215 @@
+//! Unit-independent exact interval indexing.
+//!
+//! The index is deliberately separate from the byte-oriented memory adapter.
+//! Clients may use bytes, bits, words, or another ordered unit without lying
+//! about the alias domain.  Construction costs `O(N log N)` time and `O(N)`
+//! space.  One overlap query costs `O(log N + K)`, where `K` is the number of
+//! definitions returned; neither bound depends on the numerical interval
+//! width.
+
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExactInterval<O, V> {
+    pub object: O,
+    pub start: usize,
+    pub length: usize,
+    pub value: V,
+}
+
+impl<O, V> ExactInterval<O, V> {
+    #[must_use]
+    pub fn end(&self) -> Option<usize> {
+        self.start.checked_add(self.length)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisjointIntervalError<V> {
+    Empty { value: V },
+    Overflow { value: V },
+    Overlap { first: V, second: V },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Entry<V> {
+    start: usize,
+    end: usize,
+    value: V,
+}
+
+#[derive(Debug)]
+pub struct DisjointIntervalMap<O, V> {
+    objects: BTreeMap<O, Vec<Entry<V>>>,
+}
+
+impl<O: Ord, V: Copy> DisjointIntervalMap<O, V> {
+    pub fn try_new(
+        intervals: impl IntoIterator<Item = ExactInterval<O, V>>,
+    ) -> Result<Self, DisjointIntervalError<V>> {
+        let mut objects = BTreeMap::<O, Vec<Entry<V>>>::new();
+        for interval in intervals {
+            if interval.length == 0 {
+                return Err(DisjointIntervalError::Empty {
+                    value: interval.value,
+                });
+            }
+            let Some(end) = interval.end() else {
+                return Err(DisjointIntervalError::Overflow {
+                    value: interval.value,
+                });
+            };
+            objects.entry(interval.object).or_default().push(Entry {
+                start: interval.start,
+                end,
+                value: interval.value,
+            });
+        }
+
+        for entries in objects.values_mut() {
+            entries.sort_unstable_by_key(|entry| entry.start);
+            for pair in entries.windows(2) {
+                if pair[0].end > pair[1].start {
+                    return Err(DisjointIntervalError::Overlap {
+                        first: pair[0].value,
+                        second: pair[1].value,
+                    });
+                }
+            }
+        }
+        Ok(Self { objects })
+    }
+
+    pub fn overlapping(
+        &self,
+        object: &O,
+        start: usize,
+        length: usize,
+    ) -> Result<Overlapping<'_, V>, InvalidInterval> {
+        if length == 0 {
+            return Err(InvalidInterval::Empty);
+        }
+        let end = start.checked_add(length).ok_or(InvalidInterval::Overflow)?;
+        let entries = self.objects.get(object).map_or(&[][..], Vec::as_slice);
+        let cursor = entries.partition_point(|entry| entry.end <= start);
+        Ok(Overlapping {
+            entries,
+            cursor,
+            end,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidInterval {
+    Empty,
+    Overflow,
+}
+
+pub struct Overlapping<'a, V> {
+    entries: &'a [Entry<V>],
+    cursor: usize,
+    end: usize,
+}
+
+impl<V: Copy> Iterator for Overlapping<'_, V> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry = self.entries.get(self.cursor)?;
+        if entry.start >= self.end {
+            return None;
+        }
+        self.cursor += 1;
+        Some(entry.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_queries_return_only_overlapping_disjoint_definitions() {
+        let index = DisjointIntervalMap::try_new([
+            ExactInterval {
+                object: 1u8,
+                start: 0,
+                length: 8,
+                value: 10,
+            },
+            ExactInterval {
+                object: 1,
+                start: 16,
+                length: 8,
+                value: 11,
+            },
+            ExactInterval {
+                object: 2,
+                start: 4,
+                length: 8,
+                value: 12,
+            },
+        ])
+        .unwrap();
+
+        assert_eq!(
+            index.overlapping(&1, 4, 16).unwrap().collect::<Vec<_>>(),
+            vec![10, 11]
+        );
+        assert_eq!(
+            index.overlapping(&1, 8, 8).unwrap().collect::<Vec<_>>(),
+            Vec::<i32>::new()
+        );
+        assert_eq!(
+            index.overlapping(&2, 0, 4).unwrap().collect::<Vec<_>>(),
+            Vec::<i32>::new()
+        );
+    }
+
+    #[test]
+    fn construction_rejects_overlapping_definitions() {
+        let error = DisjointIntervalMap::try_new([
+            ExactInterval {
+                object: 1u8,
+                start: 8,
+                length: 8,
+                value: 3,
+            },
+            ExactInterval {
+                object: 1,
+                start: 0,
+                length: 9,
+                value: 2,
+            },
+        ])
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            DisjointIntervalError::Overlap {
+                first: 2,
+                second: 3
+            }
+        );
+    }
+
+    #[test]
+    fn numerical_width_does_not_expand_the_index() {
+        let index = DisjointIntervalMap::try_new([ExactInterval {
+            object: 1u8,
+            start: 0,
+            length: 16 * 1024 * 1024,
+            value: 7,
+        }])
+        .unwrap();
+
+        assert_eq!(
+            index
+                .overlapping(&1, 8 * 1024 * 1024, 1)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![7]
+        );
+    }
+}

--- a/crates/causal/src/lib.rs
+++ b/crates/causal/src/lib.rs
@@ -1,0 +1,15 @@
+//! Sparse, IR-independent causal analysis.
+//!
+//! Front ends translate syntax into dense control-flow blocks, ordered memory
+//! events and half-open regions.  The analysis deliberately owns no Veryl IR
+//! types, global symbol tables or source locations, so one immutable input can
+//! be analyzed independently on any worker thread.
+
+pub mod cfg;
+pub mod graph;
+pub mod interval;
+pub mod memory;
+pub mod memory_ssa;
+pub mod procedure;
+pub mod region;
+pub mod ssa;

--- a/crates/causal/src/memory.rs
+++ b/crates/causal/src/memory.rs
@@ -1,0 +1,82 @@
+//! Memory locations and byte-range aliasing.
+//!
+//! These types are one alias-domain implementation.  MemorySSA itself does
+//! not depend on them: clients may use a different query and alias oracle.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MemoryLocation<O> {
+    pub object: O,
+    pub offset: i64,
+    pub byte_len: usize,
+}
+
+impl<O: Copy> MemoryLocation<O> {
+    #[must_use]
+    pub fn end(self) -> Option<i64> {
+        self.offset.checked_add(i64::try_from(self.byte_len).ok()?)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryEffect<O> {
+    Exact(MemoryLocation<O>),
+    UnknownObject(O),
+    UnknownAll,
+}
+
+/// Conservatively decide whether two byte-range effects may touch the same
+/// memory.  Callers are responsible for rejecting empty or overflowing exact
+/// ranges when constructing their IR adapter.
+#[must_use]
+pub fn effects_may_alias<O: Copy + Eq>(left: MemoryEffect<O>, right: MemoryEffect<O>) -> bool {
+    match (left, right) {
+        (MemoryEffect::UnknownAll, _) | (_, MemoryEffect::UnknownAll) => true,
+        (MemoryEffect::UnknownObject(left), MemoryEffect::UnknownObject(right)) => left == right,
+        (MemoryEffect::UnknownObject(object), MemoryEffect::Exact(location))
+        | (MemoryEffect::Exact(location), MemoryEffect::UnknownObject(object)) => {
+            object == location.object
+        }
+        (MemoryEffect::Exact(left), MemoryEffect::Exact(right)) => {
+            if left.object != right.object {
+                return false;
+            }
+            let (Some(left_end), Some(right_end)) = (left.end(), right.end()) else {
+                return true;
+            };
+            left.offset < right_end && right.offset < left_end
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exact(object: u8, offset: i64, byte_len: usize) -> MemoryEffect<u8> {
+        MemoryEffect::Exact(MemoryLocation {
+            object,
+            offset,
+            byte_len,
+        })
+    }
+
+    #[test]
+    fn exact_aliasing_is_object_and_half_open_range_based() {
+        assert!(effects_may_alias(exact(1, 4, 8), exact(1, 8, 8)));
+        assert!(!effects_may_alias(exact(1, 0, 8), exact(1, 8, 8)));
+        assert!(!effects_may_alias(exact(1, 4, 8), exact(2, 4, 8)));
+    }
+
+    #[test]
+    fn unknown_effects_are_conservative_within_their_domain() {
+        assert!(effects_may_alias(
+            MemoryEffect::UnknownObject(1),
+            exact(1, 64, 8)
+        ));
+        assert!(!effects_may_alias(
+            MemoryEffect::UnknownObject(1),
+            exact(2, 64, 8)
+        ));
+        assert!(effects_may_alias(MemoryEffect::UnknownAll, exact(2, 64, 8)));
+    }
+}

--- a/crates/causal/src/memory_ssa.rs
+++ b/crates/causal/src/memory_ssa.rs
@@ -1,0 +1,1038 @@
+//! IR- and alias-domain-independent access-based MemorySSA.
+//!
+//! This module owns only the sparse `LiveOnEntry`/`MemoryDef`/`MemoryPhi`
+//! graph, program-point coordinates into that graph, and the generic clobber
+//! walk.  Definition effects, byte ranges, read queries, value numbers, and
+//! lowering certificates belong to client adapters.
+//!
+//! Graph construction uses `O(B + E + C + D + F)` storage, where `B/E`
+//! describe the CFG, `C` is the number of captured program points, `D` is the
+//! number of memory definitions, and `F` is the number of MemoryPhi inputs. A
+//! clobber query is linear in the visited graph in the worst case and reuses
+//! one `O(D + F)` scratch allocation across all of that query's start points.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use crate::ssa::{self, Event, SsaCfg, Version};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MemoryAccessId(usize);
+
+/// One ordered program event.  An event with a definition creates one
+/// `MemoryDef`; an event without one only records a queryable program point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryAccessEvent<D, P> {
+    pub point: P,
+    pub definition: Option<D>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryPointAccess {
+    pub before: MemoryAccessId,
+    pub after: MemoryAccessId,
+}
+
+/// Coordinate conversion produced while building a graph.
+///
+/// This is intentionally separate from `MemoryAccessGraph`: clients that
+/// retain their own instruction-to-access mapping can discard it without
+/// changing the graph or the clobber walker.
+#[derive(Debug)]
+pub struct MemoryPointMap<P> {
+    events: BTreeMap<P, MemoryPointAccess>,
+    block_entries: Vec<MemoryAccessId>,
+    block_exits: Vec<MemoryAccessId>,
+}
+
+impl<P: Copy + Ord> MemoryPointMap<P> {
+    #[must_use]
+    pub fn event(&self, point: P) -> Option<MemoryPointAccess> {
+        self.events.get(&point).copied()
+    }
+
+    #[must_use]
+    pub fn block_entry(&self, block: usize) -> Option<MemoryAccessId> {
+        self.block_entries.get(block).copied()
+    }
+
+    #[must_use]
+    pub fn block_exit(&self, block: usize) -> Option<MemoryAccessId> {
+        self.block_exits.get(block).copied()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryAccess<'a, D> {
+    LiveOnEntry,
+    Definition {
+        definition: &'a D,
+        previous: MemoryAccessId,
+    },
+    Phi {
+        block: usize,
+        inputs: &'a [(usize, MemoryAccessId)],
+    },
+}
+
+#[derive(Debug)]
+enum MemoryAccessNode<D> {
+    LiveOnEntry,
+    Definition {
+        definition: D,
+        previous: MemoryAccessId,
+    },
+    Phi {
+        block: usize,
+        /// `(predecessor block, reaching memory state)` in CFG predecessor
+        /// order.  Keeping the edge identity lets clients build structural
+        /// certificates instead of treating every phi in one block as equal.
+        inputs: Vec<(usize, MemoryAccessId)>,
+    },
+}
+
+/// Sparse memory-state graph.  It contains no alias information and no read
+/// query results.
+#[derive(Debug)]
+pub struct MemoryAccessGraph<D> {
+    nodes: Vec<MemoryAccessNode<D>>,
+    definition_count: usize,
+    phi_count: usize,
+}
+
+impl<D> MemoryAccessGraph<D> {
+    #[must_use]
+    pub fn access(&self, access: MemoryAccessId) -> Option<MemoryAccess<'_, D>> {
+        match self.nodes.get(access.0)? {
+            MemoryAccessNode::LiveOnEntry => Some(MemoryAccess::LiveOnEntry),
+            MemoryAccessNode::Definition {
+                definition,
+                previous,
+            } => Some(MemoryAccess::Definition {
+                definition,
+                previous: *previous,
+            }),
+            MemoryAccessNode::Phi { block, inputs } => Some(MemoryAccess::Phi {
+                block: *block,
+                inputs,
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn access_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    #[must_use]
+    pub fn definition_count(&self) -> usize {
+        self.definition_count
+    }
+
+    #[must_use]
+    pub fn phi_count(&self) -> usize {
+        self.phi_count
+    }
+}
+
+/// Alias policy supplied by a client.  The definition identity is the graph
+/// payload; effects and query representation remain outside MemorySSA.
+pub trait AliasOracle<D, Q> {
+    fn may_alias(&self, definition: &D, query: &Q) -> bool;
+}
+
+impl<D, Q, F> AliasOracle<D, Q> for F
+where
+    F: Fn(&D, &Q) -> bool,
+{
+    fn may_alias(&self, definition: &D, query: &Q) -> bool {
+        self(definition, query)
+    }
+}
+
+/// Result of a clobber walk.  `Access` is a stable identity within the graph
+/// and can therefore be embedded in a client-specific snapshot certificate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryClobber {
+    Access(MemoryAccessId),
+    /// A closed cycle without a resolvable MemoryPhi.  Graphs built from a
+    /// normal reachable CFG should not produce this result.
+    Indeterminate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClobberResolution {
+    Access(usize),
+    Cycle,
+}
+
+#[derive(Debug)]
+enum ResolveFrame {
+    Enter(usize),
+    FinishDefinition(usize),
+    FinishPhi { access: usize, inputs: usize },
+}
+
+/// Reusable, query-local state for clobber walking.  It owns no graph and no
+/// alias-domain data.
+#[derive(Debug, Default)]
+pub struct ClobberWalker {
+    epochs: Vec<u32>,
+    states: Vec<u8>,
+    results: Vec<Option<ClobberResolution>>,
+    epoch: u32,
+    frames: Vec<ResolveFrame>,
+    values: Vec<ClobberResolution>,
+}
+
+impl ClobberWalker {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Find the nearest definition that may alias `query`.  Diverging
+    /// incoming clobbers resolve to their nearest `MemoryPhi`.
+    pub fn clobber<D, Q>(
+        &mut self,
+        graph: &MemoryAccessGraph<D>,
+        start: MemoryAccessId,
+        query: &Q,
+        alias_oracle: &impl AliasOracle<D, Q>,
+    ) -> Option<MemoryClobber> {
+        self.query(graph, query, alias_oracle).clobber(start)
+    }
+
+    /// Start one alias query which may resolve several program points. Results
+    /// are memoized only for the lifetime of this session and are discarded
+    /// before a different alias query begins.
+    pub fn query<'a, D, Q, A>(
+        &'a mut self,
+        graph: &'a MemoryAccessGraph<D>,
+        query: &'a Q,
+        alias_oracle: &'a A,
+    ) -> ClobberQuery<'a, D, Q, A>
+    where
+        A: AliasOracle<D, Q>,
+    {
+        self.epochs.resize(graph.nodes.len(), 0);
+        self.states.resize(graph.nodes.len(), 0);
+        self.results.resize(graph.nodes.len(), None);
+        self.epoch = self.epoch.wrapping_add(1);
+        if self.epoch == 0 {
+            self.epochs.fill(0);
+            self.epoch = 1;
+        }
+        ClobberQuery {
+            walker: self,
+            graph,
+            query,
+            alias_oracle,
+        }
+    }
+
+    fn find_clobber<D, Q>(
+        &mut self,
+        nodes: &[MemoryAccessNode<D>],
+        start: usize,
+        query: &Q,
+        alias_oracle: &impl AliasOracle<D, Q>,
+    ) -> MemoryClobber {
+        let current_epoch = self.epoch;
+        self.frames.clear();
+        self.values.clear();
+        self.frames.push(ResolveFrame::Enter(start));
+
+        while let Some(frame) = self.frames.pop() {
+            match frame {
+                ResolveFrame::Enter(access) => {
+                    if self.epochs[access] == current_epoch && self.states[access] != 0 {
+                        match self.states[access] {
+                            1 => self.values.push(ClobberResolution::Cycle),
+                            2 => self.values.push(
+                                self.results[access]
+                                    .expect("a resolved clobber node retains its result"),
+                            ),
+                            _ => unreachable!("current-epoch clobber state is valid"),
+                        }
+                        continue;
+                    }
+                    self.epochs[access] = current_epoch;
+                    self.states[access] = 1;
+                    self.results[access] = None;
+                    match &nodes[access] {
+                        MemoryAccessNode::LiveOnEntry => {
+                            let result = ClobberResolution::Access(access);
+                            self.states[access] = 2;
+                            self.results[access] = Some(result);
+                            self.values.push(result);
+                        }
+                        MemoryAccessNode::Definition {
+                            definition,
+                            previous,
+                        } => {
+                            if alias_oracle.may_alias(definition, query) {
+                                let result = ClobberResolution::Access(access);
+                                self.states[access] = 2;
+                                self.results[access] = Some(result);
+                                self.values.push(result);
+                            } else {
+                                self.frames.push(ResolveFrame::FinishDefinition(access));
+                                self.frames.push(ResolveFrame::Enter(previous.0));
+                            }
+                        }
+                        MemoryAccessNode::Phi { inputs, .. } => {
+                            self.frames.push(ResolveFrame::FinishPhi {
+                                access,
+                                inputs: inputs.len(),
+                            });
+                            self.frames.extend(
+                                inputs
+                                    .iter()
+                                    .rev()
+                                    .map(|(_, input)| ResolveFrame::Enter(input.0)),
+                            );
+                        }
+                    }
+                }
+                ResolveFrame::FinishDefinition(access) => {
+                    let result = self
+                        .values
+                        .pop()
+                        .expect("a MemoryDef predecessor produces one clobber result");
+                    if result == ClobberResolution::Cycle {
+                        // A disjoint definition on a loop backedge cannot be
+                        // resolved independently of the active MemoryPhi.
+                        self.states[access] = 0;
+                        self.results[access] = None;
+                    } else {
+                        self.states[access] = 2;
+                        self.results[access] = Some(result);
+                    }
+                    self.values.push(result);
+                }
+                ResolveFrame::FinishPhi { access, inputs } => {
+                    let first = self
+                        .values
+                        .len()
+                        .checked_sub(inputs)
+                        .expect("every MemoryPhi input produces one clobber result");
+                    let mut common = None::<ClobberResolution>;
+                    let mut diverged = false;
+                    for result in self.values.drain(first..) {
+                        if result == ClobberResolution::Cycle {
+                            continue;
+                        }
+                        match common {
+                            Some(previous) if previous != result => diverged = true,
+                            Some(_) => {}
+                            None => common = Some(result),
+                        }
+                    }
+                    let result = if diverged {
+                        ClobberResolution::Access(access)
+                    } else {
+                        common.unwrap_or(ClobberResolution::Access(access))
+                    };
+                    self.states[access] = 2;
+                    self.results[access] = Some(result);
+                    self.values.push(result);
+                }
+            }
+        }
+
+        let resolution = self
+            .values
+            .pop()
+            .expect("one clobber query produces one result");
+        debug_assert!(self.values.is_empty());
+        match resolution {
+            ClobberResolution::Access(access) => MemoryClobber::Access(MemoryAccessId(access)),
+            ClobberResolution::Cycle => MemoryClobber::Indeterminate,
+        }
+    }
+}
+
+/// Multi-point clobber query for one immutable alias query. Resolving a phi
+/// root and then its incoming states therefore visits each access at most once
+/// instead of restarting a whole-graph walk per edge.
+pub struct ClobberQuery<'a, D, Q, A> {
+    walker: &'a mut ClobberWalker,
+    graph: &'a MemoryAccessGraph<D>,
+    query: &'a Q,
+    alias_oracle: &'a A,
+}
+
+impl<D, Q, A> ClobberQuery<'_, D, Q, A>
+where
+    A: AliasOracle<D, Q>,
+{
+    pub fn clobber(&mut self, start: MemoryAccessId) -> Option<MemoryClobber> {
+        (start.0 < self.graph.nodes.len()).then(|| {
+            self.walker
+                .find_clobber(&self.graph.nodes, start.0, self.query, self.alias_oracle)
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySsaError {
+    pub rule: &'static str,
+    pub block: Option<usize>,
+    pub message: String,
+}
+
+impl MemorySsaError {
+    fn new(rule: &'static str, block: Option<usize>, message: impl Into<String>) -> Self {
+        Self {
+            rule,
+            block,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for MemorySsaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.rule)?;
+        if let Some(block) = self.block {
+            write!(formatter, " at block {block}")?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl std::error::Error for MemorySsaError {}
+
+impl From<ssa::SsaError> for MemorySsaError {
+    fn from(error: ssa::SsaError) -> Self {
+        Self {
+            rule: error.rule,
+            block: error.block,
+            message: error.message,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PendingPoint<D, P> {
+    point: P,
+    before_usage: usize,
+    definition: Option<D>,
+}
+
+#[derive(Debug)]
+struct PendingDefinition<D> {
+    definition: D,
+    predecessor_usage: usize,
+}
+
+/// Build a standard access-based MemorySSA graph and a separate coordinate
+/// map.  The caller decides which events are memory definitions; no effect or
+/// alias representation crosses this interface.
+pub fn build<D, P>(
+    cfg: &impl SsaCfg,
+    memory_events: &[Vec<MemoryAccessEvent<D, P>>],
+) -> Result<(MemoryAccessGraph<D>, MemoryPointMap<P>), MemorySsaError>
+where
+    D: Copy + Ord,
+    P: Copy + Ord,
+{
+    if memory_events.len() != cfg.successors().len() {
+        return Err(MemorySsaError::new(
+            "MEMORY_SSA.MODEL_SHAPE",
+            None,
+            "memory-event and CFG block tables have different lengths",
+        ));
+    }
+
+    // A single SSA variable represents abstract memory state.  Uses at event
+    // and block boundaries exist solely to build the separately returned
+    // coordinate map.
+    let mut events = vec![Vec::<Event<(), D, usize>>::new(); memory_events.len()];
+    let mut pending_points = Vec::<PendingPoint<D, P>>::new();
+    let mut pending_definitions = Vec::<PendingDefinition<D>>::new();
+    let mut block_entry_usages = Vec::with_capacity(memory_events.len());
+    let mut block_exit_usages = Vec::with_capacity(memory_events.len());
+    let mut point_ids = BTreeSet::<P>::new();
+    let mut next_usage = 0usize;
+
+    for (block, block_events) in memory_events.iter().enumerate() {
+        let entry_usage = allocate_usage(&mut next_usage)?;
+        events[block].push(Event::Use {
+            variable: (),
+            usage: entry_usage,
+        });
+        block_entry_usages.push(entry_usage);
+
+        for event in block_events {
+            if !point_ids.insert(event.point) {
+                return Err(MemorySsaError::new(
+                    "MEMORY_SSA.POINT_IDENTITY",
+                    Some(block),
+                    "one memory program-point identity occurs more than once",
+                ));
+            }
+            let before_usage = allocate_usage(&mut next_usage)?;
+            events[block].push(Event::Use {
+                variable: (),
+                usage: before_usage,
+            });
+            pending_points.push(PendingPoint {
+                point: event.point,
+                before_usage,
+                definition: event.definition,
+            });
+            if let Some(definition) = event.definition {
+                events[block].push(Event::Definition {
+                    variable: (),
+                    definition,
+                });
+                pending_definitions.push(PendingDefinition {
+                    definition,
+                    predecessor_usage: before_usage,
+                });
+            }
+        }
+
+        let exit_usage = allocate_usage(&mut next_usage)?;
+        events[block].push(Event::Use {
+            variable: (),
+            usage: exit_usage,
+        });
+        block_exit_usages.push(exit_usage);
+    }
+
+    let ssa = ssa::build(cfg, &events)?;
+    let mut definition_accesses = BTreeMap::<D, MemoryAccessId>::new();
+    for (definition_index, definition) in pending_definitions.iter().enumerate() {
+        let access = MemoryAccessId(definition_index + 1);
+        if definition_accesses
+            .insert(definition.definition, access)
+            .is_some()
+        {
+            return Err(MemorySsaError::new(
+                "MEMORY_SSA.DEFINITION_IDENTITY",
+                None,
+                "one definition identity has multiple MemoryDefs",
+            ));
+        }
+    }
+
+    let mut phi_accesses = BTreeMap::<usize, MemoryAccessId>::new();
+    let phi_start = pending_definitions.len() + 1;
+    for (phi_index, phi) in ssa.phis.iter().enumerate() {
+        let access = MemoryAccessId(phi_start + phi_index);
+        if phi_accesses.insert(phi.block, access).is_some() {
+            return Err(MemorySsaError::new(
+                "MEMORY_SSA.PHI_IDENTITY",
+                Some(phi.block),
+                "one block has multiple phis for the single memory state",
+            ));
+        }
+    }
+
+    let mut nodes = Vec::with_capacity(1 + pending_definitions.len() + ssa.phis.len());
+    nodes.push(MemoryAccessNode::LiveOnEntry);
+    for definition in &pending_definitions {
+        let access = definition_accesses[&definition.definition];
+        let previous = ssa
+            .uses
+            .get(&definition.predecessor_usage)
+            .copied()
+            .ok_or_else(|| {
+                MemorySsaError::new(
+                    "MEMORY_SSA.DEFINITION_PREDECESSOR",
+                    None,
+                    "MemoryDef has no reaching memory state",
+                )
+            })?;
+        let previous = access_for_version(previous, &definition_accesses, &phi_accesses)?;
+        debug_assert_eq!(nodes.len(), access.0);
+        nodes.push(MemoryAccessNode::Definition {
+            definition: definition.definition,
+            previous,
+        });
+    }
+    for phi in &ssa.phis {
+        let access = phi_accesses[&phi.block];
+        let inputs = phi
+            .inputs
+            .iter()
+            .map(|&(predecessor, version)| {
+                access_for_version(version, &definition_accesses, &phi_accesses)
+                    .map(|access| (predecessor, access))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        debug_assert_eq!(nodes.len(), access.0);
+        nodes.push(MemoryAccessNode::Phi {
+            block: phi.block,
+            inputs,
+        });
+    }
+
+    let usage_access = |usage| {
+        let version = ssa.uses.get(&usage).copied().ok_or_else(|| {
+            MemorySsaError::new(
+                "MEMORY_SSA.POINT_VERSION",
+                None,
+                "memory program point has no reaching memory state",
+            )
+        })?;
+        access_for_version(version, &definition_accesses, &phi_accesses)
+    };
+    let mut point_accesses = BTreeMap::<P, MemoryPointAccess>::new();
+    for point in pending_points {
+        let before = usage_access(point.before_usage)?;
+        let after = point
+            .definition
+            .map_or(before, |definition| definition_accesses[&definition]);
+        if point_accesses
+            .insert(point.point, MemoryPointAccess { before, after })
+            .is_some()
+        {
+            return Err(MemorySsaError::new(
+                "MEMORY_SSA.POINT_ACCESS_IDENTITY",
+                None,
+                "one program point has multiple MemorySSA coordinate records",
+            ));
+        }
+    }
+    let block_entries = block_entry_usages
+        .into_iter()
+        .map(usage_access)
+        .collect::<Result<Vec<_>, _>>()?;
+    let block_exits = block_exit_usages
+        .into_iter()
+        .map(usage_access)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok((
+        MemoryAccessGraph {
+            nodes,
+            definition_count: pending_definitions.len(),
+            phi_count: ssa.phis.len(),
+        },
+        MemoryPointMap {
+            events: point_accesses,
+            block_entries,
+            block_exits,
+        },
+    ))
+}
+
+fn allocate_usage(next_usage: &mut usize) -> Result<usize, MemorySsaError> {
+    let usage = *next_usage;
+    *next_usage = next_usage.checked_add(1).ok_or_else(|| {
+        MemorySsaError::new(
+            "MEMORY_SSA.USE_ID_RANGE",
+            None,
+            "memory use count exceeds usize",
+        )
+    })?;
+    Ok(usage)
+}
+
+fn access_for_version<D: Copy + Ord>(
+    version: Version<(), D>,
+    definitions: &BTreeMap<D, MemoryAccessId>,
+    phis: &BTreeMap<usize, MemoryAccessId>,
+) -> Result<MemoryAccessId, MemorySsaError> {
+    match version {
+        Version::Entry(()) => Ok(MemoryAccessId(0)),
+        Version::Definition { definition, .. } => {
+            definitions.get(&definition).copied().ok_or_else(|| {
+                MemorySsaError::new(
+                    "MEMORY_SSA.DEFINITION_ACCESS",
+                    None,
+                    "SSA definition has no MemoryDef",
+                )
+            })
+        }
+        Version::Phi { block, .. } => phis.get(&block).copied().ok_or_else(|| {
+            MemorySsaError::new(
+                "MEMORY_SSA.PHI_ACCESS",
+                Some(block),
+                "SSA phi has no MemoryPhi",
+            )
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cfg::ControlFlowGraph;
+    use crate::memory::{MemoryEffect, MemoryLocation, effects_may_alias};
+
+    type Object = u8;
+    type Instruction = (usize, usize);
+
+    #[derive(Debug)]
+    struct EffectEvent {
+        instruction: Instruction,
+        reads: Vec<MemoryEffect<Object>>,
+        writes: Vec<MemoryEffect<Object>>,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum TestClobber {
+        LiveOnEntry,
+        Definition(Instruction),
+        Phi(usize),
+        Indeterminate,
+    }
+
+    struct Analysis {
+        graph: MemoryAccessGraph<Instruction>,
+        points: MemoryPointMap<Instruction>,
+        writes: BTreeMap<Instruction, Vec<MemoryEffect<Object>>>,
+        reads: Vec<(Instruction, usize, MemoryEffect<Object>)>,
+    }
+
+    impl Analysis {
+        fn clobber(&self, instruction: Instruction, query: MemoryEffect<Object>) -> TestClobber {
+            let start = self.points.event(instruction).unwrap().before;
+            let oracle = |definition: &Instruction, query: &MemoryEffect<Object>| {
+                self.writes[definition]
+                    .iter()
+                    .copied()
+                    .any(|write| effects_may_alias(write, *query))
+            };
+            let mut walker = ClobberWalker::new();
+            match walker.clobber(&self.graph, start, &query, &oracle).unwrap() {
+                MemoryClobber::Indeterminate => TestClobber::Indeterminate,
+                MemoryClobber::Access(access) => match self.graph.access(access).unwrap() {
+                    MemoryAccess::LiveOnEntry => TestClobber::LiveOnEntry,
+                    MemoryAccess::Definition { definition, .. } => {
+                        TestClobber::Definition(*definition)
+                    }
+                    MemoryAccess::Phi { block, .. } => TestClobber::Phi(block),
+                },
+            }
+        }
+
+        fn only_clobber(&self) -> TestClobber {
+            assert_eq!(self.reads.len(), 1);
+            let (instruction, _, query) = self.reads[0];
+            self.clobber(instruction, query)
+        }
+    }
+
+    fn exact(object: Object, offset: i64, byte_len: usize) -> MemoryEffect<Object> {
+        MemoryEffect::Exact(MemoryLocation {
+            object,
+            offset,
+            byte_len,
+        })
+    }
+
+    fn event(
+        instruction: Instruction,
+        reads: Vec<MemoryEffect<Object>>,
+        writes: Vec<MemoryEffect<Object>>,
+    ) -> EffectEvent {
+        EffectEvent {
+            instruction,
+            reads,
+            writes,
+        }
+    }
+
+    fn analyze(cfg: &ControlFlowGraph, events: &[Vec<EffectEvent>]) -> Analysis {
+        let mut access_events = vec![Vec::new(); events.len()];
+        let mut writes = BTreeMap::new();
+        let mut reads = Vec::new();
+        for (block, block_events) in events.iter().enumerate() {
+            for event in block_events {
+                for (read_index, &read) in event.reads.iter().enumerate() {
+                    reads.push((event.instruction, read_index, read));
+                }
+                if !event.writes.is_empty() {
+                    writes.insert(event.instruction, event.writes.clone());
+                }
+                access_events[block].push(MemoryAccessEvent {
+                    point: event.instruction,
+                    definition: (!event.writes.is_empty()).then_some(event.instruction),
+                });
+            }
+        }
+        let (graph, points) = build(cfg, &access_events).unwrap();
+        Analysis {
+            graph,
+            points,
+            writes,
+            reads,
+        }
+    }
+
+    #[test]
+    fn exact_store_reaches_later_load() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[vec![
+                event((0, 0), vec![], vec![exact(1, 8, 4)]),
+                event((0, 1), vec![exact(1, 8, 4)], vec![]),
+            ]],
+        );
+
+        assert_eq!(analysis.only_clobber(), TestClobber::Definition((0, 0)));
+        assert_eq!(analysis.graph.definition_count(), 1);
+        assert_eq!(analysis.graph.phi_count(), 0);
+        assert_eq!(analysis.graph.access_count(), 2);
+    }
+
+    #[test]
+    fn point_map_supports_lowering_coordinates_without_owning_queries() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let analysis = analyze(&cfg, &[vec![event((0, 0), vec![], vec![exact(1, 8, 8)])]]);
+        let event = analysis.points.event((0, 0)).unwrap();
+
+        assert_eq!(
+            analysis.clobber((0, 0), exact(1, 8, 8)),
+            TestClobber::LiveOnEntry
+        );
+        let oracle = |definition: &Instruction, query: &MemoryEffect<Object>| {
+            analysis.writes[definition]
+                .iter()
+                .copied()
+                .any(|write| effects_may_alias(write, *query))
+        };
+        let mut walker = ClobberWalker::new();
+        let after = walker
+            .clobber(&analysis.graph, event.after, &exact(1, 8, 8), &oracle)
+            .unwrap();
+        let MemoryClobber::Access(after) = after else {
+            panic!("a store's post-state has a concrete clobber")
+        };
+        assert!(matches!(
+            analysis.graph.access(after),
+            Some(MemoryAccess::Definition {
+                definition: &(0, 0),
+                ..
+            })
+        ));
+        assert_eq!(analysis.points.block_entry(0), Some(event.before));
+        assert_eq!(analysis.points.block_exit(0), Some(event.after));
+    }
+
+    #[test]
+    fn disjoint_store_is_skipped_by_the_external_alias_oracle() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[vec![
+                event((0, 0), vec![], vec![exact(1, 0, 8)]),
+                event((0, 1), vec![exact(1, 16, 8)], vec![]),
+            ]],
+        );
+
+        assert_eq!(analysis.only_clobber(), TestClobber::LiveOnEntry);
+    }
+
+    #[test]
+    fn partial_overlap_and_unknown_object_are_clobbers() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let overlap = analyze(
+            &cfg,
+            &[vec![
+                event((0, 0), vec![], vec![exact(1, 4, 8)]),
+                event((0, 1), vec![exact(1, 8, 8)], vec![]),
+            ]],
+        );
+        assert_eq!(overlap.only_clobber(), TestClobber::Definition((0, 0)));
+
+        let unknown = analyze(
+            &cfg,
+            &[vec![
+                event((0, 0), vec![], vec![MemoryEffect::UnknownObject(1)]),
+                event((0, 1), vec![exact(1, 8, 8)], vec![]),
+            ]],
+        );
+        assert_eq!(unknown.only_clobber(), TestClobber::Definition((0, 0)));
+    }
+
+    #[test]
+    fn one_arm_store_resolves_to_the_join_phi() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![3], vec![3], vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[
+                vec![],
+                vec![event((1, 0), vec![], vec![exact(1, 8, 8)])],
+                vec![],
+                vec![event((3, 0), vec![exact(1, 8, 8)], vec![])],
+            ],
+        );
+
+        assert_eq!(analysis.only_clobber(), TestClobber::Phi(3));
+        assert_eq!(analysis.graph.phi_count(), 1);
+    }
+
+    #[test]
+    fn one_query_session_reuses_phi_input_clobbers() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![3], vec![3], vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[
+                vec![],
+                vec![event((1, 0), vec![], vec![exact(1, 8, 8)])],
+                vec![],
+                vec![event((3, 0), vec![exact(1, 8, 8)], vec![])],
+            ],
+        );
+        let calls = std::cell::Cell::new(0usize);
+        let oracle = |definition: &Instruction, query: &MemoryEffect<Object>| {
+            calls.set(calls.get() + 1);
+            analysis.writes[definition]
+                .iter()
+                .copied()
+                .any(|write| effects_may_alias(write, *query))
+        };
+        let query = exact(1, 8, 8);
+        let mut walker = ClobberWalker::new();
+        let mut session = walker.query(&analysis.graph, &query, &oracle);
+        let join = analysis.points.event((3, 0)).unwrap().before;
+        assert!(matches!(
+            session.clobber(join),
+            Some(MemoryClobber::Access(_))
+        ));
+        let calls_after_join = calls.get();
+        let left_exit = analysis.points.block_exit(1).unwrap();
+        assert!(matches!(
+            session.clobber(left_exit),
+            Some(MemoryClobber::Access(_))
+        ));
+        assert_eq!(calls.get(), calls_after_join);
+    }
+
+    #[test]
+    fn same_dominating_store_is_found_through_a_join() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![3], vec![3], vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[
+                vec![event((0, 0), vec![], vec![exact(1, 8, 8)])],
+                vec![],
+                vec![],
+                vec![event((3, 0), vec![exact(1, 8, 8)], vec![])],
+            ],
+        );
+
+        assert_eq!(analysis.only_clobber(), TestClobber::Definition((0, 0)));
+    }
+
+    #[test]
+    fn disjoint_loop_definition_does_not_hide_dominating_store() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1], vec![1, 2], vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[
+                vec![event((0, 0), vec![], vec![exact(1, 8, 8)])],
+                vec![
+                    event((1, 0), vec![], vec![exact(1, 64, 8)]),
+                    event((1, 1), vec![exact(1, 8, 8)], vec![]),
+                ],
+                vec![],
+            ],
+        );
+
+        assert_eq!(analysis.only_clobber(), TestClobber::Definition((0, 0)));
+        assert_eq!(analysis.graph.phi_count(), 1);
+    }
+
+    #[test]
+    fn aliasing_loop_definition_resolves_to_the_header_phi() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1], vec![1, 2], vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[
+                vec![event((0, 0), vec![], vec![exact(1, 8, 8)])],
+                vec![event((1, 0), vec![], vec![exact(1, 8, 1)])],
+                vec![],
+            ],
+        );
+
+        let exit = analysis.points.block_exit(1).unwrap();
+        let entry = analysis.points.block_entry(1).unwrap();
+        let oracle = |definition: &Instruction, query: &MemoryEffect<Object>| {
+            analysis.writes[definition]
+                .iter()
+                .copied()
+                .any(|write| effects_may_alias(write, *query))
+        };
+        let classify = |clobber| match clobber {
+            MemoryClobber::Indeterminate => TestClobber::Indeterminate,
+            MemoryClobber::Access(access) => match analysis.graph.access(access).unwrap() {
+                MemoryAccess::LiveOnEntry => TestClobber::LiveOnEntry,
+                MemoryAccess::Definition { definition, .. } => TestClobber::Definition(*definition),
+                MemoryAccess::Phi { block, .. } => TestClobber::Phi(block),
+            },
+        };
+        let mut walker = ClobberWalker::new();
+        assert_eq!(
+            classify(
+                walker
+                    .clobber(&analysis.graph, exit, &exact(1, 8, 8), &oracle)
+                    .unwrap()
+            ),
+            TestClobber::Definition((1, 0))
+        );
+        assert_eq!(
+            classify(
+                walker
+                    .clobber(&analysis.graph, entry, &exact(1, 8, 8), &oracle)
+                    .unwrap()
+            ),
+            TestClobber::Phi(1)
+        );
+    }
+
+    #[test]
+    fn graph_size_is_independent_of_effect_range_length() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let analysis = analyze(
+            &cfg,
+            &[vec![
+                event((0, 0), vec![], vec![exact(1, 1_000_000, 16 * 1024 * 1024)]),
+                event((0, 1), vec![exact(1, 2_000_000, 8)], vec![]),
+            ]],
+        );
+
+        assert_eq!(analysis.only_clobber(), TestClobber::Definition((0, 0)));
+        assert_eq!(analysis.graph.definition_count(), 1);
+        assert_eq!(analysis.graph.access_count(), 2);
+    }
+
+    #[test]
+    fn custom_alias_domain_needs_no_memory_effect_types() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let (graph, points) = build(
+            &cfg,
+            &[vec![
+                MemoryAccessEvent {
+                    point: 0u8,
+                    definition: Some(10u8),
+                },
+                MemoryAccessEvent {
+                    point: 1u8,
+                    definition: None,
+                },
+            ]],
+        )
+        .unwrap();
+        let oracle = |definition: &u8, query: &u8| definition % 10 == *query;
+        let mut walker = ClobberWalker::new();
+        let clobber = walker
+            .clobber(&graph, points.event(1).unwrap().before, &0, &oracle)
+            .unwrap();
+        let MemoryClobber::Access(access) = clobber else {
+            panic!("the custom oracle finds one definition")
+        };
+        assert!(matches!(
+            graph.access(access),
+            Some(MemoryAccess::Definition { definition: 10, .. })
+        ));
+    }
+}

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -35,6 +35,26 @@ pub struct AlignedDependency {
     pub source: Span,
     /// LSB-based span relative to the enclosing write region.
     pub destination: Span,
+    /// Number of copies of this transfer. A value greater than one represents
+    /// the same source span at regularly spaced destination positions without
+    /// materializing one dependency per copy.
+    pub repetitions: usize,
+    /// Distance in bits between consecutive destination copies. Ignored when
+    /// `repetitions == 1`.
+    pub destination_stride: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeriodicDependency<O> {
+    pub input: Region<O>,
+    pub output_object: O,
+    /// The first output copy influenced by `input`.
+    pub output: Span,
+    pub repetitions: usize,
+    pub destination_stride: usize,
+    pub kind: EdgeKind,
+    /// Each output copy preserves positions within `input`.
+    pub aligned: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,6 +107,8 @@ pub struct Dependency<O> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcedureSummary<O> {
     pub dependencies: Vec<Dependency<O>>,
+    /// Regular one-to-many transfers retained without expanding every copy.
+    pub periodic_dependencies: Vec<PeriodicDependency<O>>,
     /// Sparse output atoms which can be written on exit, including writes
     /// whose assigned value has no signal dependency.
     pub outputs: Vec<Region<O>>,
@@ -184,7 +206,17 @@ struct DepVersion<O> {
     aligned: bool,
     uncertain_input: bool,
     active_read: Option<ReadId>,
+    translation: Option<i128>,
+    periodic_output: Option<PeriodicProjection>,
     marker: std::marker::PhantomData<O>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct PeriodicProjection {
+    source: Span,
+    output: Span,
+    repetitions: usize,
+    destination_stride: usize,
 }
 
 /// Build a region MemorySSA summary for one procedure.
@@ -364,16 +396,26 @@ where
             Option<ReadId>,
             bool,
             bool,
+            Option<i128>,
+            Option<PeriodicProjection>,
         )>,
     >::new();
 
     for phi in &ssa.phis {
         let deps = version_deps.entry(phi.version).or_default();
-        deps.extend(
-            phi.inputs
-                .iter()
-                .map(|(_, input)| (*input, EdgeKind::Value, true, false, None, true, false)),
-        );
+        deps.extend(phi.inputs.iter().map(|(_, input)| {
+            (
+                *input,
+                EdgeKind::Value,
+                true,
+                false,
+                None,
+                true,
+                false,
+                Some(0),
+                None,
+            )
+        }));
     }
     for (&write, (write_region, write_atoms, dependencies, aligned_dependencies)) in &writes {
         let mut incoming = BTreeSet::new();
@@ -393,6 +435,8 @@ where
                         Some(read),
                         false,
                         false,
+                        None,
+                        None,
                     ));
                 }
             }
@@ -402,7 +446,17 @@ where
             if !write_region.is_exact()
                 && let Some(&previous) = ssa.uses.get(&Usage::WeakWrite { write, atom })
             {
-                atom_incoming.insert((previous, EdgeKind::Value, true, true, None, true, true));
+                atom_incoming.insert((
+                    previous,
+                    EdgeKind::Value,
+                    true,
+                    true,
+                    None,
+                    true,
+                    true,
+                    Some(0),
+                    None,
+                ));
             }
             for dependency in aligned_dependencies {
                 let Some((read_region, source_atoms)) = read_atoms.get(&dependency.read) else {
@@ -424,10 +478,17 @@ where
                     continue;
                 };
                 if dependency.source.length != dependency.destination.length
+                    || dependency.repetitions == 0
                     || dependency.source.end().is_none()
                     || dependency.source.end() > Some(source_span.length)
                     || dependency.destination.end().is_none()
-                    || dependency.destination.end() > Some(destination_span.length)
+                    || dependency
+                        .destination_stride
+                        .checked_mul(dependency.repetitions.saturating_sub(1))
+                        .and_then(|offset| dependency.destination.end()?.checked_add(offset))
+                        > Some(destination_span.length)
+                    || (dependency.repetitions > 1
+                        && dependency.destination_stride < dependency.destination.length)
                 {
                     return Err(ProcedureError::Model(
                         "aligned dependency does not fit its source and destination",
@@ -452,6 +513,90 @@ where
                     length: dependency.destination.length,
                 };
                 let output_atom = atoms[atom].span;
+                if dependency.repetitions > 1 {
+                    let Some(output_end) = output_atom.end() else {
+                        return Err(ProcedureError::Model("output atom overflows usize"));
+                    };
+                    for &source_atom in source_atoms {
+                        let Some(source_overlap) =
+                            atoms[source_atom].span.intersection(transfer_source)
+                        else {
+                            continue;
+                        };
+                        let Some(relative) =
+                            source_overlap.start.checked_sub(transfer_source.start)
+                        else {
+                            continue;
+                        };
+                        let Some(phase_start) = transfer_destination.start.checked_add(relative)
+                        else {
+                            return Err(ProcedureError::Model("periodic transfer overflows usize"));
+                        };
+                        let phase = Span {
+                            start: phase_start,
+                            length: source_overlap.length,
+                        };
+                        let Some(phase_end) = phase.end() else {
+                            return Err(ProcedureError::Model("periodic transfer overflows usize"));
+                        };
+                        let first = if output_atom.start < phase_end {
+                            0
+                        } else {
+                            output_atom
+                                .start
+                                .checked_sub(phase_end)
+                                .map(|distance| distance / dependency.destination_stride + 1)
+                                .unwrap_or(0)
+                        };
+                        let end = if output_end <= phase.start {
+                            0
+                        } else {
+                            output_end
+                                .checked_sub(phase.start)
+                                .and_then(|distance| {
+                                    distance.checked_add(dependency.destination_stride - 1)
+                                })
+                                .map(|distance| distance / dependency.destination_stride)
+                                .unwrap_or(dependency.repetitions)
+                        }
+                        .min(dependency.repetitions);
+                        if first >= end {
+                            continue;
+                        }
+                        let Some(first_start) = first
+                            .checked_mul(dependency.destination_stride)
+                            .and_then(|offset| phase.start.checked_add(offset))
+                        else {
+                            return Err(ProcedureError::Model("periodic transfer overflows usize"));
+                        };
+                        let projection = PeriodicProjection {
+                            source: source_overlap,
+                            output: Span {
+                                start: first_start,
+                                length: phase.length,
+                            },
+                            repetitions: end - first,
+                            destination_stride: dependency.destination_stride,
+                        };
+                        if let Some(&version) = ssa.uses.get(&Usage::Read {
+                            read: dependency.read,
+                            atom: source_atom,
+                        }) {
+                            atom_incoming.insert((
+                                version,
+                                dependency.kind,
+                                true,
+                                false,
+                                Some(dependency.read),
+                                false,
+                                false,
+                                None,
+                                Some(projection),
+                            ));
+                        }
+                    }
+                    continue;
+                }
                 let Some(overlap) = output_atom.intersection(transfer_destination) else {
                     continue;
                 };
@@ -483,6 +628,8 @@ where
                             Some(dependency.read),
                             false,
                             false,
+                            Some(overlap.start as i128 - mapped.start as i128),
+                            None,
                         ));
                     }
                 }
@@ -498,15 +645,31 @@ where
     }
 
     let mut dependencies = BTreeSet::new();
+    let mut periodic_dependencies = BTreeSet::new();
     let mut uncertain_input_dependencies = BTreeSet::new();
     for &output_atom in &written_atoms {
         let Some(&output_version) = ssa.uses.get(&Usage::Exit { atom: output_atom }) else {
             continue;
         };
-        let mut stack = vec![(output_version, EdgeKind::Value, true, false, None)];
+        let mut stack = vec![(
+            output_version,
+            EdgeKind::Value,
+            true,
+            false,
+            None,
+            Some(0i128),
+            None,
+        )];
         let mut visited = BTreeSet::new();
-        while let Some((version, path_kind, path_aligned, path_uncertain_input, active_read)) =
-            stack.pop()
+        while let Some((
+            version,
+            path_kind,
+            path_aligned,
+            path_uncertain_input,
+            active_read,
+            path_translation,
+            path_periodic_output,
+        )) = stack.pop()
         {
             if !visited.insert(DepVersion::<O> {
                 version,
@@ -514,20 +677,35 @@ where
                 aligned: path_aligned,
                 uncertain_input: path_uncertain_input,
                 active_read,
+                translation: path_translation,
+                periodic_output: path_periodic_output,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
             }
             if let Version::Entry(input_atom) = version {
-                let dependency = Dependency {
-                    input: atom_region(atoms[input_atom]),
-                    output: atom_region(atoms[output_atom]),
-                    kind: path_kind,
-                    aligned: path_aligned,
-                };
-                dependencies.insert(dependency);
-                if path_uncertain_input {
-                    uncertain_input_dependencies.insert((dependency.input, dependency.output));
+                let input = atom_region(atoms[input_atom]);
+                if let Some(periodic) = path_periodic_output {
+                    periodic_dependencies.insert(PeriodicDependency {
+                        input,
+                        output_object: atoms[output_atom].object,
+                        output: periodic.output,
+                        repetitions: periodic.repetitions,
+                        destination_stride: periodic.destination_stride,
+                        kind: path_kind,
+                        aligned: path_aligned,
+                    });
+                } else {
+                    let dependency = Dependency {
+                        input,
+                        output: atom_region(atoms[output_atom]),
+                        kind: path_kind,
+                        aligned: path_aligned,
+                    };
+                    dependencies.insert(dependency);
+                    if path_uncertain_input {
+                        uncertain_input_dependencies.insert((dependency.input, dependency.output));
+                    }
                 }
                 continue;
             }
@@ -544,6 +722,8 @@ where
                     source_read,
                     preserve_active_read,
                     weak_previous,
+                    translation,
+                    periodic_output,
                 ) in inputs
                 {
                     if weak_previous {
@@ -557,16 +737,132 @@ where
                             continue;
                         }
                     }
+                    let mut next_aligned = path_aligned && aligned;
+                    let (next_translation, next_periodic_output) = if let Some(periodic) =
+                        periodic_output
+                    {
+                        if let Some(outer) = path_periodic_output {
+                            let flattens_with_outer = periodic
+                                .destination_stride
+                                .checked_mul(periodic.repetitions)
+                                == Some(outer.destination_stride);
+                            let Some(relative) =
+                                periodic.output.start.checked_sub(outer.source.start)
+                            else {
+                                continue;
+                            };
+                            if flattens_with_outer {
+                                let Some(start) = outer.output.start.checked_add(relative) else {
+                                    continue;
+                                };
+                                let Some(repetitions) =
+                                    periodic.repetitions.checked_mul(outer.repetitions)
+                                else {
+                                    continue;
+                                };
+                                (
+                                    None,
+                                    Some(PeriodicProjection {
+                                        source: periodic.source,
+                                        output: Span {
+                                            start,
+                                            length: periodic.output.length,
+                                        },
+                                        repetitions,
+                                        destination_stride: periodic.destination_stride,
+                                    }),
+                                )
+                            } else {
+                                // Keep a genuinely two-dimensional set
+                                // exact by retaining one inner periodic
+                                // segment per outer copy. Regular nested
+                                // repeats tile and take the constant-size
+                                // flattening path above; this fallback has
+                                // no arbitrary expansion guard.
+                                for copy in 0..outer.repetitions {
+                                    let Some(start) = copy
+                                        .checked_mul(outer.destination_stride)
+                                        .and_then(|copy_offset| {
+                                            outer
+                                                .output
+                                                .start
+                                                .checked_add(relative)?
+                                                .checked_add(copy_offset)
+                                        })
+                                    else {
+                                        continue;
+                                    };
+                                    stack.push((
+                                        input,
+                                        combine_edge_kinds(path_kind, kind),
+                                        next_aligned,
+                                        path_uncertain_input || uncertain_input,
+                                        if preserve_active_read {
+                                            active_read
+                                        } else {
+                                            source_read
+                                        },
+                                        None,
+                                        Some(PeriodicProjection {
+                                            source: periodic.source,
+                                            output: Span {
+                                                start,
+                                                length: periodic.output.length,
+                                            },
+                                            repetitions: periodic.repetitions,
+                                            destination_stride: periodic.destination_stride,
+                                        }),
+                                    ));
+                                }
+                                continue;
+                            }
+                        } else if let Some(offset) = path_translation {
+                            let shifted = if offset >= 0 {
+                                periodic.output.start.checked_add(offset as usize)
+                            } else {
+                                periodic.output.start.checked_sub((-offset) as usize)
+                            };
+                            let Some(start) = shifted else {
+                                continue;
+                            };
+                            (
+                                None,
+                                Some(PeriodicProjection {
+                                    source: periodic.source,
+                                    output: Span {
+                                        start,
+                                        length: periodic.output.length,
+                                    },
+                                    repetitions: periodic.repetitions,
+                                    destination_stride: periodic.destination_stride,
+                                }),
+                            )
+                        } else {
+                            next_aligned = false;
+                            (None, None)
+                        }
+                    } else if path_periodic_output.is_some() {
+                        (None, path_periodic_output)
+                    } else {
+                        (
+                            path_translation.and_then(|path| {
+                                translation.and_then(|edge| path.checked_add(edge))
+                            }),
+                            None,
+                        )
+                    };
                     stack.push((
                         input,
                         combine_edge_kinds(path_kind, kind),
-                        path_aligned && aligned,
+                        next_aligned,
                         path_uncertain_input || uncertain_input,
                         if preserve_active_read {
                             active_read
                         } else {
                             source_read
                         },
+                        next_translation,
+                        next_periodic_output,
                     ));
                 }
             }
@@ -591,6 +887,7 @@ where
                 aligned,
             })
             .collect(),
+        periodic_dependencies: periodic_dependencies.into_iter().collect(),
         outputs: written_atoms
             .iter()
             .copied()
@@ -717,6 +1014,8 @@ fn build_atoms<O: Copy + Ord>(
         source_span: Span,
         destination_object: O,
         destination_span: Span,
+        repetitions: usize,
+        destination_stride: usize,
     }
 
     let mut transfers = Vec::<Transfer<O>>::new();
@@ -745,10 +1044,17 @@ fn build_atoms<O: Copy + Ord>(
                 continue;
             };
             if dependency.source.length != dependency.destination.length
+                || dependency.repetitions == 0
                 || dependency.source.end().is_none()
                 || dependency.source.end() > Some(source_span.length)
                 || dependency.destination.end().is_none()
-                || dependency.destination.end() > Some(destination_span.length)
+                || dependency
+                    .destination_stride
+                    .checked_mul(dependency.repetitions.saturating_sub(1))
+                    .and_then(|offset| dependency.destination.end()?.checked_add(offset))
+                    > Some(destination_span.length)
+                || (dependency.repetitions > 1
+                    && dependency.destination_stride < dependency.destination.length)
             {
                 return Err(ProcedureError::Model(
                     "aligned dependency regions have different lengths",
@@ -776,6 +1082,8 @@ fn build_atoms<O: Copy + Ord>(
                 source_span: mapped_source,
                 destination_object,
                 destination_span: mapped_destination,
+                repetitions: dependency.repetitions,
+                destination_stride: dependency.destination_stride,
             });
         }
     }
@@ -868,7 +1176,11 @@ fn build_atoms<O: Copy + Ord>(
                 index,
                 from_source: false,
                 start: transfer.destination_span.start,
-                end: transfer.destination_span.end().unwrap_or(usize::MAX),
+                end: transfer
+                    .destination_stride
+                    .checked_mul(transfer.repetitions.saturating_sub(1))
+                    .and_then(|offset| transfer.destination_span.end()?.checked_add(offset))
+                    .unwrap_or(usize::MAX),
             });
     }
     let transfer_index = transfer_refs
@@ -885,6 +1197,57 @@ fn build_atoms<O: Copy + Ord>(
         };
         for transfer_ref in object_transfers.containing(point) {
             let transfer = transfers[transfer_ref.index];
+            if transfer.repetitions > 1 {
+                if transfer_ref.from_source {
+                    // Destination copy boundaries stay symbolic. Observed
+                    // destination boundaries are projected back below.
+                    continue;
+                }
+                let Some(relative) = point.checked_sub(transfer.destination_span.start) else {
+                    continue;
+                };
+                let copy = relative / transfer.destination_stride;
+                for candidate in [copy.checked_sub(1), Some(copy)]
+                    .into_iter()
+                    .flatten()
+                    .filter(|copy| *copy < transfer.repetitions)
+                {
+                    let Some(copy_start) = candidate
+                        .checked_mul(transfer.destination_stride)
+                        .and_then(|offset| transfer.destination_span.start.checked_add(offset))
+                    else {
+                        continue;
+                    };
+                    let Some(copy_end) = copy_start.checked_add(transfer.destination_span.length)
+                    else {
+                        continue;
+                    };
+                    if point < copy_start || point > copy_end {
+                        continue;
+                    }
+                    let Some(mapped) = point
+                        .checked_sub(copy_start)
+                        .and_then(|offset| transfer.source_span.start.checked_add(offset))
+                    else {
+                        return Err(ProcedureError::Model("aligned transfer overflows usize"));
+                    };
+                    let inserted = match endpoints
+                        .entry(transfer.source_object)
+                        .or_default()
+                        .entry(mapped)
+                    {
+                        std::collections::btree_map::Entry::Vacant(entry) => {
+                            entry.insert(0);
+                            true
+                        }
+                        std::collections::btree_map::Entry::Occupied(_) => false,
+                    };
+                    if inserted {
+                        pending.push_back((transfer.source_object, mapped));
+                    }
+                }
+                continue;
+            }
             let (from, to_object, to) = if transfer_ref.from_source {
                 (
                     transfer.source_span,
@@ -1108,6 +1471,8 @@ mod tests {
                             start: 0,
                             length: 1 << 30,
                         },
+                        repetitions: 1,
+                        destination_stride: 0,
                     }],
                 },
                 Event::Read {
@@ -1143,6 +1508,91 @@ mod tests {
                 aligned: false,
             }]
         );
+    }
+
+    #[test]
+    fn periodic_copy_keeps_summary_size_and_phase_independent_of_copy_count() {
+        // Why this case exists: a replicated aligned transfer is succinct in
+        // RTL but used to create one transfer and atom boundary per copy. A
+        // distant sparse read must project back to the matching source phase
+        // while the summary remains constant-sized at 200,000 copies.
+        let copies = 200_000usize;
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: exact(1, 0, 2),
+                },
+                Event::Write {
+                    id: 0,
+                    region: exact(2, 0, copies * 2),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![AlignedDependency {
+                        read: 0,
+                        kind: EdgeKind::Value,
+                        source: Span {
+                            start: 0,
+                            length: 2,
+                        },
+                        destination: Span {
+                            start: 0,
+                            length: 2,
+                        },
+                        repetitions: copies,
+                        destination_stride: 2,
+                    }],
+                },
+                Event::Read {
+                    id: 1,
+                    region: exact(2, 123_456 * 2, 1),
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(3, 0, 1),
+                    dependencies: vec![(1, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(summary.atom_count < 16, "{summary:#?}");
+        assert!(summary.periodic_dependencies.len() < 8, "{summary:#?}");
+        for bit in 0..2 {
+            let phase = summary
+                .periodic_dependencies
+                .iter()
+                .filter(|dependency| {
+                    dependency.input == exact(1, bit, 1) && dependency.output_object == 2
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                phase
+                    .iter()
+                    .map(|dependency| dependency.repetitions)
+                    .sum::<usize>(),
+                copies,
+                "{summary:#?}"
+            );
+            assert!(phase.iter().all(|dependency| {
+                dependency.output.length == 1
+                    && dependency.output.start % 2 == bit
+                    && dependency.destination_stride == 2
+            }));
+        }
+        let final_inputs = summary
+            .dependencies
+            .iter()
+            .filter(|dependency| dependency.output == exact(3, 0, 1))
+            .map(|dependency| dependency.input)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(final_inputs, [exact(1, 0, 1)].into());
     }
 
     #[test]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -1875,6 +1875,104 @@ mod tests {
     }
 
     #[test]
+    fn direct_multiaxis_transfer_preserves_holes_without_enumeration() {
+        // Why this case exists: the public event API now carries every repeat
+        // axis directly. A distant interior sparse read must project to the
+        // source, while its adjacent stride gap remains dependency-free;
+        // neither result may expand the 200,000-by-200,000 copy lattice.
+        let copies = 200_000usize;
+        let inner_stride = 2usize;
+        let outer_stride = 500_000usize;
+        let destination_length = (copies - 1) * outer_stride + (copies - 1) * inner_stride + 1;
+        let selected = 123_456 * outer_stride + 65_432 * inner_stride;
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: exact(1, 0, 1),
+                },
+                Event::Write {
+                    id: 0,
+                    region: exact(2, 0, destination_length),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![AlignedDependency {
+                        read: 0,
+                        kind: EdgeKind::Value,
+                        source: Span {
+                            start: 0,
+                            length: 1,
+                        },
+                        destination: Span {
+                            start: 0,
+                            length: 1,
+                        },
+                        axes: vec![
+                            PeriodicAxis {
+                                repetitions: copies,
+                                destination_stride: inner_stride,
+                            },
+                            PeriodicAxis {
+                                repetitions: copies,
+                                destination_stride: outer_stride,
+                            },
+                        ],
+                    }],
+                },
+                Event::Read {
+                    id: 1,
+                    region: exact(2, selected, 1),
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(3, 0, 1),
+                    dependencies: vec![(1, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+                Event::Read {
+                    id: 2,
+                    region: exact(2, selected + 1, 1),
+                },
+                Event::Write {
+                    id: 2,
+                    region: exact(4, 0, 1),
+                    dependencies: vec![(2, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(summary.atom_count < 20, "{summary:#?}");
+        assert!(summary.dependencies.iter().any(|dependency| {
+            dependency.input == exact(1, 0, 1) && dependency.output == exact(3, 0, 1)
+        }));
+        assert!(!summary.dependencies.iter().any(|dependency| {
+            dependency.input == exact(1, 0, 1) && dependency.output == exact(4, 0, 1)
+        }));
+        let copies = summary
+            .periodic_dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.input == exact(1, 0, 1) && dependency.output_object == 2
+            })
+            .map(|dependency| {
+                dependency
+                    .axes
+                    .iter()
+                    .map(|axis| axis.repetitions)
+                    .product::<usize>()
+            })
+            .sum::<usize>();
+        assert_eq!(copies, 200_000usize * 200_000, "{summary:#?}");
+    }
+
+    #[test]
     fn object_local_uncertainty_preserves_other_exact_dependencies() {
         let procedure = Procedure {
             entry: 0,

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -63,6 +63,10 @@ pub struct PeriodicDependency<O> {
     pub kind: EdgeKind,
     /// Each output copy preserves positions within `input`.
     pub aligned: bool,
+    /// The first concrete write encountered from the procedure exit toward
+    /// this input. `None` denotes retained entry state rather than an
+    /// assignment which can anchor a source diagnostic.
+    pub origin: Option<WriteId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,6 +114,10 @@ pub struct Dependency<O> {
     /// may safely project a requested output subspan back to the same relative
     /// input subspan only when this is true.
     pub aligned: bool,
+    /// The first concrete write encountered from the procedure exit toward
+    /// this input. Distinct reaching assignments remain distinct dependencies
+    /// so adapters can attach an exact source location to each causal edge.
+    pub origin: Option<WriteId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -216,6 +224,7 @@ struct DepVersion<O> {
     active_read: Option<ReadId>,
     translation: Option<i128>,
     periodic_output: Option<PeriodicProjection>,
+    origin: Option<WriteId>,
     marker: std::marker::PhantomData<O>,
 }
 
@@ -732,6 +741,7 @@ where
             None,
             Some(0i128),
             None,
+            None,
         )];
         let mut visited = BTreeSet::new();
         while let Some((
@@ -742,6 +752,7 @@ where
             active_read,
             path_translation,
             path_periodic_output,
+            path_origin,
         )) = stack.pop()
         {
             if !visited.insert(DepVersion::<O> {
@@ -752,6 +763,7 @@ where
                 active_read,
                 translation: path_translation,
                 periodic_output: path_periodic_output.clone(),
+                origin: path_origin,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
@@ -766,6 +778,7 @@ where
                         axes: periodic.axes,
                         kind: path_kind,
                         aligned: path_aligned,
+                        origin: path_origin,
                     });
                 } else {
                     let dependency = Dependency {
@@ -773,6 +786,7 @@ where
                         output: atom_region(atoms[output_atom]),
                         kind: path_kind,
                         aligned: path_aligned,
+                        origin: path_origin,
                     };
                     dependencies.insert(dependency);
                     if path_uncertain_input {
@@ -785,6 +799,7 @@ where
                 Version::Definition { definition, .. } => Some(definition.write),
                 Version::Entry(_) | Version::Phi { .. } => None,
             };
+            let next_origin = path_origin.or(current_write);
             if let Some(inputs) = version_deps.get(&version) {
                 for (
                     input,
@@ -872,6 +887,7 @@ where
                         },
                         next_translation,
                         next_periodic_output,
+                        next_origin,
                     ));
                 }
             }
@@ -881,7 +897,12 @@ where
     let mut collapsed_dependencies = BTreeMap::new();
     for dependency in dependencies {
         collapsed_dependencies
-            .entry((dependency.input, dependency.output, dependency.kind))
+            .entry((
+                dependency.input,
+                dependency.output,
+                dependency.kind,
+                dependency.origin,
+            ))
             .and_modify(|aligned| *aligned &= dependency.aligned)
             .or_insert(dependency.aligned);
     }
@@ -889,11 +910,12 @@ where
     Ok(ProcedureSummary {
         dependencies: collapsed_dependencies
             .into_iter()
-            .map(|((input, output, kind), aligned)| Dependency {
+            .map(|((input, output, kind, origin), aligned)| Dependency {
                 input,
                 output,
                 kind,
                 aligned,
+                origin,
             })
             .collect(),
         periodic_dependencies: periodic_dependencies.into_iter().collect(),
@@ -1422,6 +1444,7 @@ mod tests {
                 output: exact(1, 0, 1),
                 kind: EdgeKind::Value,
                 aligned: true,
+                origin: None,
             }]
         );
         assert_eq!(summary.phi_count, 1);
@@ -1515,6 +1538,7 @@ mod tests {
                 output: exact(3, 0, 1),
                 kind: EdgeKind::Value,
                 aligned: false,
+                origin: Some(1),
             }]
         );
     }
@@ -1755,6 +1779,7 @@ mod tests {
                 output: exact(2, 0, 1),
                 kind: EdgeKind::Value,
                 aligned: false,
+                origin: Some(1),
             }]
         );
     }
@@ -1862,6 +1887,7 @@ mod tests {
                 output: exact(1, 0, 8),
                 kind: EdgeKind::Value,
                 aligned: false,
+                origin: Some(0),
             }]
         );
     }

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -72,6 +72,10 @@ pub struct ProcedureSummary<O> {
     /// Objects touched through an unresolved region. Exact dependencies on
     /// other objects remain independently provable.
     pub uncertain_objects: BTreeSet<O>,
+    /// Objects written through an unresolved region. Adapters use this
+    /// narrower set when exact SSA atoms must be projected back to a sparse
+    /// object-level destination without conflating dynamic reads with writes.
+    pub uncertain_write_objects: BTreeSet<O>,
     pub unknown_all: bool,
     pub atom_count: usize,
     pub definition_count: usize,
@@ -164,6 +168,7 @@ where
     >::new();
     let mut incomplete = procedure.incomplete.clone();
     let mut uncertain_objects = BTreeSet::new();
+    let mut uncertain_write_objects = BTreeSet::new();
     let mut unknown_all = false;
     let mut ssa_events = vec![Vec::new(); procedure.events.len()];
 
@@ -202,6 +207,9 @@ where
                         &mut uncertain_objects,
                         &mut unknown_all,
                     );
+                    if let Region::UnknownObject(object) = region {
+                        uncertain_write_objects.insert(*object);
+                    }
                     if writes
                         .insert(
                             *id,
@@ -382,6 +390,7 @@ where
         dependencies: dependencies.into_iter().collect(),
         incomplete,
         uncertain_objects,
+        uncertain_write_objects,
         unknown_all,
         atom_count: atoms.len(),
         definition_count: definitions,
@@ -838,6 +847,7 @@ mod tests {
 
         let summary = analyze(&procedure).unwrap();
         assert_eq!(summary.uncertain_objects, BTreeSet::from([1]));
+        assert_eq!(summary.uncertain_write_objects, BTreeSet::from([1]));
         assert!(!summary.unknown_all);
         assert_eq!(
             summary.dependencies,
@@ -847,6 +857,31 @@ mod tests {
                 kind: EdgeKind::Value,
             }]
         );
+    }
+
+    #[test]
+    fn dynamic_read_does_not_mark_object_as_dynamically_written() {
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![Event::Read {
+                id: 0,
+                region: Region::UnknownObject(1),
+            }]],
+            object_spans: BTreeMap::from([(
+                1,
+                Span {
+                    start: 0,
+                    length: 8,
+                },
+            )]),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(summary.uncertain_objects, BTreeSet::from([1]));
+        assert!(summary.uncertain_write_objects.is_empty());
     }
 
     #[test]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -27,7 +27,7 @@ pub struct MustAliasCandidate {
 /// A width-preserving positional transfer from a read region to a write
 /// region. Boundaries discovered on either side are propagated to the other;
 /// no per-bit expansion is required.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AlignedDependency {
     pub read: ReadId,
     pub kind: EdgeKind,
@@ -66,7 +66,7 @@ pub struct PeriodicDependency<O> {
     pub origin: Option<WriteId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Event<O> {
     Read {
         id: ReadId,
@@ -88,7 +88,7 @@ pub enum Event<O> {
     SuppressRetentionDiagnostic,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Procedure<O> {
     pub entry: usize,
     pub exit: usize,
@@ -215,6 +215,19 @@ struct Definition {
     atom: usize,
 }
 
+type VersionKey = Version<usize, Definition>;
+type VersionDependency = (
+    VersionKey,
+    EdgeKind,
+    bool,
+    bool,
+    Option<ReadId>,
+    bool,
+    bool,
+    Option<i128>,
+    Option<PeriodicProjection>,
+);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Usage {
     Read {
@@ -252,6 +265,19 @@ struct PeriodicProjection {
     source: Span,
     output: Span,
     axes: Vec<PeriodicAxis>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ResolvedPath {
+    input_atom: usize,
+    kind: EdgeKind,
+    aligned: bool,
+    uncertain_input: bool,
+    has_active_read: bool,
+    translation: Option<i128>,
+    origin: Option<WriteId>,
+    /// The deepest phi on this path overrides outer coverage annotations.
+    coverage_override: Option<bool>,
 }
 
 fn normalize_periodic_axes(axes: &mut Vec<PeriodicAxis>) -> Option<()> {
@@ -675,20 +701,7 @@ where
         })
         .collect::<BTreeSet<_>>();
     let definitions = writes.values().map(|(_, atoms, _, _)| atoms.len()).sum();
-    let mut version_deps = BTreeMap::<
-        Version<usize, Definition>,
-        BTreeSet<(
-            Version<usize, Definition>,
-            EdgeKind,
-            bool,
-            bool,
-            Option<ReadId>,
-            bool,
-            bool,
-            Option<i128>,
-            Option<PeriodicProjection>,
-        )>,
-    >::new();
+    let mut version_deps = BTreeMap::<VersionKey, BTreeSet<VersionDependency>>::new();
 
     for phi in &ssa.phis {
         let deps = version_deps.entry(phi.version).or_default();
@@ -917,82 +930,133 @@ where
     let mut dependencies = BTreeSet::new();
     let mut periodic_dependencies = BTreeSet::new();
     let mut uncertain_input_dependencies = BTreeSet::new();
-    for &output_atom in &written_atoms {
-        let Some(&output_version) = ssa.uses.get(&Usage::Exit { atom: output_atom }) else {
-            continue;
-        };
-        let mut stack = vec![(
-            output_version,
-            EdgeKind::Value,
-            true,
-            false,
-            None,
-            Some(0i128),
-            None,
-            None,
-            None,
-            true,
-        )];
-        let mut visited = BTreeSet::new();
-        while let Some((
-            version,
-            path_kind,
-            path_aligned,
-            path_uncertain_input,
-            active_read,
-            path_translation,
-            path_periodic_output,
-            path_origin,
-            path_retention_origin,
-            path_retention_coverage_diagnostic,
-        )) = stack.pop()
-        {
-            if !visited.insert(DepVersion::<O> {
+    let output_versions = written_atoms
+        .iter()
+        .filter_map(|&output_atom| {
+            ssa.uses
+                .get(&Usage::Exit { atom: output_atom })
+                .copied()
+                .map(|version| (output_atom, version))
+        })
+        .collect::<Vec<_>>();
+    let roots = output_versions
+        .iter()
+        .map(|(_, version)| *version)
+        .collect::<Vec<_>>();
+    if must_alias.is_empty()
+        && let Some(resolved) =
+            resolve_acyclic_paths(&roots, &version_deps, &suppressed_retention_blocks)
+    {
+        for (output_atom, output_version) in output_versions {
+            let Some(paths) = resolved.get(&output_version) else {
+                continue;
+            };
+            for path in paths {
+                if !path.has_active_read {
+                    retained_outputs.insert(RetainedOutput {
+                        output: atom_region(atoms[output_atom]),
+                        origin: None,
+                        coverage_diagnostic: path.coverage_override.unwrap_or(true),
+                    });
+                    continue;
+                }
+                let dependency = Dependency {
+                    input: atom_region(atoms[path.input_atom]),
+                    output: atom_region(atoms[output_atom]),
+                    kind: path.kind,
+                    aligned: path.aligned,
+                    origin: path.origin,
+                };
+                dependencies.insert(dependency);
+                if path.uncertain_input {
+                    uncertain_input_dependencies.insert((dependency.input, dependency.output));
+                }
+            }
+        }
+    } else {
+        let mut pending = BTreeMap::<DepVersion<O>, BTreeSet<usize>>::new();
+        for (output_atom, output_version) in output_versions {
+            pending
+                .entry(DepVersion::<O> {
+                    version: output_version,
+                    kind: EdgeKind::Value,
+                    aligned: true,
+                    uncertain_input: false,
+                    active_read: None,
+                    translation: Some(0),
+                    periodic_output: None,
+                    origin: None,
+                    retention_origin: None,
+                    retention_coverage_diagnostic: true,
+                    marker: std::marker::PhantomData,
+                })
+                .or_default()
+                .insert(output_atom);
+        }
+
+        // Many output atoms of a wide procedure converge on exactly the same
+        // dependency suffix. Propagate those outputs together instead of walking
+        // the suffix independently for every atom. `visited[state]` records the
+        // output atoms already processed at that state, so each (state, output)
+        // pair follows precisely the same transitions as the per-output DFS while
+        // cycles still reach a finite fixed point.
+        let mut visited = BTreeMap::<DepVersion<O>, BTreeSet<usize>>::new();
+        while let Some((state, pending_outputs)) = pending.pop_first() {
+            let visited_outputs = visited.entry(state.clone()).or_default();
+            let output_atoms = pending_outputs
+                .into_iter()
+                .filter(|output| visited_outputs.insert(*output))
+                .collect::<Vec<_>>();
+            if output_atoms.is_empty() {
+                continue;
+            }
+            let DepVersion {
                 version,
                 kind: path_kind,
                 aligned: path_aligned,
                 uncertain_input: path_uncertain_input,
                 active_read,
                 translation: path_translation,
-                periodic_output: path_periodic_output.clone(),
+                periodic_output: path_periodic_output,
                 origin: path_origin,
                 retention_origin: path_retention_origin,
                 retention_coverage_diagnostic: path_retention_coverage_diagnostic,
-                marker: std::marker::PhantomData,
-            }) {
-                continue;
-            }
+                marker: _,
+            } = state;
             if let Version::Entry(input_atom) = version {
-                if active_read.is_none() {
-                    retained_outputs.insert(RetainedOutput {
-                        output: atom_region(atoms[output_atom]),
-                        origin: path_retention_origin,
-                        coverage_diagnostic: path_retention_coverage_diagnostic,
-                    });
-                    continue;
-                }
-                let input = atom_region(atoms[input_atom]);
-                if let Some(periodic) = path_periodic_output {
-                    periodic_dependencies.insert(PeriodicDependency {
-                        input,
-                        output_object: atoms[output_atom].object,
-                        output: periodic.output,
-                        axes: periodic.axes,
-                        kind: path_kind,
-                        aligned: path_aligned,
-                        origin: path_origin,
-                    });
-                } else {
-                    let dependency = Dependency {
-                        input,
-                        output: atom_region(atoms[output_atom]),
-                        kind: path_kind,
-                        aligned: path_aligned,
-                        origin: path_origin,
-                    };
-                    dependencies.insert(dependency);
-                    if path_uncertain_input {
-                        uncertain_input_dependencies.insert((dependency.input, dependency.output));
+                for output_atom in output_atoms {
+                    if active_read.is_none() {
+                        retained_outputs.insert(RetainedOutput {
+                            output: atom_region(atoms[output_atom]),
+                            origin: path_retention_origin,
+                            coverage_diagnostic: path_retention_coverage_diagnostic,
+                        });
+                        continue;
+                    }
+                    let input = atom_region(atoms[input_atom]);
+                    if let Some(periodic) = &path_periodic_output {
+                        periodic_dependencies.insert(PeriodicDependency {
+                            input,
+                            output_object: atoms[output_atom].object,
+                            output: periodic.output,
+                            axes: periodic.axes.clone(),
+                            kind: path_kind,
+                            aligned: path_aligned,
+                            origin: path_origin,
+                        });
+                    } else {
+                        let dependency = Dependency {
+                            input,
+                            output: atom_region(atoms[output_atom]),
+                            kind: path_kind,
+                            aligned: path_aligned,
+                            origin: path_origin,
+                        };
+                        dependencies.insert(dependency);
+                        if path_uncertain_input {
+                            uncertain_input_dependencies
+                                .insert((dependency.input, dependency.output));
+                        }
                     }
                 }
                 continue;
@@ -1049,11 +1113,19 @@ where
                     } else {
                         path_origin.or(current_write)
                     };
-                    let next_active_read = if preserve_active_read {
+                    let mut next_active_read = if preserve_active_read {
                         active_read
                     } else {
                         source_read
                     };
+                    // Read identity is observable only by a proven dynamic
+                    // read/write must-alias pair. Exact-only procedures can merge
+                    // all causal-read states; retaining every syntactic ReadId
+                    // here otherwise makes reconvergent unrolled arithmetic grow
+                    // a distinct path state for each historical read.
+                    if must_alias.is_empty() {
+                        next_active_read = next_active_read.map(|_| usize::MAX);
+                    }
                     let next_retention_origin = if next_active_read.is_some() {
                         // Once a source read is active, this path is a causal
                         // dependency rather than source-read-free retention.
@@ -1108,23 +1180,26 @@ where
                                 None,
                             )
                         };
-                    stack.push((
-                        input,
-                        combine_edge_kinds(path_kind, kind),
-                        next_aligned,
-                        path_uncertain_input || uncertain_input,
-                        next_active_read,
-                        next_translation,
-                        next_periodic_output,
-                        next_origin,
-                        next_retention_origin,
-                        next_retention_coverage_diagnostic,
-                    ));
+                    pending
+                        .entry(DepVersion::<O> {
+                            version: input,
+                            kind: combine_edge_kinds(path_kind, kind),
+                            aligned: next_aligned,
+                            uncertain_input: path_uncertain_input || uncertain_input,
+                            active_read: next_active_read,
+                            translation: next_translation,
+                            periodic_output: next_periodic_output,
+                            origin: next_origin,
+                            retention_origin: next_retention_origin,
+                            retention_coverage_diagnostic: next_retention_coverage_diagnostic,
+                            marker: std::marker::PhantomData,
+                        })
+                        .or_default()
+                        .extend(output_atoms.iter().copied());
                 }
             }
         }
     }
-
     let mut collapsed_dependencies = BTreeMap::new();
     for dependency in dependencies {
         collapsed_dependencies
@@ -1204,6 +1279,117 @@ fn combine_edge_kinds(outer: EdgeKind, inner: EdgeKind) -> EdgeKind {
     } else {
         EdgeKind::Value
     }
+}
+
+/// Resolve an acyclic exact-write dependency graph once per SSA version.
+///
+/// Weak writes need the caller's active ReadId and periodic transfers need the
+/// caller's positional projection, so those context-sensitive cases use the
+/// general worklist below. Ordinary unrolled RTL has neither: memoizing its
+/// suffixes avoids enumerating every path from every output independently.
+fn resolve_acyclic_paths(
+    roots: &[VersionKey],
+    version_deps: &BTreeMap<VersionKey, BTreeSet<VersionDependency>>,
+    suppressed_retention_blocks: &BTreeSet<usize>,
+) -> Option<BTreeMap<VersionKey, BTreeSet<ResolvedPath>>> {
+    if version_deps
+        .values()
+        .flatten()
+        .any(|(_, _, _, _, _, _, weak_previous, _, periodic)| *weak_previous || periodic.is_some())
+    {
+        return None;
+    }
+
+    let mut reachable = BTreeSet::new();
+    let mut stack = roots.to_vec();
+    while let Some(version) = stack.pop() {
+        if !reachable.insert(version) {
+            continue;
+        }
+        if let Some(inputs) = version_deps.get(&version) {
+            stack.extend(inputs.iter().map(|(input, ..)| *input));
+        }
+    }
+
+    let mut remaining_inputs = BTreeMap::<VersionKey, usize>::new();
+    let mut parents = BTreeMap::<VersionKey, BTreeSet<VersionKey>>::new();
+    for &version in &reachable {
+        let inputs = version_deps
+            .get(&version)
+            .into_iter()
+            .flatten()
+            .map(|(input, ..)| *input)
+            .collect::<BTreeSet<_>>();
+        remaining_inputs.insert(version, inputs.len());
+        for input in inputs {
+            parents.entry(input).or_default().insert(version);
+        }
+    }
+
+    let mut ready = remaining_inputs
+        .iter()
+        .filter_map(|(&version, &count)| (count == 0).then_some(version))
+        .collect::<BTreeSet<_>>();
+    let mut resolved = BTreeMap::<VersionKey, BTreeSet<ResolvedPath>>::new();
+    let mut resolved_count = 0usize;
+    while let Some(version) = ready.pop_first() {
+        let mut paths = BTreeSet::new();
+        if let Version::Entry(input_atom) = version {
+            paths.insert(ResolvedPath {
+                input_atom,
+                kind: EdgeKind::Value,
+                aligned: true,
+                uncertain_input: false,
+                has_active_read: false,
+                translation: Some(0),
+                origin: None,
+                coverage_override: None,
+            });
+        } else if let Some(inputs) = version_deps.get(&version) {
+            let current_write = match version {
+                Version::Definition { definition, .. } => Some(definition.write),
+                Version::Entry(_) | Version::Phi { .. } => None,
+            };
+            let coverage_override = match version {
+                Version::Phi { block, .. } => Some(!suppressed_retention_blocks.contains(&block)),
+                Version::Entry(_) | Version::Definition { .. } => None,
+            };
+            for (input, kind, aligned, uncertain_input, source_read, _, _, translation, _) in inputs
+            {
+                let input_paths = resolved.get(input)?;
+                for input_path in input_paths {
+                    paths.insert(ResolvedPath {
+                        input_atom: input_path.input_atom,
+                        kind: combine_edge_kinds(*kind, input_path.kind),
+                        aligned: *aligned && input_path.aligned,
+                        uncertain_input: *uncertain_input || input_path.uncertain_input,
+                        has_active_read: source_read.is_some() || input_path.has_active_read,
+                        translation: translation.and_then(|outer| {
+                            input_path
+                                .translation
+                                .and_then(|inner| outer.checked_add(inner))
+                        }),
+                        origin: current_write.or(input_path.origin),
+                        coverage_override: input_path.coverage_override.or(coverage_override),
+                    });
+                }
+            }
+        }
+        resolved.insert(version, paths);
+        resolved_count += 1;
+
+        if let Some(version_parents) = parents.get(&version) {
+            for parent in version_parents {
+                let remaining = remaining_inputs.get_mut(parent)?;
+                *remaining = remaining.checked_sub(1)?;
+                if *remaining == 0 {
+                    ready.insert(*parent);
+                }
+            }
+        }
+    }
+
+    (resolved_count == reachable.len()).then_some(resolved)
 }
 
 fn atom_region<O>(atom: Atom<O>) -> Region<O> {
@@ -2422,5 +2608,103 @@ mod tests {
                 .incomplete
                 .contains(&IncompleteReason::DynamicRegion)
         );
+    }
+
+    #[test]
+    fn many_outputs_share_an_acyclic_reconvergent_suffix() {
+        // Why this case exists: unrolled arithmetic produces long diamond
+        // chains whose final value fans out to many output atoms. Walking the
+        // same suffix once per output made analysis scale as outputs * chain.
+        const STAGES: usize = 256;
+        const OUTPUTS: usize = 256;
+
+        let input = 0u16;
+        let temporary = 1u16;
+        let bit = |object| Region::Exact {
+            object,
+            span: Span {
+                start: 0,
+                length: 1,
+            },
+        };
+        let mut successors = vec![Vec::new()];
+        let mut events = vec![vec![
+            Event::Read {
+                id: 0,
+                region: bit(input),
+            },
+            Event::Write {
+                id: 0,
+                region: bit(temporary),
+                dependencies: vec![(0, EdgeKind::Value)],
+                aligned_dependencies: vec![],
+            },
+        ]];
+        let mut current = 0;
+        let mut next_read = 1;
+        let mut next_write = 1;
+        for _ in 0..STAGES {
+            let left = events.len();
+            let right = left + 1;
+            let join = left + 2;
+            successors[current] = vec![left, right];
+            successors.push(vec![join]);
+            successors.push(vec![join]);
+            successors.push(Vec::new());
+            let branch = |read, write| {
+                vec![
+                    Event::Read {
+                        id: read,
+                        region: bit(temporary),
+                    },
+                    Event::Write {
+                        id: write,
+                        region: bit(temporary),
+                        dependencies: vec![(read, EdgeKind::Value)],
+                        aligned_dependencies: vec![],
+                    },
+                ]
+            };
+            events.push(branch(next_read, next_write));
+            next_read += 1;
+            next_write += 1;
+            events.push(branch(next_read, next_write));
+            next_read += 1;
+            next_write += 1;
+            events.push(Vec::new());
+            current = join;
+        }
+
+        events[current].push(Event::Read {
+            id: next_read,
+            region: bit(temporary),
+        });
+        for output in 0..OUTPUTS {
+            events[current].push(Event::Write {
+                id: next_write + output,
+                region: bit((output + 2) as u16),
+                dependencies: vec![(next_read, EdgeKind::Value)],
+                aligned_dependencies: vec![],
+            });
+        }
+
+        let summary = analyze(&Procedure {
+            entry: 0,
+            exit: current,
+            successors,
+            events,
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        })
+        .unwrap();
+
+        for output in 0..OUTPUTS {
+            assert!(summary.dependencies.iter().any(|dependency| {
+                dependency.input == bit(input)
+                    && dependency.output == bit((output + 2) as u16)
+                    && dependency.origin == Some(next_write + output)
+            }));
+        }
     }
 }

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -87,6 +87,9 @@ pub struct Dependency<O> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcedureSummary<O> {
     pub dependencies: Vec<Dependency<O>>,
+    /// Sparse output atoms which can be written on exit, including writes
+    /// whose assigned value has no signal dependency.
+    pub outputs: Vec<Region<O>>,
     pub incomplete: BTreeSet<IncompleteReason>,
     /// Objects touched through an unresolved region. Exact dependencies on
     /// other objects remain independently provable.
@@ -587,6 +590,11 @@ where
                 kind,
                 aligned,
             })
+            .collect(),
+        outputs: written_atoms
+            .iter()
+            .copied()
+            .map(|atom| atom_region(atoms[atom]))
             .collect(),
         incomplete,
         uncertain_objects,

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -15,6 +15,15 @@ use crate::ssa::{self, Event as SsaEvent, Version};
 pub type ReadId = usize;
 pub type WriteId = usize;
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MustAliasCandidate {
+    pub read: ReadId,
+    pub write: WriteId,
+    /// Corresponding reads which determine the unresolved selectors. The
+    /// candidate is proven only when every pair observes the same SSA version.
+    pub selector_reads: Vec<(ReadId, ReadId)>,
+}
+
 /// A width-preserving positional transfer from a read region to a write
 /// region. Boundaries discovered on either side are propagated to the other;
 /// no per-bit expansion is required.
@@ -57,6 +66,10 @@ pub struct Procedure<O> {
     /// are partitioned only at observed access endpoints; they are never
     /// expanded into individual bits or elements.
     pub object_spans: BTreeMap<O, Span>,
+    /// Syntactically corresponding unresolved accesses. MemorySSA additionally
+    /// requires the write to dominate the read and every selector input to
+    /// observe the same SSA version before accepting a must-alias proof.
+    pub must_alias: BTreeSet<MustAliasCandidate>,
     pub incomplete: BTreeSet<IncompleteReason>,
 }
 
@@ -78,10 +91,11 @@ pub struct ProcedureSummary<O> {
     /// Objects touched through an unresolved region. Exact dependencies on
     /// other objects remain independently provable.
     pub uncertain_objects: BTreeSet<O>,
-    /// Original unresolved read regions. MemorySSA expands these to sparse
-    /// exact atoms internally; adapters use this set to restore the declared
-    /// uncertainty without widening a known static prefix.
-    pub uncertain_read_regions: BTreeSet<Region<O>>,
+    /// Original unresolved regions which can source an entry dependency.
+    /// These include reads and the retained previous value of a may-write.
+    /// MemorySSA expands them to sparse exact atoms internally; adapters use
+    /// this set to restore uncertainty without widening a known prefix.
+    pub uncertain_input_regions: BTreeSet<Region<O>>,
     /// Exact atom dependency pairs which originated at an unresolved read.
     /// This prevents adapters from widening an unrelated exact read merely
     /// because the same procedure also reads that object dynamically.
@@ -90,7 +104,7 @@ pub struct ProcedureSummary<O> {
     /// narrower set when exact SSA atoms must be projected back to a sparse
     /// object-level destination without conflating dynamic reads with writes.
     pub uncertain_write_objects: BTreeSet<O>,
-    /// Original unresolved write regions; see `uncertain_read_regions`.
+    /// Original unresolved write regions; see `uncertain_input_regions`.
     pub uncertain_write_regions: BTreeSet<Region<O>>,
     pub unknown_all: bool,
     pub atom_count: usize,
@@ -145,8 +159,19 @@ struct Definition {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Usage {
-    Read { read: ReadId, atom: usize },
-    Exit { atom: usize },
+    Read {
+        read: ReadId,
+        atom: usize,
+    },
+    /// The previous value retained by a may-write when this atom is not the
+    /// dynamically selected destination.
+    WeakWrite {
+        write: WriteId,
+        atom: usize,
+    },
+    Exit {
+        atom: usize,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -155,6 +180,7 @@ struct DepVersion<O> {
     kind: EdgeKind,
     aligned: bool,
     uncertain_input: bool,
+    active_read: Option<ReadId>,
     marker: std::marker::PhantomData<O>,
 }
 
@@ -186,16 +212,19 @@ where
     >::new();
     let mut incomplete = procedure.incomplete.clone();
     let mut uncertain_objects = BTreeSet::new();
-    let mut uncertain_read_regions = BTreeSet::new();
+    let mut uncertain_input_regions = BTreeSet::new();
     let mut uncertain_write_objects = BTreeSet::new();
     let mut uncertain_write_regions = BTreeSet::new();
     let mut unknown_all = false;
     let mut ssa_events = vec![Vec::new(); procedure.events.len()];
+    let mut read_locations = BTreeMap::new();
+    let mut write_locations = BTreeMap::new();
 
     for (block, events) in procedure.events.iter().enumerate() {
-        for event in events {
+        for (position, event) in events.iter().enumerate() {
             match event {
                 Event::Read { id, region } => {
+                    read_locations.insert(*id, (block, position));
                     let expanded = expand(*region, &atoms, &atoms_by_object);
                     record_unknown_region(
                         *region,
@@ -204,7 +233,7 @@ where
                         &mut unknown_all,
                     );
                     if !region.is_exact() {
-                        uncertain_read_regions.insert(*region);
+                        uncertain_input_regions.insert(*region);
                     }
                     if read_atoms
                         .insert(*id, (*region, expanded.clone()))
@@ -223,6 +252,7 @@ where
                     dependencies,
                     aligned_dependencies,
                 } => {
+                    write_locations.insert(*id, (block, position));
                     let expanded = expand(*region, &atoms, &atoms_by_object);
                     record_unknown_region(
                         *region,
@@ -234,6 +264,7 @@ where
                         Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
                             uncertain_write_objects.insert(*object);
                             uncertain_write_regions.insert(*region);
+                            uncertain_input_regions.insert(*region);
                         }
                         Region::Exact { .. } | Region::UnknownAll => {}
                     }
@@ -251,12 +282,18 @@ where
                     {
                         return Err(ProcedureError::Model("duplicate write identity"));
                     }
-                    ssa_events[block].extend(expanded.into_iter().map(|atom| {
-                        SsaEvent::Definition {
+                    for atom in expanded {
+                        if !region.is_exact() {
+                            ssa_events[block].push(SsaEvent::Use {
+                                variable: atom,
+                                usage: Usage::WeakWrite { write: *id, atom },
+                            });
+                        }
+                        ssa_events[block].push(SsaEvent::Definition {
                             variable: atom,
                             definition: Definition { write: *id, atom },
-                        }
-                    }));
+                        });
+                    }
                 }
             }
         }
@@ -272,10 +309,59 @@ where
     }));
 
     let ssa = ssa::build(&cfg, &ssa_events)?;
+    let must_alias = procedure
+        .must_alias
+        .iter()
+        .filter_map(|candidate| {
+            let &(write_block, write_position) = write_locations.get(&candidate.write)?;
+            let &(read_block, read_position) = read_locations.get(&candidate.read)?;
+            let ordered = if write_block == read_block {
+                write_position < read_position
+            } else {
+                cfg.dominators.dominates(write_block, read_block)
+            };
+            if !ordered {
+                return None;
+            }
+            let same_versions =
+                candidate
+                    .selector_reads
+                    .iter()
+                    .all(|&(write_selector, read_selector)| {
+                        let Some((_, write_atoms)) = read_atoms.get(&write_selector) else {
+                            return false;
+                        };
+                        let Some((_, read_atoms)) = read_atoms.get(&read_selector) else {
+                            return false;
+                        };
+                        write_atoms.len() == read_atoms.len()
+                            && write_atoms.iter().zip(read_atoms).all(
+                                |(&write_atom, &read_atom)| {
+                                    ssa.uses.get(&Usage::Read {
+                                        read: write_selector,
+                                        atom: write_atom,
+                                    }) == ssa.uses.get(&Usage::Read {
+                                        read: read_selector,
+                                        atom: read_atom,
+                                    })
+                                },
+                            )
+                    });
+            same_versions.then_some((candidate.read, candidate.write))
+        })
+        .collect::<BTreeSet<_>>();
     let definitions = writes.values().map(|(_, atoms, _, _)| atoms.len()).sum();
     let mut version_deps = BTreeMap::<
         Version<usize, Definition>,
-        BTreeSet<(Version<usize, Definition>, EdgeKind, bool, bool)>,
+        BTreeSet<(
+            Version<usize, Definition>,
+            EdgeKind,
+            bool,
+            bool,
+            Option<ReadId>,
+            bool,
+            bool,
+        )>,
     >::new();
 
     for phi in &ssa.phis {
@@ -283,7 +369,7 @@ where
         deps.extend(
             phi.inputs
                 .iter()
-                .map(|(_, input)| (*input, EdgeKind::Value, true, false)),
+                .map(|(_, input)| (*input, EdgeKind::Value, true, false, None, true, false)),
         );
     }
     for (&write, (write_region, write_atoms, dependencies, aligned_dependencies)) in &writes {
@@ -296,12 +382,25 @@ where
             };
             for &atom in atoms {
                 if let Some(&version) = ssa.uses.get(&Usage::Read { read, atom }) {
-                    incoming.insert((version, kind, false, !read_region.is_exact()));
+                    incoming.insert((
+                        version,
+                        kind,
+                        false,
+                        !read_region.is_exact(),
+                        Some(read),
+                        false,
+                        false,
+                    ));
                 }
             }
         }
         for &atom in write_atoms {
             let mut atom_incoming = incoming.clone();
+            if !write_region.is_exact()
+                && let Some(&previous) = ssa.uses.get(&Usage::WeakWrite { write, atom })
+            {
+                atom_incoming.insert((previous, EdgeKind::Value, true, true, None, true, true));
+            }
             for dependency in aligned_dependencies {
                 let Some((read_region, source_atoms)) = read_atoms.get(&dependency.read) else {
                     return Err(ProcedureError::Model(
@@ -373,7 +472,15 @@ where
                             atom: source_atom,
                         })
                     {
-                        atom_incoming.insert((version, dependency.kind, true, false));
+                        atom_incoming.insert((
+                            version,
+                            dependency.kind,
+                            true,
+                            false,
+                            Some(dependency.read),
+                            false,
+                            false,
+                        ));
                     }
                 }
             }
@@ -393,54 +500,97 @@ where
         let Some(&output_version) = ssa.uses.get(&Usage::Exit { atom: output_atom }) else {
             continue;
         };
-        let mut stack = vec![(output_version, EdgeKind::Value, true, false)];
+        let mut stack = vec![(output_version, EdgeKind::Value, true, false, None)];
         let mut visited = BTreeSet::new();
-        while let Some((version, path_kind, path_aligned, path_uncertain_input)) = stack.pop() {
+        while let Some((version, path_kind, path_aligned, path_uncertain_input, active_read)) =
+            stack.pop()
+        {
             if !visited.insert(DepVersion::<O> {
                 version,
                 kind: path_kind,
                 aligned: path_aligned,
                 uncertain_input: path_uncertain_input,
+                active_read,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
             }
-            match version {
-                Version::Entry(input_atom) => {
-                    let dependency = Dependency {
-                        input: atom_region(atoms[input_atom]),
-                        output: atom_region(atoms[output_atom]),
-                        kind: path_kind,
-                        aligned: path_aligned,
-                    };
-                    dependencies.insert(dependency);
-                    if path_uncertain_input {
-                        uncertain_input_dependencies.insert((dependency.input, dependency.output));
-                    }
+            if let Version::Entry(input_atom) = version {
+                let dependency = Dependency {
+                    input: atom_region(atoms[input_atom]),
+                    output: atom_region(atoms[output_atom]),
+                    kind: path_kind,
+                    aligned: path_aligned,
+                };
+                dependencies.insert(dependency);
+                if path_uncertain_input {
+                    uncertain_input_dependencies.insert((dependency.input, dependency.output));
                 }
-                Version::Definition { .. } | Version::Phi { .. } => {
-                    if let Some(inputs) = version_deps.get(&version) {
-                        stack.extend(inputs.iter().map(
-                            |&(input, kind, aligned, uncertain_input)| {
-                                (
-                                    input,
-                                    combine_edge_kinds(path_kind, kind),
-                                    path_aligned && aligned,
-                                    path_uncertain_input || uncertain_input,
-                                )
-                            },
-                        ));
+                continue;
+            }
+            let current_write = match version {
+                Version::Definition { definition, .. } => Some(definition.write),
+                Version::Entry(_) | Version::Phi { .. } => None,
+            };
+            if let Some(inputs) = version_deps.get(&version) {
+                for &(
+                    input,
+                    kind,
+                    aligned,
+                    uncertain_input,
+                    source_read,
+                    preserve_active_read,
+                    weak_previous,
+                ) in inputs
+                {
+                    if weak_previous {
+                        let Some(read) = active_read else {
+                            // Retention by itself is not value feedback. It
+                            // becomes observable only through a later read of
+                            // a possibly unselected candidate.
+                            continue;
+                        };
+                        if current_write.is_some_and(|write| must_alias.contains(&(read, write))) {
+                            continue;
+                        }
                     }
+                    stack.push((
+                        input,
+                        combine_edge_kinds(path_kind, kind),
+                        path_aligned && aligned,
+                        path_uncertain_input || uncertain_input,
+                        if preserve_active_read {
+                            active_read
+                        } else {
+                            source_read
+                        },
+                    ));
                 }
             }
         }
     }
 
+    let mut collapsed_dependencies = BTreeMap::new();
+    for dependency in dependencies {
+        collapsed_dependencies
+            .entry((dependency.input, dependency.output, dependency.kind))
+            .and_modify(|aligned| *aligned &= dependency.aligned)
+            .or_insert(dependency.aligned);
+    }
+
     Ok(ProcedureSummary {
-        dependencies: dependencies.into_iter().collect(),
+        dependencies: collapsed_dependencies
+            .into_iter()
+            .map(|((input, output, kind), aligned)| Dependency {
+                input,
+                output,
+                kind,
+                aligned,
+            })
+            .collect(),
         incomplete,
         uncertain_objects,
-        uncertain_read_regions,
+        uncertain_input_regions,
         uncertain_input_dependencies,
         uncertain_write_objects,
         uncertain_write_regions,
@@ -769,6 +919,7 @@ mod tests {
                 },
             ]],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
         let summary = analyze(&procedure).unwrap();
@@ -793,6 +944,7 @@ mod tests {
                 vec![],
             ],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
         let summary = analyze(&procedure).unwrap();
@@ -827,6 +979,7 @@ mod tests {
                 },
             ]],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
         let summary = analyze(&procedure).unwrap();
@@ -874,6 +1027,7 @@ mod tests {
                 },
             ]],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
 
@@ -921,6 +1075,7 @@ mod tests {
                 },
             ]],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
 
@@ -968,13 +1123,14 @@ mod tests {
                 },
             ]],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
 
         let summary = analyze(&procedure).unwrap();
         assert_eq!(summary.atom_count, 1);
         assert_eq!(summary.definition_count, 1);
-        assert_eq!(summary.uncertain_read_regions, BTreeSet::from([prefix]));
+        assert_eq!(summary.uncertain_input_regions, BTreeSet::from([prefix]));
         assert_eq!(summary.uncertain_write_regions, BTreeSet::from([prefix]));
     }
 
@@ -995,6 +1151,7 @@ mod tests {
                     length: 8,
                 },
             )]),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
 
@@ -1028,6 +1185,7 @@ mod tests {
                     length: 8,
                 },
             )]),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
 
@@ -1056,6 +1214,7 @@ mod tests {
                 aligned_dependencies: vec![],
             }]],
             object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
             incomplete: BTreeSet::new(),
         };
 

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -862,7 +862,18 @@ where
                     } else {
                         path_origin.or(current_write)
                     };
-                    let next_retention_origin = if weak_previous {
+                    let next_active_read = if preserve_active_read {
+                        active_read
+                    } else {
+                        source_read
+                    };
+                    let next_retention_origin = if next_active_read.is_some() {
+                        // Once a source read is active, this path is a causal
+                        // dependency rather than source-read-free retention.
+                        // Canonicalize provenance so reconvergent weak writes
+                        // can share the same visited state.
+                        None
+                    } else if weak_previous {
                         path_retention_origin.or(current_write)
                     } else {
                         path_retention_origin
@@ -915,11 +926,7 @@ where
                         combine_edge_kinds(path_kind, kind),
                         next_aligned,
                         path_uncertain_input || uncertain_input,
-                        if preserve_active_read {
-                            active_read
-                        } else {
-                            source_read
-                        },
+                        next_active_read,
                         next_translation,
                         next_periodic_output,
                         next_origin,
@@ -1384,7 +1391,7 @@ fn expand<O: Copy + Ord>(
         Region::Exact { object, span } => (object, Some(span)),
         Region::UnknownRegion { object, span } => (object, Some(span)),
         Region::UnknownObject(object) => (object, None),
-        Region::UnknownAll => return Vec::new(),
+        Region::UnknownAll => return (0..atoms.len()).collect(),
     };
     let Some(object_atoms) = atoms_by_object.get(&object) else {
         return Vec::new();

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -783,25 +783,109 @@ fn build_atoms<O: Copy + Ord>(
     // Copy relationships form a sparse coordinate graph. Propagate only
     // observed access boundaries through it, so even million-bit objects cost
     // O(accesses + propagated endpoints), never O(width).
-    let mut transfer_index = BTreeMap::<O, Vec<(usize, bool)>>::new();
+    #[derive(Clone, Copy)]
+    struct TransferRef {
+        index: usize,
+        from_source: bool,
+        start: usize,
+        end: usize,
+    }
+
+    struct TransferIndex {
+        transfers: Vec<TransferRef>,
+        leaf_base: usize,
+        max_end: Vec<usize>,
+    }
+
+    impl TransferIndex {
+        fn new(mut transfers: Vec<TransferRef>) -> Self {
+            transfers.sort_unstable_by_key(|transfer| transfer.start);
+            let leaf_base = transfers.len().next_power_of_two().max(1);
+            let mut max_end = vec![0; leaf_base * 2];
+            for (index, transfer) in transfers.iter().enumerate() {
+                max_end[leaf_base + index] = transfer.end;
+            }
+            for index in (1..leaf_base).rev() {
+                max_end[index] = max_end[index * 2].max(max_end[index * 2 + 1]);
+            }
+            Self {
+                transfers,
+                leaf_base,
+                max_end,
+            }
+        }
+
+        fn containing(&self, point: usize) -> Vec<TransferRef> {
+            let high = self
+                .transfers
+                .partition_point(|transfer| transfer.start <= point);
+            let mut matches = Vec::new();
+            self.visit_containing(1, 0, self.leaf_base, high, point, &mut matches);
+            matches
+        }
+
+        fn visit_containing(
+            &self,
+            node: usize,
+            low: usize,
+            high: usize,
+            query_high: usize,
+            point: usize,
+            matches: &mut Vec<TransferRef>,
+        ) {
+            if low >= query_high || self.max_end[node] < point {
+                return;
+            }
+            if high - low == 1 {
+                if let Some(&transfer) = self.transfers.get(low)
+                    && transfer.end >= point
+                {
+                    matches.push(transfer);
+                }
+                return;
+            }
+            let middle = low + (high - low) / 2;
+            self.visit_containing(node * 2, low, middle, query_high, point, matches);
+            self.visit_containing(node * 2 + 1, middle, high, query_high, point, matches);
+        }
+    }
+
+    let mut transfer_refs = BTreeMap::<O, Vec<TransferRef>>::new();
     for (index, transfer) in transfers.iter().enumerate() {
-        transfer_index
+        transfer_refs
             .entry(transfer.source_object)
             .or_default()
-            .push((index, true));
-        transfer_index
+            .push(TransferRef {
+                index,
+                from_source: true,
+                start: transfer.source_span.start,
+                end: transfer.source_span.end().unwrap_or(usize::MAX),
+            });
+        transfer_refs
             .entry(transfer.destination_object)
             .or_default()
-            .push((index, false));
+            .push(TransferRef {
+                index,
+                from_source: false,
+                start: transfer.destination_span.start,
+                end: transfer.destination_span.end().unwrap_or(usize::MAX),
+            });
     }
+    let transfer_index = transfer_refs
+        .into_iter()
+        .map(|(object, transfers)| (object, TransferIndex::new(transfers)))
+        .collect::<BTreeMap<_, _>>();
     let mut pending = std::collections::VecDeque::new();
     for (&object, points) in &endpoints {
         pending.extend(points.keys().map(|&point| (object, point)));
     }
     while let Some((object, point)) = pending.pop_front() {
-        for &(index, from_source) in transfer_index.get(&object).into_iter().flatten() {
-            let transfer = transfers[index];
-            let (from, to_object, to) = if from_source {
+        let Some(object_transfers) = transfer_index.get(&object) else {
+            continue;
+        };
+        for transfer_ref in object_transfers.containing(point) {
+            let transfer = transfers[transfer_ref.index];
+            let (from, to_object, to) = if transfer_ref.from_source {
                 (
                     transfer.source_span,
                     transfer.destination_object,
@@ -814,12 +898,6 @@ fn build_atoms<O: Copy + Ord>(
                     transfer.source_span,
                 )
             };
-            let Some(from_end) = from.end() else {
-                return Err(ProcedureError::Model("aligned transfer overflows usize"));
-            };
-            if point < from.start || point > from_end {
-                continue;
-            }
             let Some(mapped) = point
                 .checked_sub(from.start)
                 .and_then(|offset| to.start.checked_add(offset))
@@ -877,18 +955,27 @@ fn expand<O: Copy + Ord>(
         Region::UnknownObject(object) => (object, None),
         Region::UnknownAll => return Vec::new(),
     };
-    atoms_by_object
-        .get(&object)
-        .map(|object_atoms| {
-            object_atoms
-                .iter()
-                .copied()
-                .filter(|&atom| {
-                    span.is_none_or(|span| atoms[atom].span.intersection(span).is_some())
-                })
-                .collect()
-        })
-        .unwrap_or_default()
+    let Some(object_atoms) = atoms_by_object.get(&object) else {
+        return Vec::new();
+    };
+    let Some(span) = span else {
+        return object_atoms.clone();
+    };
+    let Some(end) = span.end() else {
+        return Vec::new();
+    };
+
+    // Object atoms are disjoint and ordered by start. Query only the interval
+    // which can overlap this region instead of scanning every atom of a wide
+    // object for every individual read or write.
+    let low = object_atoms.partition_point(|&atom| {
+        atoms[atom]
+            .span
+            .end()
+            .is_some_and(|atom_end| atom_end <= span.start)
+    });
+    let high = object_atoms.partition_point(|&atom| atoms[atom].span.start < end);
+    object_atoms[low..high].to_vec()
 }
 
 #[cfg(test)]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -120,11 +120,25 @@ pub struct Dependency<O> {
     pub origin: Option<WriteId>,
 }
 
+/// An output region whose exit version can be the procedure-entry version
+/// without any source-level read. This is state retention/incomplete write
+/// coverage, not a value dependency suitable for a combinational SCC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RetainedOutput<O> {
+    pub output: Region<O>,
+    /// The unresolved write which may leave this region untouched. `None`
+    /// means retention comes from a control-flow path which performs no write.
+    pub origin: Option<WriteId>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcedureSummary<O> {
     pub dependencies: Vec<Dependency<O>>,
     /// Regular one-to-many transfers retained without expanding every copy.
     pub periodic_dependencies: Vec<PeriodicDependency<O>>,
+    /// Entry-state preservation is kept separate from value dependencies so
+    /// consumers can diagnose inferred state without inventing comb loops.
+    pub retained_outputs: Vec<RetainedOutput<O>>,
     /// Sparse output atoms which can be written on exit, including writes
     /// whose assigned value has no signal dependency.
     pub outputs: Vec<Region<O>>,
@@ -225,6 +239,7 @@ struct DepVersion<O> {
     translation: Option<i128>,
     periodic_output: Option<PeriodicProjection>,
     origin: Option<WriteId>,
+    retention_origin: Option<WriteId>,
     marker: std::marker::PhantomData<O>,
 }
 
@@ -726,6 +741,7 @@ where
         }
     }
 
+    let mut retained_outputs = BTreeSet::new();
     let mut dependencies = BTreeSet::new();
     let mut periodic_dependencies = BTreeSet::new();
     let mut uncertain_input_dependencies = BTreeSet::new();
@@ -742,6 +758,7 @@ where
             Some(0i128),
             None,
             None,
+            None,
         )];
         let mut visited = BTreeSet::new();
         while let Some((
@@ -753,6 +770,7 @@ where
             path_translation,
             path_periodic_output,
             path_origin,
+            path_retention_origin,
         )) = stack.pop()
         {
             if !visited.insert(DepVersion::<O> {
@@ -764,11 +782,19 @@ where
                 translation: path_translation,
                 periodic_output: path_periodic_output.clone(),
                 origin: path_origin,
+                retention_origin: path_retention_origin,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
             }
             if let Version::Entry(input_atom) = version {
+                if active_read.is_none() {
+                    retained_outputs.insert(RetainedOutput {
+                        output: atom_region(atoms[output_atom]),
+                        origin: path_retention_origin,
+                    });
+                    continue;
+                }
                 let input = atom_region(atoms[input_atom]);
                 if let Some(periodic) = path_periodic_output {
                     periodic_dependencies.insert(PeriodicDependency {
@@ -799,7 +825,6 @@ where
                 Version::Definition { definition, .. } => Some(definition.write),
                 Version::Entry(_) | Version::Phi { .. } => None,
             };
-            let next_origin = path_origin.or(current_write);
             if let Some(inputs) = version_deps.get(&version) {
                 for (
                     input,
@@ -821,17 +846,27 @@ where
                     let preserve_active_read = *preserve_active_read;
                     let weak_previous = *weak_previous;
                     let translation = *translation;
-                    if weak_previous {
-                        let Some(read) = active_read else {
-                            // Retention by itself is not value feedback. It
-                            // becomes observable only through a later read of
-                            // a possibly unselected candidate.
-                            continue;
-                        };
-                        if current_write.is_some_and(|write| must_alias.contains(&(read, write))) {
-                            continue;
-                        }
+                    if weak_previous
+                        && active_read.is_some_and(|read| {
+                            current_write.is_some_and(|write| must_alias.contains(&(read, write)))
+                        })
+                    {
+                        continue;
                     }
+                    // A weak write does not supply the preserved value. Walk
+                    // through it without claiming it as the dependency origin;
+                    // remember it separately only if the walk reaches entry
+                    // without encountering an actual read.
+                    let next_origin = if weak_previous {
+                        path_origin
+                    } else {
+                        path_origin.or(current_write)
+                    };
+                    let next_retention_origin = if weak_previous {
+                        path_retention_origin.or(current_write)
+                    } else {
+                        path_retention_origin
+                    };
                     let mut next_aligned = path_aligned && aligned;
                     let (next_translation, next_periodic_output) =
                         if let Some(periodic) = periodic_output {
@@ -888,6 +923,7 @@ where
                         next_translation,
                         next_periodic_output,
                         next_origin,
+                        next_retention_origin,
                     ));
                 }
             }
@@ -919,6 +955,7 @@ where
             })
             .collect(),
         periodic_dependencies: periodic_dependencies.into_iter().collect(),
+        retained_outputs: retained_outputs.into_iter().collect(),
         outputs: written_atoms
             .iter()
             .copied()
@@ -1416,7 +1453,7 @@ mod tests {
     }
 
     #[test]
-    fn branch_merge_retains_only_the_live_entry_arm() {
+    fn branch_merge_reports_retained_entry_separately() {
         let procedure = Procedure {
             entry: 0,
             exit: 3,
@@ -1437,13 +1474,11 @@ mod tests {
             incomplete: BTreeSet::new(),
         };
         let summary = analyze(&procedure).unwrap();
+        assert!(summary.dependencies.is_empty());
         assert_eq!(
-            summary.dependencies,
-            vec![Dependency {
-                input: exact(1, 0, 1),
+            summary.retained_outputs,
+            vec![RetainedOutput {
                 output: exact(1, 0, 1),
-                kind: EdgeKind::Value,
-                aligned: true,
                 origin: None,
             }]
         );

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -237,9 +237,7 @@ fn normalize_periodic_axes(axes: &mut Vec<PeriodicAxis>) -> Option<()> {
             return None;
         }
         if let Some(inner) = normalized.last_mut()
-            && inner
-                .destination_stride
-                .checked_mul(inner.repetitions)
+            && inner.destination_stride.checked_mul(inner.repetitions)
                 == Some(axis.destination_stride)
         {
             inner.repetitions = inner.repetitions.checked_mul(axis.repetitions)?;
@@ -820,49 +818,48 @@ where
                         }
                     }
                     let mut next_aligned = path_aligned && aligned;
-                    let (next_translation, next_periodic_output) = if let Some(periodic) =
-                        periodic_output
-                    {
-                        if let Some(outer) = &path_periodic_output {
-                            let Some(composed) = compose_periodic_projections(periodic, outer)
-                            else {
-                                continue;
-                            };
-                            (None, Some(composed))
-                        } else if let Some(offset) = path_translation {
-                            let shifted = if offset >= 0 {
-                                periodic.output.start.checked_add(offset as usize)
+                    let (next_translation, next_periodic_output) =
+                        if let Some(periodic) = periodic_output {
+                            if let Some(outer) = &path_periodic_output {
+                                let Some(composed) = compose_periodic_projections(periodic, outer)
+                                else {
+                                    continue;
+                                };
+                                (None, Some(composed))
+                            } else if let Some(offset) = path_translation {
+                                let shifted = if offset >= 0 {
+                                    periodic.output.start.checked_add(offset as usize)
+                                } else {
+                                    periodic.output.start.checked_sub((-offset) as usize)
+                                };
+                                let Some(start) = shifted else {
+                                    continue;
+                                };
+                                (
+                                    None,
+                                    Some(PeriodicProjection {
+                                        source: periodic.source,
+                                        output: Span {
+                                            start,
+                                            length: periodic.output.length,
+                                        },
+                                        axes: periodic.axes.clone(),
+                                    }),
+                                )
                             } else {
-                                periodic.output.start.checked_sub((-offset) as usize)
-                            };
-                            let Some(start) = shifted else {
-                                continue;
-                            };
-                            (
-                                None,
-                                Some(PeriodicProjection {
-                                    source: periodic.source,
-                                    output: Span {
-                                        start,
-                                        length: periodic.output.length,
-                                    },
-                                    axes: periodic.axes.clone(),
-                                }),
-                            )
+                                next_aligned = false;
+                                (None, None)
+                            }
+                        } else if path_periodic_output.is_some() {
+                            (None, path_periodic_output.clone())
                         } else {
-                            next_aligned = false;
-                            (None, None)
-                        }
-                    } else if path_periodic_output.is_some() {
-                        (None, path_periodic_output.clone())
-                    } else {
-                        (
-                            path_translation.and_then(|path| {
-                                translation.and_then(|edge| path.checked_add(edge))
-                            }),
-                            None,
-                        )
-                    };
+                            (
+                                path_translation.and_then(|path| {
+                                    translation.and_then(|edge| path.checked_add(edge))
+                                }),
+                                None,
+                            )
+                        };
                     stack.push((
                         input,
                         combine_edge_kinds(path_kind, kind),
@@ -1696,7 +1693,13 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(nested.len(), 1, "{summary:#?}");
-        assert_eq!(nested[0].output, Span { start: 0, length: 1 });
+        assert_eq!(
+            nested[0].output,
+            Span {
+                start: 0,
+                length: 1
+            }
+        );
         assert_eq!(
             nested[0].axes,
             vec![

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -83,6 +83,9 @@ pub enum Event<O> {
         /// of `dst[0]` depends only on `src[0]`.
         aligned_dependencies: Vec<AlignedDependency>,
     },
+    /// Marks a CFG join whose entry-state retention is intentionally exempt
+    /// from coverage diagnostics. The retained value remains in the summary.
+    SuppressRetentionDiagnostic,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -126,6 +129,9 @@ pub struct RetainedOutput<O> {
     /// The unresolved write which may leave this region untouched. `None`
     /// means retention comes from a control-flow path which performs no write.
     pub origin: Option<WriteId>,
+    /// Whether this retained path is eligible for an incomplete-assignment
+    /// diagnostic. Paths to the same output may carry both values.
+    pub coverage_diagnostic: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -237,6 +243,7 @@ struct DepVersion<O> {
     periodic_output: Option<PeriodicProjection>,
     origin: Option<WriteId>,
     retention_origin: Option<WriteId>,
+    retention_coverage_diagnostic: bool,
     marker: std::marker::PhantomData<O>,
 }
 
@@ -503,6 +510,17 @@ where
     let mut ssa_events = vec![Vec::new(); procedure.events.len()];
     let mut read_locations = BTreeMap::new();
     let mut write_locations = BTreeMap::new();
+    let suppressed_retention_blocks = procedure
+        .events
+        .iter()
+        .enumerate()
+        .filter_map(|(block, events)| {
+            events
+                .iter()
+                .any(|event| matches!(event, Event::SuppressRetentionDiagnostic))
+                .then_some(block)
+        })
+        .collect::<BTreeSet<_>>();
 
     for (block, events) in procedure.events.iter().enumerate() {
         for (position, event) in events.iter().enumerate() {
@@ -581,6 +599,7 @@ where
                         });
                     }
                 }
+                Event::SuppressRetentionDiagnostic => {}
             }
         }
     }
@@ -893,6 +912,7 @@ where
             None,
             None,
             None,
+            true,
         )];
         let mut visited = BTreeSet::new();
         while let Some((
@@ -905,6 +925,7 @@ where
             path_periodic_output,
             path_origin,
             path_retention_origin,
+            path_retention_coverage_diagnostic,
         )) = stack.pop()
         {
             if !visited.insert(DepVersion::<O> {
@@ -917,6 +938,7 @@ where
                 periodic_output: path_periodic_output.clone(),
                 origin: path_origin,
                 retention_origin: path_retention_origin,
+                retention_coverage_diagnostic: path_retention_coverage_diagnostic,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
@@ -926,6 +948,7 @@ where
                     retained_outputs.insert(RetainedOutput {
                         output: atom_region(atoms[output_atom]),
                         origin: path_retention_origin,
+                        coverage_diagnostic: path_retention_coverage_diagnostic,
                     });
                     continue;
                 }
@@ -960,6 +983,17 @@ where
                 Version::Entry(_) | Version::Phi { .. } => None,
             };
             if let Some(inputs) = version_deps.get(&version) {
+                // The innermost join on a retained path determines which
+                // source construct exposed the missing definition. A nested
+                // ordinary join must therefore override an outer suppression,
+                // and an annotated inner join must override an ordinary outer
+                // join for its own path.
+                let next_retention_coverage_diagnostic = match version {
+                    Version::Phi { block, .. } => !suppressed_retention_blocks.contains(&block),
+                    Version::Entry(_) | Version::Definition { .. } => {
+                        path_retention_coverage_diagnostic
+                    }
+                };
                 for (
                     input,
                     kind,
@@ -1065,6 +1099,7 @@ where
                         next_periodic_output,
                         next_origin,
                         next_retention_origin,
+                        next_retention_coverage_diagnostic,
                     ));
                 }
             }
@@ -1174,6 +1209,7 @@ fn build_atoms<O: Copy + Ord>(
         }
         let region = match event {
             Event::Read { region, .. } | Event::Write { region, .. } => *region,
+            Event::SuppressRetentionDiagnostic => continue,
         };
         if matches!(
             region,
@@ -1602,9 +1638,99 @@ mod tests {
             vec![RetainedOutput {
                 output: exact(1, 0, 1),
                 origin: None,
+                coverage_diagnostic: true,
             }]
         );
         assert_eq!(summary.phi_count, 1);
+    }
+
+    #[test]
+    fn suppressed_join_preserves_retention_without_diagnostic_provenance() {
+        // Why this case exists: source-level completeness assertions suppress
+        // only the coverage diagnostic. They must not erase the retained
+        // entry value from the MemorySSA summary.
+        let procedure = Procedure {
+            entry: 0,
+            exit: 3,
+            successors: vec![vec![1, 2], vec![3], vec![3], vec![]],
+            events: vec![
+                vec![],
+                vec![Event::Write {
+                    id: 0,
+                    region: exact(1, 0, 1),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                }],
+                vec![],
+                vec![Event::SuppressRetentionDiagnostic],
+            ],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(
+            summary.retained_outputs,
+            vec![RetainedOutput {
+                output: exact(1, 0, 1),
+                origin: None,
+                coverage_diagnostic: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn nested_ordinary_join_overrides_outer_retention_suppression() {
+        // Why this case exists: suppression belongs to one annotated join,
+        // not every write lexically inside it. The inner ordinary branch has
+        // its own missing-definition path and remains diagnostic.
+        let procedure = Procedure {
+            entry: 0,
+            exit: 6,
+            successors: vec![
+                vec![1, 2],
+                vec![3, 4],
+                vec![6],
+                vec![5],
+                vec![5],
+                vec![6],
+                vec![],
+            ],
+            events: vec![
+                vec![],
+                vec![],
+                vec![],
+                vec![Event::Write {
+                    id: 0,
+                    region: exact(1, 0, 1),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                }],
+                vec![],
+                vec![],
+                vec![Event::SuppressRetentionDiagnostic],
+            ],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(
+            summary
+                .retained_outputs
+                .iter()
+                .any(|retained| retained.coverage_diagnostic),
+            "the inner ordinary join must retain diagnostic provenance: {summary:#?}"
+        );
+        assert!(
+            summary
+                .retained_outputs
+                .iter()
+                .any(|retained| !retained.coverage_diagnostic),
+            "the outer annotated join must retain suppressed provenance: {summary:#?}"
+        );
     }
 
     #[test]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -489,7 +489,18 @@ where
         return Err(ProcedureError::Model("procedure exit is out of range"));
     }
 
-    let cfg = ForwardControlFlowGraph::analyze(procedure.successors.clone(), procedure.entry)?;
+    let is_linear = procedure.events.len() == 1
+        && procedure.entry == 0
+        && procedure.exit == 0
+        && procedure.successors[0].is_empty();
+    let cfg = if is_linear {
+        None
+    } else {
+        Some(ForwardControlFlowGraph::analyze(
+            procedure.successors.clone(),
+            procedure.entry,
+        )?)
+    };
     let (atoms, atoms_by_object) = build_atoms(&procedure.events, &procedure.object_spans)?;
     let mut read_atoms = BTreeMap::<ReadId, (Region<O>, Vec<usize>)>::new();
     let mut writes = BTreeMap::<
@@ -613,7 +624,14 @@ where
         usage: Usage::Exit { atom },
     }));
 
-    let ssa = ssa::build(&cfg, &ssa_events)?;
+    let ssa = if is_linear {
+        ssa::build_linear(&ssa_events[0])?
+    } else {
+        ssa::build(
+            cfg.as_ref().expect("non-linear procedure has a CFG"),
+            &ssa_events,
+        )?
+    };
     let must_alias = procedure
         .must_alias
         .iter()
@@ -623,7 +641,8 @@ where
             let ordered = if write_block == read_block {
                 write_position < read_position
             } else {
-                cfg.dominators.dominates(write_block, read_block)
+                cfg.as_ref()
+                    .is_some_and(|cfg| cfg.dominators.dominates(write_block, read_block))
             };
             if !ordered {
                 return None;

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -519,6 +519,53 @@ where
         && procedure.entry == 0
         && procedure.exit == 0
         && procedure.successors[0].is_empty();
+    // Exact constant writes cannot observe an earlier SSA version and cannot
+    // retain entry state. They still use the normal sparse atom builder so
+    // overlap partitioning and model validation remain identical.
+    if is_linear
+        && procedure.events[0].iter().all(|event| match event {
+            Event::Write {
+                region: Region::Exact { .. },
+                dependencies,
+                aligned_dependencies,
+                ..
+            } => dependencies.is_empty() && aligned_dependencies.is_empty(),
+            Event::SuppressRetentionDiagnostic => true,
+            Event::Read { .. } | Event::Write { .. } => false,
+        })
+    {
+        let (atoms, atoms_by_object) = build_atoms(&procedure.events, &procedure.object_spans)?;
+        let mut writes = BTreeSet::new();
+        let mut outputs = BTreeSet::new();
+        let mut definition_count = 0usize;
+        for event in &procedure.events[0] {
+            let Event::Write { id, region, .. } = event else {
+                continue;
+            };
+            if !writes.insert(*id) {
+                return Err(ProcedureError::Model("duplicate write identity"));
+            }
+            let expanded = expand(*region, &atoms, &atoms_by_object);
+            definition_count += expanded.len();
+            outputs.extend(expanded.into_iter().map(|atom| atom_region(atoms[atom])));
+        }
+        return Ok(ProcedureSummary {
+            dependencies: Vec::new(),
+            periodic_dependencies: Vec::new(),
+            retained_outputs: Vec::new(),
+            outputs: outputs.into_iter().collect(),
+            incomplete: procedure.incomplete.clone(),
+            uncertain_objects: BTreeSet::new(),
+            uncertain_input_regions: BTreeSet::new(),
+            uncertain_input_dependencies: BTreeSet::new(),
+            uncertain_write_objects: BTreeSet::new(),
+            uncertain_write_regions: BTreeSet::new(),
+            unknown_all: false,
+            atom_count: atoms.len(),
+            definition_count,
+            phi_count: 0,
+        });
+    }
     let cfg = if is_linear {
         None
     } else {
@@ -1813,6 +1860,46 @@ mod tests {
         };
         let summary = analyze(&procedure).unwrap();
         assert!(summary.dependencies.is_empty());
+    }
+
+    #[test]
+    fn linear_constant_writes_still_partition_overlapping_outputs() {
+        // Why this case exists: constant-only straight-line procedures take a
+        // reduced analysis path. Overlapping writes must retain the same atom
+        // boundaries and accounting as the general MemorySSA construction.
+        let procedure: Procedure<u8> = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Write {
+                    id: 0,
+                    region: exact(1, 0, 8),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(1, 4, 8),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(
+            summary.outputs,
+            vec![exact(1, 0, 4), exact(1, 4, 4), exact(1, 8, 4)]
+        );
+        assert!(summary.dependencies.is_empty());
+        assert!(summary.retained_outputs.is_empty());
+        assert_eq!(summary.atom_count, 3);
+        assert_eq!(summary.definition_count, 4);
+        assert_eq!(summary.phi_count, 0);
     }
 
     #[test]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -512,6 +512,7 @@ where
                     let expanded = expand(*region, &atoms, &atoms_by_object);
                     record_unknown_region(
                         *region,
+                        &procedure.object_spans,
                         &mut incomplete,
                         &mut uncertain_objects,
                         &mut unknown_all,
@@ -540,6 +541,7 @@ where
                     let expanded = expand(*region, &atoms, &atoms_by_object);
                     record_unknown_region(
                         *region,
+                        &procedure.object_spans,
                         &mut incomplete,
                         &mut uncertain_objects,
                         &mut unknown_all,
@@ -723,7 +725,28 @@ where
                     },
                 ) = (*read_region, *write_region)
                 else {
-                    incomplete.insert(IncompleteReason::DynamicRegion);
+                    // Positional transfer is optional precision. When either
+                    // endpoint is dynamic but bounded, retain a complete
+                    // whole-dependency fallback instead of dropping the read
+                    // and misclassifying loss of precision as incompleteness.
+                    for &source_atom in source_atoms {
+                        if let Some(&version) = ssa.uses.get(&Usage::Read {
+                            read: dependency.read,
+                            atom: source_atom,
+                        }) {
+                            atom_incoming.insert((
+                                version,
+                                dependency.kind,
+                                false,
+                                !read_region.is_exact(),
+                                Some(dependency.read),
+                                false,
+                                false,
+                                None,
+                                None,
+                            ));
+                        }
+                    }
                     continue;
                 };
                 let mut axes = dependency.axes.clone();
@@ -1094,15 +1117,21 @@ where
 
 fn record_unknown_region<O: Copy + Ord>(
     region: Region<O>,
+    object_spans: &BTreeMap<O, Span>,
     incomplete: &mut BTreeSet<IncompleteReason>,
     uncertain_objects: &mut BTreeSet<O>,
     unknown_all: &mut bool,
 ) {
     match region {
         Region::Exact { .. } => {}
-        Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
-            incomplete.insert(IncompleteReason::DynamicRegion);
+        Region::UnknownRegion { object, .. } => {
             uncertain_objects.insert(object);
+        }
+        Region::UnknownObject(object) => {
+            uncertain_objects.insert(object);
+            if !object_spans.contains_key(&object) {
+                incomplete.insert(IncompleteReason::DynamicRegion);
+            }
         }
         Region::UnknownAll => {
             incomplete.insert(IncompleteReason::DynamicRegion);
@@ -2055,6 +2084,7 @@ mod tests {
         assert_eq!(summary.definition_count, 1);
         assert_eq!(summary.uncertain_input_regions, BTreeSet::from([prefix]));
         assert_eq!(summary.uncertain_write_regions, BTreeSet::from([prefix]));
+        assert!(summary.incomplete.is_empty(), "{summary:#?}");
     }
 
     #[test]
@@ -2081,6 +2111,34 @@ mod tests {
         let summary = analyze(&procedure).unwrap();
         assert_eq!(summary.uncertain_objects, BTreeSet::from([1]));
         assert!(summary.uncertain_write_objects.is_empty());
+        assert!(summary.incomplete.is_empty(), "{summary:#?}");
+    }
+
+    #[test]
+    fn unknown_object_without_declared_shape_is_incomplete() {
+        // Why this case exists: UnknownObject is complete only when its
+        // declared span lets MemorySSA cover the entire object. Without that
+        // span, expanding to the atoms seen elsewhere could omit dependencies.
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![Event::Read {
+                id: 0,
+                region: Region::UnknownObject(1u8),
+            }]],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(
+            summary
+                .incomplete
+                .contains(&IncompleteReason::DynamicRegion),
+            "{summary:#?}"
+        );
     }
 
     #[test]
@@ -2118,6 +2176,75 @@ mod tests {
             vec![Dependency {
                 input: exact(1, 0, 8),
                 output: exact(1, 0, 8),
+                kind: EdgeKind::Value,
+                aligned: false,
+                origin: Some(0),
+            }]
+        );
+        assert!(summary.incomplete.is_empty(), "{summary:#?}");
+    }
+
+    #[test]
+    fn dynamic_aligned_transfer_falls_back_to_complete_whole_dependency() {
+        // Why this case exists: a positional transfer cannot align an unknown
+        // selected element, but both objects are bounded. Dropping the aligned
+        // read makes the result incomplete and loses a real dependency; the
+        // complete fallback is an unaligned whole-object edge.
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: Region::UnknownObject(1u8),
+                },
+                Event::Write {
+                    id: 0,
+                    region: exact(2, 0, 8),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![AlignedDependency {
+                        read: 0,
+                        kind: EdgeKind::Value,
+                        source: Span {
+                            start: 0,
+                            length: 8,
+                        },
+                        destination: Span {
+                            start: 0,
+                            length: 8,
+                        },
+                        axes: vec![],
+                    }],
+                },
+            ]],
+            object_spans: BTreeMap::from([
+                (
+                    1,
+                    Span {
+                        start: 0,
+                        length: 8,
+                    },
+                ),
+                (
+                    2,
+                    Span {
+                        start: 0,
+                        length: 8,
+                    },
+                ),
+            ]),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(summary.incomplete.is_empty(), "{summary:#?}");
+        assert_eq!(
+            summary.dependencies,
+            vec![Dependency {
+                input: exact(1, 0, 8),
+                output: exact(2, 0, 8),
                 kind: EdgeKind::Value,
                 aligned: false,
                 origin: Some(0),

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -22,6 +22,8 @@ pub type WriteId = usize;
 pub struct AlignedDependency {
     pub read: ReadId,
     pub kind: EdgeKind,
+    /// LSB-based span relative to the enclosing read region.
+    pub source: Span,
     /// LSB-based span relative to the enclosing write region.
     pub destination: Span,
 }
@@ -294,24 +296,34 @@ where
                     incomplete.insert(IncompleteReason::DynamicRegion);
                     continue;
                 };
+                if dependency.source.length != dependency.destination.length
+                    || dependency.source.end().is_none()
+                    || dependency.source.end() > Some(source_span.length)
+                    || dependency.destination.end().is_none()
+                    || dependency.destination.end() > Some(destination_span.length)
+                {
+                    return Err(ProcedureError::Model(
+                        "aligned dependency does not fit its source and destination",
+                    ));
+                }
+                let Some(source_start) = source_span.start.checked_add(dependency.source.start)
+                else {
+                    return Err(ProcedureError::Model("aligned transfer overflows usize"));
+                };
                 let Some(destination_start) = destination_span
                     .start
                     .checked_add(dependency.destination.start)
                 else {
                     return Err(ProcedureError::Model("aligned transfer overflows usize"));
                 };
+                let transfer_source = Span {
+                    start: source_start,
+                    length: dependency.source.length,
+                };
                 let transfer_destination = Span {
                     start: destination_start,
                     length: dependency.destination.length,
                 };
-                if dependency.destination.end().is_none()
-                    || dependency.destination.end() > Some(destination_span.length)
-                    || source_span.length != transfer_destination.length
-                {
-                    return Err(ProcedureError::Model(
-                        "aligned dependency does not fit its source and destination",
-                    ));
-                }
                 let output_atom = atoms[atom].span;
                 let Some(overlap) = output_atom.intersection(transfer_destination) else {
                     continue;
@@ -322,7 +334,7 @@ where
                         "write atom begins before its aligned transfer",
                     ));
                 };
-                let Some(mapped_start) = source_span.start.checked_add(relative_start) else {
+                let Some(mapped_start) = transfer_source.start.checked_add(relative_start) else {
                     return Err(ProcedureError::Model("aligned transfer overflows usize"));
                 };
                 let mapped = Span {
@@ -523,27 +535,36 @@ fn build_atoms<O: Copy + Ord>(
             else {
                 continue;
             };
+            if dependency.source.length != dependency.destination.length
+                || dependency.source.end().is_none()
+                || dependency.source.end() > Some(source_span.length)
+                || dependency.destination.end().is_none()
+                || dependency.destination.end() > Some(destination_span.length)
+            {
+                return Err(ProcedureError::Model(
+                    "aligned dependency regions have different lengths",
+                ));
+            }
+            let Some(source_start) = source_span.start.checked_add(dependency.source.start) else {
+                return Err(ProcedureError::Model("aligned transfer overflows usize"));
+            };
             let Some(destination_start) = destination_span
                 .start
                 .checked_add(dependency.destination.start)
             else {
                 return Err(ProcedureError::Model("aligned transfer overflows usize"));
             };
+            let mapped_source = Span {
+                start: source_start,
+                length: dependency.source.length,
+            };
             let mapped_destination = Span {
                 start: destination_start,
                 length: dependency.destination.length,
             };
-            if dependency.destination.end().is_none()
-                || dependency.destination.end() > Some(destination_span.length)
-                || source_span.length != mapped_destination.length
-            {
-                return Err(ProcedureError::Model(
-                    "aligned dependency regions have different lengths",
-                ));
-            }
             transfers.push(Transfer {
                 source_object,
-                source_span,
+                source_span: mapped_source,
                 destination_object,
                 destination_span: mapped_destination,
             });
@@ -778,6 +799,10 @@ mod tests {
                     aligned_dependencies: vec![AlignedDependency {
                         read: 0,
                         kind: EdgeKind::Value,
+                        source: Span {
+                            start: 0,
+                            length: 1 << 30,
+                        },
                         destination: Span {
                             start: 0,
                             length: 1 << 30,

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -45,13 +45,21 @@ pub struct AlignedDependency {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeriodicAxis {
+    pub repetitions: usize,
+    pub destination_stride: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PeriodicDependency<O> {
     pub input: Region<O>,
     pub output_object: O,
     /// The first output copy influenced by `input`.
     pub output: Span,
-    pub repetitions: usize,
-    pub destination_stride: usize,
+    /// Cartesian repetition axes, ordered from the innermost to the
+    /// outermost transfer. Representation size depends on nesting depth, not
+    /// on the number of copies along any axis.
+    pub axes: Vec<PeriodicAxis>,
     pub kind: EdgeKind,
     /// Each output copy preserves positions within `input`.
     pub aligned: bool,
@@ -199,7 +207,7 @@ enum Usage {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct DepVersion<O> {
     version: Version<usize, Definition>,
     kind: EdgeKind,
@@ -211,12 +219,77 @@ struct DepVersion<O> {
     marker: std::marker::PhantomData<O>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct PeriodicProjection {
     source: Span,
     output: Span,
-    repetitions: usize,
-    destination_stride: usize,
+    axes: Vec<PeriodicAxis>,
+}
+
+fn normalize_periodic_axes(axes: &mut Vec<PeriodicAxis>) -> Option<()> {
+    if axes.iter().any(|axis| axis.repetitions == 0) {
+        return None;
+    }
+    axes.retain(|axis| axis.repetitions > 1);
+    let mut normalized: Vec<PeriodicAxis> = Vec::with_capacity(axes.len());
+    for axis in axes.drain(..) {
+        if axis.destination_stride == 0 {
+            return None;
+        }
+        if let Some(inner) = normalized.last_mut()
+            && inner
+                .destination_stride
+                .checked_mul(inner.repetitions)
+                == Some(axis.destination_stride)
+        {
+            inner.repetitions = inner.repetitions.checked_mul(axis.repetitions)?;
+            continue;
+        }
+        normalized.push(axis);
+    }
+    *axes = normalized;
+    Some(())
+}
+
+fn periodic_extent(length: usize, axes: &[PeriodicAxis]) -> Option<usize> {
+    axes.iter().try_fold(length, |extent, axis| {
+        if axis.repetitions == 0 || axis.destination_stride < extent {
+            return None;
+        }
+        axis.destination_stride
+            .checked_mul(axis.repetitions - 1)
+            .and_then(|offset| extent.checked_add(offset))
+    })
+}
+
+fn periodic_end(output: Span, axes: &[PeriodicAxis]) -> Option<usize> {
+    output
+        .start
+        .checked_add(periodic_extent(output.length, axes)?)
+}
+
+fn compose_periodic_projections(
+    inner: &PeriodicProjection,
+    outer: &PeriodicProjection,
+) -> Option<PeriodicProjection> {
+    let relative = inner.output.start.checked_sub(outer.source.start)?;
+    if periodic_end(inner.output, &inner.axes)? > outer.source.end()? {
+        return None;
+    }
+    let start = outer.output.start.checked_add(relative)?;
+    let mut axes = Vec::with_capacity(inner.axes.len().checked_add(outer.axes.len())?);
+    axes.extend_from_slice(&inner.axes);
+    axes.extend_from_slice(&outer.axes);
+    normalize_periodic_axes(&mut axes)?;
+    periodic_extent(inner.output.length, &axes)?;
+    Some(PeriodicProjection {
+        source: inner.source,
+        output: Span {
+            start,
+            length: inner.output.length,
+        },
+        axes,
+    })
 }
 
 /// Build a region MemorySSA summary for one procedure.
@@ -575,8 +648,10 @@ where
                                 start: first_start,
                                 length: phase.length,
                             },
-                            repetitions: end - first,
-                            destination_stride: dependency.destination_stride,
+                            axes: vec![PeriodicAxis {
+                                repetitions: end - first,
+                                destination_stride: dependency.destination_stride,
+                            }],
                         };
                         if let Some(&version) = ssa.uses.get(&Usage::Read {
                             read: dependency.read,
@@ -678,7 +753,7 @@ where
                 uncertain_input: path_uncertain_input,
                 active_read,
                 translation: path_translation,
-                periodic_output: path_periodic_output,
+                periodic_output: path_periodic_output.clone(),
                 marker: std::marker::PhantomData,
             }) {
                 continue;
@@ -690,8 +765,7 @@ where
                         input,
                         output_object: atoms[output_atom].object,
                         output: periodic.output,
-                        repetitions: periodic.repetitions,
-                        destination_stride: periodic.destination_stride,
+                        axes: periodic.axes,
                         kind: path_kind,
                         aligned: path_aligned,
                     });
@@ -714,7 +788,7 @@ where
                 Version::Entry(_) | Version::Phi { .. } => None,
             };
             if let Some(inputs) = version_deps.get(&version) {
-                for &(
+                for (
                     input,
                     kind,
                     aligned,
@@ -726,6 +800,14 @@ where
                     periodic_output,
                 ) in inputs
                 {
+                    let input = *input;
+                    let kind = *kind;
+                    let aligned = *aligned;
+                    let uncertain_input = *uncertain_input;
+                    let source_read = *source_read;
+                    let preserve_active_read = *preserve_active_read;
+                    let weak_previous = *weak_previous;
+                    let translation = *translation;
                     if weak_previous {
                         let Some(read) = active_read else {
                             // Retention by itself is not value feedback. It
@@ -741,81 +823,12 @@ where
                     let (next_translation, next_periodic_output) = if let Some(periodic) =
                         periodic_output
                     {
-                        if let Some(outer) = path_periodic_output {
-                            let flattens_with_outer = periodic
-                                .destination_stride
-                                .checked_mul(periodic.repetitions)
-                                == Some(outer.destination_stride);
-                            let Some(relative) =
-                                periodic.output.start.checked_sub(outer.source.start)
+                        if let Some(outer) = &path_periodic_output {
+                            let Some(composed) = compose_periodic_projections(periodic, outer)
                             else {
                                 continue;
                             };
-                            if flattens_with_outer {
-                                let Some(start) = outer.output.start.checked_add(relative) else {
-                                    continue;
-                                };
-                                let Some(repetitions) =
-                                    periodic.repetitions.checked_mul(outer.repetitions)
-                                else {
-                                    continue;
-                                };
-                                (
-                                    None,
-                                    Some(PeriodicProjection {
-                                        source: periodic.source,
-                                        output: Span {
-                                            start,
-                                            length: periodic.output.length,
-                                        },
-                                        repetitions,
-                                        destination_stride: periodic.destination_stride,
-                                    }),
-                                )
-                            } else {
-                                // Keep a genuinely two-dimensional set
-                                // exact by retaining one inner periodic
-                                // segment per outer copy. Regular nested
-                                // repeats tile and take the constant-size
-                                // flattening path above; this fallback has
-                                // no arbitrary expansion guard.
-                                for copy in 0..outer.repetitions {
-                                    let Some(start) = copy
-                                        .checked_mul(outer.destination_stride)
-                                        .and_then(|copy_offset| {
-                                            outer
-                                                .output
-                                                .start
-                                                .checked_add(relative)?
-                                                .checked_add(copy_offset)
-                                        })
-                                    else {
-                                        continue;
-                                    };
-                                    stack.push((
-                                        input,
-                                        combine_edge_kinds(path_kind, kind),
-                                        next_aligned,
-                                        path_uncertain_input || uncertain_input,
-                                        if preserve_active_read {
-                                            active_read
-                                        } else {
-                                            source_read
-                                        },
-                                        None,
-                                        Some(PeriodicProjection {
-                                            source: periodic.source,
-                                            output: Span {
-                                                start,
-                                                length: periodic.output.length,
-                                            },
-                                            repetitions: periodic.repetitions,
-                                            destination_stride: periodic.destination_stride,
-                                        }),
-                                    ));
-                                }
-                                continue;
-                            }
+                            (None, Some(composed))
                         } else if let Some(offset) = path_translation {
                             let shifted = if offset >= 0 {
                                 periodic.output.start.checked_add(offset as usize)
@@ -833,8 +846,7 @@ where
                                         start,
                                         length: periodic.output.length,
                                     },
-                                    repetitions: periodic.repetitions,
-                                    destination_stride: periodic.destination_stride,
+                                    axes: periodic.axes.clone(),
                                 }),
                             )
                         } else {
@@ -842,7 +854,7 @@ where
                             (None, None)
                         }
                     } else if path_periodic_output.is_some() {
-                        (None, path_periodic_output)
+                        (None, path_periodic_output.clone())
                     } else {
                         (
                             path_translation.and_then(|path| {

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -78,10 +78,20 @@ pub struct ProcedureSummary<O> {
     /// Objects touched through an unresolved region. Exact dependencies on
     /// other objects remain independently provable.
     pub uncertain_objects: BTreeSet<O>,
+    /// Original unresolved read regions. MemorySSA expands these to sparse
+    /// exact atoms internally; adapters use this set to restore the declared
+    /// uncertainty without widening a known static prefix.
+    pub uncertain_read_regions: BTreeSet<Region<O>>,
+    /// Exact atom dependency pairs which originated at an unresolved read.
+    /// This prevents adapters from widening an unrelated exact read merely
+    /// because the same procedure also reads that object dynamically.
+    pub uncertain_input_dependencies: BTreeSet<(Region<O>, Region<O>)>,
     /// Objects written through an unresolved region. Adapters use this
     /// narrower set when exact SSA atoms must be projected back to a sparse
     /// object-level destination without conflating dynamic reads with writes.
     pub uncertain_write_objects: BTreeSet<O>,
+    /// Original unresolved write regions; see `uncertain_read_regions`.
+    pub uncertain_write_regions: BTreeSet<Region<O>>,
     pub unknown_all: bool,
     pub atom_count: usize,
     pub definition_count: usize,
@@ -144,6 +154,7 @@ struct DepVersion<O> {
     version: Version<usize, Definition>,
     kind: EdgeKind,
     aligned: bool,
+    uncertain_input: bool,
     marker: std::marker::PhantomData<O>,
 }
 
@@ -175,7 +186,9 @@ where
     >::new();
     let mut incomplete = procedure.incomplete.clone();
     let mut uncertain_objects = BTreeSet::new();
+    let mut uncertain_read_regions = BTreeSet::new();
     let mut uncertain_write_objects = BTreeSet::new();
+    let mut uncertain_write_regions = BTreeSet::new();
     let mut unknown_all = false;
     let mut ssa_events = vec![Vec::new(); procedure.events.len()];
 
@@ -190,6 +203,9 @@ where
                         &mut uncertain_objects,
                         &mut unknown_all,
                     );
+                    if !region.is_exact() {
+                        uncertain_read_regions.insert(*region);
+                    }
                     if read_atoms
                         .insert(*id, (*region, expanded.clone()))
                         .is_some()
@@ -214,8 +230,12 @@ where
                         &mut uncertain_objects,
                         &mut unknown_all,
                     );
-                    if let Region::UnknownObject(object) = region {
-                        uncertain_write_objects.insert(*object);
+                    match region {
+                        Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
+                            uncertain_write_objects.insert(*object);
+                            uncertain_write_regions.insert(*region);
+                        }
+                        Region::Exact { .. } | Region::UnknownAll => {}
                     }
                     if writes
                         .insert(
@@ -255,7 +275,7 @@ where
     let definitions = writes.values().map(|(_, atoms, _, _)| atoms.len()).sum();
     let mut version_deps = BTreeMap::<
         Version<usize, Definition>,
-        BTreeSet<(Version<usize, Definition>, EdgeKind, bool)>,
+        BTreeSet<(Version<usize, Definition>, EdgeKind, bool, bool)>,
     >::new();
 
     for phi in &ssa.phis {
@@ -263,20 +283,20 @@ where
         deps.extend(
             phi.inputs
                 .iter()
-                .map(|(_, input)| (*input, EdgeKind::Value, true)),
+                .map(|(_, input)| (*input, EdgeKind::Value, true, false)),
         );
     }
     for (&write, (write_region, write_atoms, dependencies, aligned_dependencies)) in &writes {
         let mut incoming = BTreeSet::new();
         for &(read, kind) in dependencies {
-            let Some((_, atoms)) = read_atoms.get(&read) else {
+            let Some((read_region, atoms)) = read_atoms.get(&read) else {
                 return Err(ProcedureError::Model(
                     "write dependency refers to an unknown read",
                 ));
             };
             for &atom in atoms {
                 if let Some(&version) = ssa.uses.get(&Usage::Read { read, atom }) {
-                    incoming.insert((version, kind, false));
+                    incoming.insert((version, kind, false, !read_region.is_exact()));
                 }
             }
         }
@@ -353,7 +373,7 @@ where
                             atom: source_atom,
                         })
                     {
-                        atom_incoming.insert((version, dependency.kind, true));
+                        atom_incoming.insert((version, dependency.kind, true, false));
                     }
                 }
             }
@@ -368,39 +388,48 @@ where
     }
 
     let mut dependencies = BTreeSet::new();
+    let mut uncertain_input_dependencies = BTreeSet::new();
     for &output_atom in &written_atoms {
         let Some(&output_version) = ssa.uses.get(&Usage::Exit { atom: output_atom }) else {
             continue;
         };
-        let mut stack = vec![(output_version, EdgeKind::Value, true)];
+        let mut stack = vec![(output_version, EdgeKind::Value, true, false)];
         let mut visited = BTreeSet::new();
-        while let Some((version, path_kind, path_aligned)) = stack.pop() {
+        while let Some((version, path_kind, path_aligned, path_uncertain_input)) = stack.pop() {
             if !visited.insert(DepVersion::<O> {
                 version,
                 kind: path_kind,
                 aligned: path_aligned,
+                uncertain_input: path_uncertain_input,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
             }
             match version {
                 Version::Entry(input_atom) => {
-                    dependencies.insert(Dependency {
+                    let dependency = Dependency {
                         input: atom_region(atoms[input_atom]),
                         output: atom_region(atoms[output_atom]),
                         kind: path_kind,
                         aligned: path_aligned,
-                    });
+                    };
+                    dependencies.insert(dependency);
+                    if path_uncertain_input {
+                        uncertain_input_dependencies.insert((dependency.input, dependency.output));
+                    }
                 }
                 Version::Definition { .. } | Version::Phi { .. } => {
                     if let Some(inputs) = version_deps.get(&version) {
-                        stack.extend(inputs.iter().map(|&(input, kind, aligned)| {
-                            (
-                                input,
-                                combine_edge_kinds(path_kind, kind),
-                                path_aligned && aligned,
-                            )
-                        }));
+                        stack.extend(inputs.iter().map(
+                            |&(input, kind, aligned, uncertain_input)| {
+                                (
+                                    input,
+                                    combine_edge_kinds(path_kind, kind),
+                                    path_aligned && aligned,
+                                    path_uncertain_input || uncertain_input,
+                                )
+                            },
+                        ));
                     }
                 }
             }
@@ -411,7 +440,10 @@ where
         dependencies: dependencies.into_iter().collect(),
         incomplete,
         uncertain_objects,
+        uncertain_read_regions,
+        uncertain_input_dependencies,
         uncertain_write_objects,
+        uncertain_write_regions,
         unknown_all,
         atom_count: atoms.len(),
         definition_count: definitions,
@@ -427,7 +459,7 @@ fn record_unknown_region<O: Copy + Ord>(
 ) {
     match region {
         Region::Exact { .. } => {}
-        Region::UnknownObject(object) => {
+        Region::UnknownRegion { object, .. } | Region::UnknownObject(object) => {
             incomplete.insert(IncompleteReason::DynamicRegion);
             uncertain_objects.insert(object);
         }
@@ -463,7 +495,7 @@ fn build_atoms<O: Copy + Ord>(
 ) -> Result<(Vec<Atom<O>>, AtomIndex<O>), ProcedureError> {
     let mut endpoints = BTreeMap::<O, BTreeMap<usize, i64>>::new();
     let mut read_regions = BTreeMap::<ReadId, Region<O>>::new();
-    let mut dynamic_objects = BTreeSet::new();
+    let mut dynamic_regions = BTreeSet::new();
     for event in blocks.iter().flatten() {
         if let Event::Read { id, region } = event
             && read_regions.insert(*id, *region).is_some()
@@ -473,8 +505,11 @@ fn build_atoms<O: Copy + Ord>(
         let region = match event {
             Event::Read { region, .. } | Event::Write { region, .. } => *region,
         };
-        if let Region::UnknownObject(object) = region {
-            dynamic_objects.insert(object);
+        if matches!(
+            region,
+            Region::UnknownRegion { .. } | Region::UnknownObject(_)
+        ) {
+            dynamic_regions.insert(region);
         }
         let Region::Exact { object, span } = region else {
             continue;
@@ -493,9 +528,16 @@ fn build_atoms<O: Copy + Ord>(
         *endpoints.entry(object).or_default().entry(end).or_default() -= 1;
     }
 
-    for object in dynamic_objects {
-        let Some(span) = object_spans.get(&object).copied() else {
-            continue;
+    for region in dynamic_regions {
+        let (object, span) = match region {
+            Region::UnknownRegion { object, span } => (object, span),
+            Region::UnknownObject(object) => {
+                let Some(span) = object_spans.get(&object).copied() else {
+                    continue;
+                };
+                (object, span)
+            }
+            Region::Exact { .. } | Region::UnknownAll => continue,
         };
         let Some(end) = span.end() else {
             return Err(ProcedureError::Model("object span end overflows usize"));
@@ -673,6 +715,7 @@ fn expand<O: Copy + Ord>(
 ) -> Vec<usize> {
     let (object, span) = match region {
         Region::Exact { object, span } => (object, Some(span)),
+        Region::UnknownRegion { object, span } => (object, Some(span)),
         Region::UnknownObject(object) => (object, None),
         Region::UnknownAll => return Vec::new(),
     };
@@ -894,6 +937,45 @@ mod tests {
                 aligned: false,
             }]
         );
+    }
+
+    #[test]
+    fn unknown_static_prefix_cost_is_independent_of_span_length() {
+        // Why this case exists: a dynamic suffix may be confined to a very
+        // large static array prefix. The causal graph must retain that prefix
+        // as one interval rather than allocate one atom per possible element.
+        let prefix = Region::UnknownRegion {
+            object: 1u8,
+            span: Span {
+                start: 1 << 40,
+                length: 1 << 39,
+            },
+        };
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: prefix,
+                },
+                Event::Write {
+                    id: 0,
+                    region: prefix,
+                    dependencies: vec![(0, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(summary.atom_count, 1);
+        assert_eq!(summary.definition_count, 1);
+        assert_eq!(summary.uncertain_read_regions, BTreeSet::from([prefix]));
+        assert_eq!(summary.uncertain_write_regions, BTreeSet::from([prefix]));
     }
 
     #[test]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -27,7 +27,7 @@ pub struct MustAliasCandidate {
 /// A width-preserving positional transfer from a read region to a write
 /// region. Boundaries discovered on either side are propagated to the other;
 /// no per-bit expansion is required.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlignedDependency {
     pub read: ReadId,
     pub kind: EdgeKind,
@@ -35,13 +35,10 @@ pub struct AlignedDependency {
     pub source: Span,
     /// LSB-based span relative to the enclosing write region.
     pub destination: Span,
-    /// Number of copies of this transfer. A value greater than one represents
-    /// the same source span at regularly spaced destination positions without
-    /// materializing one dependency per copy.
-    pub repetitions: usize,
-    /// Distance in bits between consecutive destination copies. Ignored when
-    /// `repetitions == 1`.
-    pub destination_stride: usize,
+    /// Cartesian destination-copy axes, innermost first. An empty vector is a
+    /// single transfer. Representation size depends on nesting depth rather
+    /// than on any axis's numerical copy count.
+    pub axes: Vec<PeriodicAxis>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -288,6 +285,163 @@ fn periodic_end(output: Span, axes: &[PeriodicAxis]) -> Option<usize> {
     output
         .start
         .checked_add(periodic_extent(output.length, axes)?)
+}
+
+fn clip_periodic_projection(
+    source: Span,
+    output: Span,
+    axes: &[PeriodicAxis],
+    query: Span,
+) -> Option<Vec<PeriodicProjection>> {
+    fn visit(
+        source: Span,
+        output: Span,
+        axes: &[PeriodicAxis],
+        query: Span,
+        projections: &mut Vec<PeriodicProjection>,
+    ) -> Option<()> {
+        let pattern_end = periodic_end(output, axes)?;
+        let query_end = query.end()?;
+        if pattern_end <= query.start || query_end <= output.start {
+            return Some(());
+        }
+        if query.start <= output.start && pattern_end <= query_end {
+            projections.push(PeriodicProjection {
+                source,
+                output,
+                axes: axes.to_vec(),
+            });
+            return Some(());
+        }
+        let Some((outer, inner_axes)) = axes.split_last() else {
+            let overlap = output.intersection(query)?;
+            let relative = overlap.start.checked_sub(output.start)?;
+            projections.push(PeriodicProjection {
+                source: Span {
+                    start: source.start.checked_add(relative)?,
+                    length: overlap.length,
+                },
+                output: overlap,
+                axes: Vec::new(),
+            });
+            return Some(());
+        };
+        let inner_extent = periodic_extent(output.length, inner_axes)?;
+        let inner_end = output.start.checked_add(inner_extent)?;
+        let first = if query.start < inner_end {
+            0
+        } else {
+            query
+                .start
+                .checked_sub(inner_end)?
+                .checked_div(outer.destination_stride)?
+                .checked_add(1)?
+        }
+        .min(outer.repetitions);
+        let end = if query_end <= output.start {
+            0
+        } else {
+            query_end
+                .checked_sub(output.start)?
+                .checked_add(outer.destination_stride - 1)?
+                .checked_div(outer.destination_stride)?
+        }
+        .min(outer.repetitions);
+        if first >= end {
+            return Some(());
+        }
+
+        let shifted = |copy: usize| {
+            copy.checked_mul(outer.destination_stride)
+                .and_then(|offset| output.start.checked_add(offset))
+                .map(|start| Span {
+                    start,
+                    length: output.length,
+                })
+        };
+        let mut full_first = first;
+        let mut full_end = end;
+        let first_output = shifted(first)?;
+        if query.start > first_output.start
+            || first_output.start.checked_add(inner_extent)? > query_end
+        {
+            visit(source, first_output, inner_axes, query, projections)?;
+            full_first += 1;
+        }
+        if full_first < full_end {
+            let last = full_end - 1;
+            let last_output = shifted(last)?;
+            if query.start > last_output.start
+                || last_output.start.checked_add(inner_extent)? > query_end
+            {
+                visit(source, last_output, inner_axes, query, projections)?;
+                full_end -= 1;
+            }
+        }
+        if full_first < full_end {
+            let mut full_axes = inner_axes.to_vec();
+            full_axes.push(PeriodicAxis {
+                repetitions: full_end - full_first,
+                destination_stride: outer.destination_stride,
+            });
+            normalize_periodic_axes(&mut full_axes)?;
+            projections.push(PeriodicProjection {
+                source,
+                output: shifted(full_first)?,
+                axes: full_axes,
+            });
+        }
+        Some(())
+    }
+
+    let mut projections = Vec::new();
+    visit(source, output, axes, query, &mut projections)?;
+    Some(projections)
+}
+
+fn periodic_source_offsets_at_point(
+    output: Span,
+    axes: &[PeriodicAxis],
+    point: usize,
+) -> Option<Vec<usize>> {
+    fn visit(
+        output: Span,
+        axes: &[PeriodicAxis],
+        point: usize,
+        offsets: &mut BTreeSet<usize>,
+    ) -> Option<()> {
+        let Some((outer, inner_axes)) = axes.split_last() else {
+            if output.start <= point && point <= output.end()? {
+                offsets.insert(point.checked_sub(output.start)?);
+            }
+            return Some(());
+        };
+        let relative = point.checked_sub(output.start);
+        let copy = relative.map(|relative| relative / outer.destination_stride);
+        for candidate in [copy.and_then(|copy| copy.checked_sub(1)), copy]
+            .into_iter()
+            .flatten()
+            .filter(|&copy| copy < outer.repetitions)
+        {
+            let start = candidate
+                .checked_mul(outer.destination_stride)
+                .and_then(|offset| output.start.checked_add(offset))?;
+            visit(
+                Span {
+                    start,
+                    length: output.length,
+                },
+                inner_axes,
+                point,
+                offsets,
+            )?;
+        }
+        Some(())
+    }
+
+    let mut offsets = BTreeSet::new();
+    visit(output, axes, point, &mut offsets)?;
+    Some(offsets.into_iter().collect())
 }
 
 fn compose_periodic_projections(
@@ -572,18 +726,15 @@ where
                     incomplete.insert(IncompleteReason::DynamicRegion);
                     continue;
                 };
+                let mut axes = dependency.axes.clone();
                 if dependency.source.length != dependency.destination.length
-                    || dependency.repetitions == 0
+                    || normalize_periodic_axes(&mut axes).is_none()
                     || dependency.source.end().is_none()
                     || dependency.source.end() > Some(source_span.length)
                     || dependency.destination.end().is_none()
-                    || dependency
-                        .destination_stride
-                        .checked_mul(dependency.repetitions.saturating_sub(1))
-                        .and_then(|offset| dependency.destination.end()?.checked_add(offset))
-                        > Some(destination_span.length)
-                    || (dependency.repetitions > 1
-                        && dependency.destination_stride < dependency.destination.length)
+                    || periodic_extent(dependency.destination.length, &axes)
+                        .and_then(|extent| dependency.destination.start.checked_add(extent))
+                        .is_none_or(|end| end > destination_span.length)
                 {
                     return Err(ProcedureError::Model(
                         "aligned dependency does not fit its source and destination",
@@ -608,10 +759,7 @@ where
                     length: dependency.destination.length,
                 };
                 let output_atom = atoms[atom].span;
-                if dependency.repetitions > 1 {
-                    let Some(output_end) = output_atom.end() else {
-                        return Err(ProcedureError::Model("output atom overflows usize"));
-                    };
+                if !axes.is_empty() {
                     for &source_atom in source_atoms {
                         let Some(source_overlap) =
                             atoms[source_atom].span.intersection(transfer_source)
@@ -631,65 +779,28 @@ where
                             start: phase_start,
                             length: source_overlap.length,
                         };
-                        let Some(phase_end) = phase.end() else {
-                            return Err(ProcedureError::Model("periodic transfer overflows usize"));
-                        };
-                        let first = if output_atom.start < phase_end {
-                            0
-                        } else {
-                            output_atom
-                                .start
-                                .checked_sub(phase_end)
-                                .map(|distance| distance / dependency.destination_stride + 1)
-                                .unwrap_or(0)
-                        };
-                        let end = if output_end <= phase.start {
-                            0
-                        } else {
-                            output_end
-                                .checked_sub(phase.start)
-                                .and_then(|distance| {
-                                    distance.checked_add(dependency.destination_stride - 1)
-                                })
-                                .map(|distance| distance / dependency.destination_stride)
-                                .unwrap_or(dependency.repetitions)
-                        }
-                        .min(dependency.repetitions);
-                        if first >= end {
-                            continue;
-                        }
-                        let Some(first_start) = first
-                            .checked_mul(dependency.destination_stride)
-                            .and_then(|offset| phase.start.checked_add(offset))
-                        else {
-                            return Err(ProcedureError::Model("periodic transfer overflows usize"));
-                        };
-                        let projection = PeriodicProjection {
-                            source: source_overlap,
-                            output: Span {
-                                start: first_start,
-                                length: phase.length,
-                            },
-                            axes: vec![PeriodicAxis {
-                                repetitions: end - first,
-                                destination_stride: dependency.destination_stride,
-                            }],
-                        };
                         if let Some(&version) = ssa.uses.get(&Usage::Read {
                             read: dependency.read,
                             atom: source_atom,
                         }) {
-                            atom_incoming.insert((
-                                version,
-                                dependency.kind,
-                                true,
-                                false,
-                                Some(dependency.read),
-                                false,
-                                false,
-                                None,
-                                Some(projection),
-                            ));
+                            let projections =
+                                clip_periodic_projection(source_overlap, phase, &axes, output_atom)
+                                    .ok_or(ProcedureError::Model(
+                                        "periodic transfer overflows usize",
+                                    ))?;
+                            for projection in projections {
+                                atom_incoming.insert((
+                                    version,
+                                    dependency.kind,
+                                    true,
+                                    false,
+                                    Some(dependency.read),
+                                    false,
+                                    false,
+                                    None,
+                                    Some(projection),
+                                ));
+                            }
                         }
                     }
                     continue;
@@ -1083,14 +1194,13 @@ fn build_atoms<O: Copy + Ord>(
         *endpoints.entry(object).or_default().entry(end).or_default() -= 1;
     }
 
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     struct Transfer<O> {
         source_object: O,
         source_span: Span,
         destination_object: O,
         destination_span: Span,
-        repetitions: usize,
-        destination_stride: usize,
+        axes: Vec<PeriodicAxis>,
     }
 
     let mut transfers = Vec::<Transfer<O>>::new();
@@ -1118,18 +1228,15 @@ fn build_atoms<O: Copy + Ord>(
             else {
                 continue;
             };
+            let mut axes = dependency.axes.clone();
             if dependency.source.length != dependency.destination.length
-                || dependency.repetitions == 0
+                || normalize_periodic_axes(&mut axes).is_none()
                 || dependency.source.end().is_none()
                 || dependency.source.end() > Some(source_span.length)
                 || dependency.destination.end().is_none()
-                || dependency
-                    .destination_stride
-                    .checked_mul(dependency.repetitions.saturating_sub(1))
-                    .and_then(|offset| dependency.destination.end()?.checked_add(offset))
-                    > Some(destination_span.length)
-                || (dependency.repetitions > 1
-                    && dependency.destination_stride < dependency.destination.length)
+                || periodic_extent(dependency.destination.length, &axes)
+                    .and_then(|extent| dependency.destination.start.checked_add(extent))
+                    .is_none_or(|end| end > destination_span.length)
             {
                 return Err(ProcedureError::Model(
                     "aligned dependency regions have different lengths",
@@ -1157,8 +1264,7 @@ fn build_atoms<O: Copy + Ord>(
                 source_span: mapped_source,
                 destination_object,
                 destination_span: mapped_destination,
-                repetitions: dependency.repetitions,
-                destination_stride: dependency.destination_stride,
+                axes,
             });
         }
     }
@@ -1251,11 +1357,7 @@ fn build_atoms<O: Copy + Ord>(
                 index,
                 from_source: false,
                 start: transfer.destination_span.start,
-                end: transfer
-                    .destination_stride
-                    .checked_mul(transfer.repetitions.saturating_sub(1))
-                    .and_then(|offset| transfer.destination_span.end()?.checked_add(offset))
-                    .unwrap_or(usize::MAX),
+                end: periodic_end(transfer.destination_span, &transfer.axes).unwrap_or(usize::MAX),
             });
     }
     let transfer_index = transfer_refs
@@ -1271,41 +1373,25 @@ fn build_atoms<O: Copy + Ord>(
             continue;
         };
         for transfer_ref in object_transfers.containing(point) {
-            let transfer = transfers[transfer_ref.index];
-            if transfer.repetitions > 1 {
+            let transfer = &transfers[transfer_ref.index];
+            if !transfer.axes.is_empty() {
                 if transfer_ref.from_source {
                     // Destination copy boundaries stay symbolic. Observed
                     // destination boundaries are projected back below.
                     continue;
                 }
-                let Some(relative) = point.checked_sub(transfer.destination_span.start) else {
-                    continue;
-                };
-                let copy = relative / transfer.destination_stride;
-                for candidate in [copy.checked_sub(1), Some(copy)]
-                    .into_iter()
-                    .flatten()
-                    .filter(|copy| *copy < transfer.repetitions)
-                {
-                    let Some(copy_start) = candidate
-                        .checked_mul(transfer.destination_stride)
-                        .and_then(|offset| transfer.destination_span.start.checked_add(offset))
-                    else {
-                        continue;
-                    };
-                    let Some(copy_end) = copy_start.checked_add(transfer.destination_span.length)
-                    else {
-                        continue;
-                    };
-                    if point < copy_start || point > copy_end {
-                        continue;
-                    }
-                    let Some(mapped) = point
-                        .checked_sub(copy_start)
-                        .and_then(|offset| transfer.source_span.start.checked_add(offset))
-                    else {
-                        return Err(ProcedureError::Model("aligned transfer overflows usize"));
-                    };
+                let offsets = periodic_source_offsets_at_point(
+                    transfer.destination_span,
+                    &transfer.axes,
+                    point,
+                )
+                .ok_or(ProcedureError::Model("aligned transfer overflows usize"))?;
+                for offset in offsets {
+                    let mapped = transfer
+                        .source_span
+                        .start
+                        .checked_add(offset)
+                        .ok_or(ProcedureError::Model("aligned transfer overflows usize"))?;
                     let inserted = match endpoints
                         .entry(transfer.source_object)
                         .or_default()
@@ -1545,8 +1631,7 @@ mod tests {
                             start: 0,
                             length: 1 << 30,
                         },
-                        repetitions: 1,
-                        destination_stride: 0,
+                        axes: vec![],
                     }],
                 },
                 Event::Read {
@@ -1616,8 +1701,10 @@ mod tests {
                             start: 0,
                             length: 2,
                         },
-                        repetitions: copies,
-                        destination_stride: 2,
+                        axes: vec![PeriodicAxis {
+                            repetitions: copies,
+                            destination_stride: 2,
+                        }],
                     }],
                 },
                 Event::Read {
@@ -1665,8 +1752,10 @@ mod tests {
                 phase.iter().all(|dependency| {
                     dependency.output.length == 1
                         && dependency.output.start % 2 == bit
-                        && dependency.axes.len() == 1
-                        && dependency.axes[0].destination_stride == 2
+                        && dependency
+                            .axes
+                            .iter()
+                            .all(|axis| axis.destination_stride == 2)
                 }),
                 "{summary:#?}"
             );
@@ -1715,8 +1804,10 @@ mod tests {
                             start: 0,
                             length: 1,
                         },
-                        repetitions: copies,
-                        destination_stride: inner_stride,
+                        axes: vec![PeriodicAxis {
+                            repetitions: copies,
+                            destination_stride: inner_stride,
+                        }],
                     }],
                 },
                 Event::Read {
@@ -1738,8 +1829,10 @@ mod tests {
                             start: 0,
                             length: inner_length,
                         },
-                        repetitions: copies,
-                        destination_stride: outer_stride,
+                        axes: vec![PeriodicAxis {
+                            repetitions: copies,
+                            destination_stride: outer_stride,
+                        }],
                     }],
                 },
             ]],

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -255,8 +255,9 @@ where
         let mut incoming = BTreeSet::new();
         for &(read, kind) in dependencies {
             let Some((_, atoms)) = read_atoms.get(&read) else {
-                incomplete.insert(IncompleteReason::UnsupportedSyntax);
-                continue;
+                return Err(ProcedureError::Model(
+                    "write dependency refers to an unknown read",
+                ));
             };
             for &atom in atoms {
                 if let Some(&version) = ssa.uses.get(&Usage::Read { read, atom }) {
@@ -268,8 +269,9 @@ where
             let mut atom_incoming = incoming.clone();
             for dependency in aligned_dependencies {
                 let Some((read_region, source_atoms)) = read_atoms.get(&dependency.read) else {
-                    incomplete.insert(IncompleteReason::UnsupportedSyntax);
-                    continue;
+                    return Err(ProcedureError::Model(
+                        "aligned dependency refers to an unknown read",
+                    ));
                 };
                 let (
                     Region::Exact {
@@ -298,8 +300,9 @@ where
                     || dependency.destination.end() > Some(destination_span.length)
                     || source_span.length != transfer_destination.length
                 {
-                    incomplete.insert(IncompleteReason::UnsupportedSyntax);
-                    continue;
+                    return Err(ProcedureError::Model(
+                        "aligned dependency does not fit its source and destination",
+                    ));
                 }
                 let output_atom = atoms[atom].span;
                 let Some(overlap) = output_atom.intersection(transfer_destination) else {

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use crate::cfg::{CfgError, ForwardControlFlowGraph};
-use crate::graph::{EdgeKind, IncompleteReason};
+use crate::graph::{EdgeKind, IncompleteReason, OpaqueBoundary};
 use crate::region::{Region, Span};
 use crate::ssa::{self, Event as SsaEvent, Version};
 
@@ -1306,11 +1306,11 @@ fn record_unknown_region<O: Copy + Ord>(
         Region::UnknownObject(object) => {
             uncertain_objects.insert(object);
             if !object_spans.contains_key(&object) {
-                incomplete.insert(IncompleteReason::DynamicRegion);
+                incomplete.insert(IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion));
             }
         }
         Region::UnknownAll => {
-            incomplete.insert(IncompleteReason::DynamicRegion);
+            incomplete.insert(IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion));
             *unknown_all = true;
         }
     }
@@ -2554,7 +2554,7 @@ mod tests {
         assert!(
             summary
                 .incomplete
-                .contains(&IncompleteReason::DynamicRegion),
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion)),
             "{summary:#?}"
         );
     }
@@ -2693,7 +2693,7 @@ mod tests {
         assert!(
             summary
                 .incomplete
-                .contains(&IncompleteReason::DynamicRegion)
+                .contains(&IncompleteReason::Opaque(OpaqueBoundary::UnboundedRegion))
         );
     }
 

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -1587,16 +1587,26 @@ mod tests {
             assert_eq!(
                 phase
                     .iter()
-                    .map(|dependency| dependency.repetitions)
+                    .map(|dependency| {
+                        dependency
+                            .axes
+                            .iter()
+                            .map(|axis| axis.repetitions)
+                            .product::<usize>()
+                    })
                     .sum::<usize>(),
                 copies,
                 "{summary:#?}"
             );
-            assert!(phase.iter().all(|dependency| {
-                dependency.output.length == 1
-                    && dependency.output.start % 2 == bit
-                    && dependency.destination_stride == 2
-            }));
+            assert!(
+                phase.iter().all(|dependency| {
+                    dependency.output.length == 1
+                        && dependency.output.start % 2 == bit
+                        && dependency.axes.len() == 1
+                        && dependency.axes[0].destination_stride == 2
+                }),
+                "{summary:#?}"
+            );
         }
         let final_inputs = summary
             .dependencies
@@ -1605,6 +1615,101 @@ mod tests {
             .map(|dependency| dependency.input)
             .collect::<BTreeSet<_>>();
         assert_eq!(final_inputs, [exact(1, 0, 1)].into());
+    }
+
+    #[test]
+    fn nested_periodic_copy_keeps_summary_size_independent_of_axis_counts() {
+        // Why this case exists: composing two non-flattenable periodic copies
+        // used to emit one inner projection per outer copy. Both axes must
+        // remain exact while summary size stays independent of 200,000²
+        // concrete destinations.
+        let copies = 200_000usize;
+        let inner_stride = 2usize;
+        let inner_length = (copies - 1) * inner_stride + 1;
+        let outer_stride = 500_000usize;
+        let outer_length = (copies - 1) * outer_stride + inner_length;
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: exact(1, 0, 1),
+                },
+                Event::Write {
+                    id: 0,
+                    region: exact(2, 0, inner_length),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![AlignedDependency {
+                        read: 0,
+                        kind: EdgeKind::Value,
+                        source: Span {
+                            start: 0,
+                            length: 1,
+                        },
+                        destination: Span {
+                            start: 0,
+                            length: 1,
+                        },
+                        repetitions: copies,
+                        destination_stride: inner_stride,
+                    }],
+                },
+                Event::Read {
+                    id: 1,
+                    region: exact(2, 0, inner_length),
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(3, 0, outer_length),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![AlignedDependency {
+                        read: 1,
+                        kind: EdgeKind::Value,
+                        source: Span {
+                            start: 0,
+                            length: inner_length,
+                        },
+                        destination: Span {
+                            start: 0,
+                            length: inner_length,
+                        },
+                        repetitions: copies,
+                        destination_stride: outer_stride,
+                    }],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            must_alias: BTreeSet::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(summary.atom_count < 16, "{summary:#?}");
+        assert!(summary.periodic_dependencies.len() < 16, "{summary:#?}");
+        let nested = summary
+            .periodic_dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.input == exact(1, 0, 1) && dependency.output_object == 3
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(nested.len(), 1, "{summary:#?}");
+        assert_eq!(nested[0].output, Span { start: 0, length: 1 });
+        assert_eq!(
+            nested[0].axes,
+            vec![
+                PeriodicAxis {
+                    repetitions: copies,
+                    destination_stride: inner_stride,
+                },
+                PeriodicAxis {
+                    repetitions: copies,
+                    destination_stride: outer_stride,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -1,0 +1,913 @@
+//! Sparse region MemorySSA for one independently analyzable procedure.
+//!
+//! Region endpoints, rather than individual bits or array elements, form the
+//! SSA variable domain.  Consequently construction depends on the number of
+//! accesses and CFG edges, not on the numerical width of an RTL object.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use crate::cfg::{CfgError, ForwardControlFlowGraph};
+use crate::graph::{EdgeKind, IncompleteReason};
+use crate::region::{Region, Span};
+use crate::ssa::{self, Event as SsaEvent, Version};
+
+pub type ReadId = usize;
+pub type WriteId = usize;
+
+/// A width-preserving positional transfer from a read region to a write
+/// region. Boundaries discovered on either side are propagated to the other;
+/// no per-bit expansion is required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlignedDependency {
+    pub read: ReadId,
+    pub kind: EdgeKind,
+    /// LSB-based span relative to the enclosing write region.
+    pub destination: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event<O> {
+    Read {
+        id: ReadId,
+        region: Region<O>,
+    },
+    Write {
+        id: WriteId,
+        region: Region<O>,
+        /// Reads which determine the value, address, or execution of this
+        /// write. Observer-only reads must not be listed here.
+        dependencies: Vec<(ReadId, EdgeKind)>,
+        /// Position-preserving dependencies such as `dst = src`. These are
+        /// kept separate from all-to-all value dependencies so a later read
+        /// of `dst[0]` depends only on `src[0]`.
+        aligned_dependencies: Vec<AlignedDependency>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Procedure<O> {
+    pub entry: usize,
+    pub exit: usize,
+    pub successors: Vec<Vec<usize>>,
+    pub events: Vec<Vec<Event<O>>>,
+    /// Declared bounds for objects which may be accessed dynamically. Bounds
+    /// are partitioned only at observed access endpoints; they are never
+    /// expanded into individual bits or elements.
+    pub object_spans: BTreeMap<O, Span>,
+    pub incomplete: BTreeSet<IncompleteReason>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Dependency<O> {
+    pub input: Region<O>,
+    pub output: Region<O>,
+    pub kind: EdgeKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcedureSummary<O> {
+    pub dependencies: Vec<Dependency<O>>,
+    pub incomplete: BTreeSet<IncompleteReason>,
+    /// Objects touched through an unresolved region. Exact dependencies on
+    /// other objects remain independently provable.
+    pub uncertain_objects: BTreeSet<O>,
+    pub unknown_all: bool,
+    pub atom_count: usize,
+    pub definition_count: usize,
+    pub phi_count: usize,
+}
+
+#[derive(Debug)]
+pub enum ProcedureError {
+    Cfg(CfgError),
+    Ssa(ssa::SsaError),
+    Model(&'static str),
+}
+
+impl fmt::Display for ProcedureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cfg(error) => error.fmt(formatter),
+            Self::Ssa(error) => error.fmt(formatter),
+            Self::Model(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for ProcedureError {}
+
+impl From<CfgError> for ProcedureError {
+    fn from(value: CfgError) -> Self {
+        Self::Cfg(value)
+    }
+}
+
+impl From<ssa::SsaError> for ProcedureError {
+    fn from(value: ssa::SsaError) -> Self {
+        Self::Ssa(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Atom<O> {
+    object: O,
+    span: Span,
+}
+
+type AtomIndex<O> = BTreeMap<O, Vec<usize>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Definition {
+    write: WriteId,
+    atom: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Usage {
+    Read { read: ReadId, atom: usize },
+    Exit { atom: usize },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct DepVersion<O> {
+    version: Version<usize, Definition>,
+    kind: EdgeKind,
+    marker: std::marker::PhantomData<O>,
+}
+
+/// Build a region MemorySSA summary for one procedure.
+pub fn analyze<O>(procedure: &Procedure<O>) -> Result<ProcedureSummary<O>, ProcedureError>
+where
+    O: Copy + Ord,
+{
+    if procedure.events.len() != procedure.successors.len() {
+        return Err(ProcedureError::Model(
+            "event and successor tables cover different block domains",
+        ));
+    }
+    if procedure.exit >= procedure.successors.len() {
+        return Err(ProcedureError::Model("procedure exit is out of range"));
+    }
+
+    let cfg = ForwardControlFlowGraph::analyze(procedure.successors.clone(), procedure.entry)?;
+    let (atoms, atoms_by_object) = build_atoms(&procedure.events, &procedure.object_spans)?;
+    let mut read_atoms = BTreeMap::<ReadId, (Region<O>, Vec<usize>)>::new();
+    let mut writes = BTreeMap::<
+        WriteId,
+        (
+            Region<O>,
+            Vec<usize>,
+            Vec<(ReadId, EdgeKind)>,
+            Vec<AlignedDependency>,
+        ),
+    >::new();
+    let mut incomplete = procedure.incomplete.clone();
+    let mut uncertain_objects = BTreeSet::new();
+    let mut unknown_all = false;
+    let mut ssa_events = vec![Vec::new(); procedure.events.len()];
+
+    for (block, events) in procedure.events.iter().enumerate() {
+        for event in events {
+            match event {
+                Event::Read { id, region } => {
+                    let expanded = expand(*region, &atoms, &atoms_by_object);
+                    record_unknown_region(
+                        *region,
+                        &mut incomplete,
+                        &mut uncertain_objects,
+                        &mut unknown_all,
+                    );
+                    if read_atoms
+                        .insert(*id, (*region, expanded.clone()))
+                        .is_some()
+                    {
+                        return Err(ProcedureError::Model("duplicate read identity"));
+                    }
+                    ssa_events[block].extend(expanded.into_iter().map(|atom| SsaEvent::Use {
+                        variable: atom,
+                        usage: Usage::Read { read: *id, atom },
+                    }));
+                }
+                Event::Write {
+                    id,
+                    region,
+                    dependencies,
+                    aligned_dependencies,
+                } => {
+                    let expanded = expand(*region, &atoms, &atoms_by_object);
+                    record_unknown_region(
+                        *region,
+                        &mut incomplete,
+                        &mut uncertain_objects,
+                        &mut unknown_all,
+                    );
+                    if writes
+                        .insert(
+                            *id,
+                            (
+                                *region,
+                                expanded.clone(),
+                                dependencies.clone(),
+                                aligned_dependencies.clone(),
+                            ),
+                        )
+                        .is_some()
+                    {
+                        return Err(ProcedureError::Model("duplicate write identity"));
+                    }
+                    ssa_events[block].extend(expanded.into_iter().map(|atom| {
+                        SsaEvent::Definition {
+                            variable: atom,
+                            definition: Definition { write: *id, atom },
+                        }
+                    }));
+                }
+            }
+        }
+    }
+
+    let written_atoms = writes
+        .values()
+        .flat_map(|(_, atoms, _, _)| atoms.iter().copied())
+        .collect::<BTreeSet<_>>();
+    ssa_events[procedure.exit].extend(written_atoms.iter().copied().map(|atom| SsaEvent::Use {
+        variable: atom,
+        usage: Usage::Exit { atom },
+    }));
+
+    let ssa = ssa::build(&cfg, &ssa_events)?;
+    let definitions = writes.values().map(|(_, atoms, _, _)| atoms.len()).sum();
+    let mut version_deps = BTreeMap::<
+        Version<usize, Definition>,
+        BTreeSet<(Version<usize, Definition>, EdgeKind)>,
+    >::new();
+
+    for phi in &ssa.phis {
+        let deps = version_deps.entry(phi.version).or_default();
+        deps.extend(
+            phi.inputs
+                .iter()
+                .map(|(_, input)| (*input, EdgeKind::Value)),
+        );
+    }
+    for (&write, (write_region, write_atoms, dependencies, aligned_dependencies)) in &writes {
+        let mut incoming = BTreeSet::new();
+        for &(read, kind) in dependencies {
+            let Some((_, atoms)) = read_atoms.get(&read) else {
+                incomplete.insert(IncompleteReason::UnsupportedSyntax);
+                continue;
+            };
+            for &atom in atoms {
+                if let Some(&version) = ssa.uses.get(&Usage::Read { read, atom }) {
+                    incoming.insert((version, kind));
+                }
+            }
+        }
+        for &atom in write_atoms {
+            let mut atom_incoming = incoming.clone();
+            for dependency in aligned_dependencies {
+                let Some((read_region, source_atoms)) = read_atoms.get(&dependency.read) else {
+                    incomplete.insert(IncompleteReason::UnsupportedSyntax);
+                    continue;
+                };
+                let (
+                    Region::Exact {
+                        span: source_span, ..
+                    },
+                    Region::Exact {
+                        span: destination_span,
+                        ..
+                    },
+                ) = (*read_region, *write_region)
+                else {
+                    incomplete.insert(IncompleteReason::DynamicRegion);
+                    continue;
+                };
+                let Some(destination_start) = destination_span
+                    .start
+                    .checked_add(dependency.destination.start)
+                else {
+                    return Err(ProcedureError::Model("aligned transfer overflows usize"));
+                };
+                let transfer_destination = Span {
+                    start: destination_start,
+                    length: dependency.destination.length,
+                };
+                if dependency.destination.end().is_none()
+                    || dependency.destination.end() > Some(destination_span.length)
+                    || source_span.length != transfer_destination.length
+                {
+                    incomplete.insert(IncompleteReason::UnsupportedSyntax);
+                    continue;
+                }
+                let output_atom = atoms[atom].span;
+                let Some(overlap) = output_atom.intersection(transfer_destination) else {
+                    continue;
+                };
+                let Some(relative_start) = overlap.start.checked_sub(transfer_destination.start)
+                else {
+                    return Err(ProcedureError::Model(
+                        "write atom begins before its aligned transfer",
+                    ));
+                };
+                let Some(mapped_start) = source_span.start.checked_add(relative_start) else {
+                    return Err(ProcedureError::Model("aligned transfer overflows usize"));
+                };
+                let mapped = Span {
+                    start: mapped_start,
+                    length: overlap.length,
+                };
+                for &source_atom in source_atoms {
+                    if atoms[source_atom].span.intersection(mapped).is_some()
+                        && let Some(&version) = ssa.uses.get(&Usage::Read {
+                            read: dependency.read,
+                            atom: source_atom,
+                        })
+                    {
+                        atom_incoming.insert((version, dependency.kind));
+                    }
+                }
+            }
+            version_deps.insert(
+                Version::Definition {
+                    variable: atom,
+                    definition: Definition { write, atom },
+                },
+                atom_incoming,
+            );
+        }
+    }
+
+    let mut dependencies = BTreeSet::new();
+    for &output_atom in &written_atoms {
+        let Some(&output_version) = ssa.uses.get(&Usage::Exit { atom: output_atom }) else {
+            continue;
+        };
+        let mut stack = vec![(output_version, EdgeKind::Value)];
+        let mut visited = BTreeSet::new();
+        while let Some((version, path_kind)) = stack.pop() {
+            if !visited.insert(DepVersion::<O> {
+                version,
+                kind: path_kind,
+                marker: std::marker::PhantomData,
+            }) {
+                continue;
+            }
+            match version {
+                Version::Entry(input_atom) => {
+                    dependencies.insert(Dependency {
+                        input: atom_region(atoms[input_atom]),
+                        output: atom_region(atoms[output_atom]),
+                        kind: path_kind,
+                    });
+                }
+                Version::Definition { .. } | Version::Phi { .. } => {
+                    if let Some(inputs) = version_deps.get(&version) {
+                        stack.extend(
+                            inputs
+                                .iter()
+                                .map(|&(input, kind)| (input, combine_edge_kinds(path_kind, kind))),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(ProcedureSummary {
+        dependencies: dependencies.into_iter().collect(),
+        incomplete,
+        uncertain_objects,
+        unknown_all,
+        atom_count: atoms.len(),
+        definition_count: definitions,
+        phi_count: ssa.phis.len(),
+    })
+}
+
+fn record_unknown_region<O: Copy + Ord>(
+    region: Region<O>,
+    incomplete: &mut BTreeSet<IncompleteReason>,
+    uncertain_objects: &mut BTreeSet<O>,
+    unknown_all: &mut bool,
+) {
+    match region {
+        Region::Exact { .. } => {}
+        Region::UnknownObject(object) => {
+            incomplete.insert(IncompleteReason::DynamicRegion);
+            uncertain_objects.insert(object);
+        }
+        Region::UnknownAll => {
+            incomplete.insert(IncompleteReason::DynamicRegion);
+            *unknown_all = true;
+        }
+    }
+}
+
+fn combine_edge_kinds(outer: EdgeKind, inner: EdgeKind) -> EdgeKind {
+    if outer == EdgeKind::Unknown || inner == EdgeKind::Unknown {
+        EdgeKind::Unknown
+    } else if outer == EdgeKind::Control || inner == EdgeKind::Control {
+        EdgeKind::Control
+    } else if outer == EdgeKind::Address || inner == EdgeKind::Address {
+        EdgeKind::Address
+    } else {
+        EdgeKind::Value
+    }
+}
+
+fn atom_region<O>(atom: Atom<O>) -> Region<O> {
+    Region::Exact {
+        object: atom.object,
+        span: atom.span,
+    }
+}
+
+fn build_atoms<O: Copy + Ord>(
+    blocks: &[Vec<Event<O>>],
+    object_spans: &BTreeMap<O, Span>,
+) -> Result<(Vec<Atom<O>>, AtomIndex<O>), ProcedureError> {
+    let mut endpoints = BTreeMap::<O, BTreeMap<usize, i64>>::new();
+    let mut read_regions = BTreeMap::<ReadId, Region<O>>::new();
+    let mut dynamic_objects = BTreeSet::new();
+    for event in blocks.iter().flatten() {
+        if let Event::Read { id, region } = event
+            && read_regions.insert(*id, *region).is_some()
+        {
+            return Err(ProcedureError::Model("duplicate read identity"));
+        }
+        let region = match event {
+            Event::Read { region, .. } | Event::Write { region, .. } => *region,
+        };
+        if let Region::UnknownObject(object) = region {
+            dynamic_objects.insert(object);
+        }
+        let Region::Exact { object, span } = region else {
+            continue;
+        };
+        let Some(end) = span.end() else {
+            return Err(ProcedureError::Model("region end overflows usize"));
+        };
+        if span.length == 0 {
+            return Err(ProcedureError::Model("empty region"));
+        }
+        *endpoints
+            .entry(object)
+            .or_default()
+            .entry(span.start)
+            .or_default() += 1;
+        *endpoints.entry(object).or_default().entry(end).or_default() -= 1;
+    }
+
+    for object in dynamic_objects {
+        let Some(span) = object_spans.get(&object).copied() else {
+            continue;
+        };
+        let Some(end) = span.end() else {
+            return Err(ProcedureError::Model("object span end overflows usize"));
+        };
+        if span.length == 0 {
+            return Err(ProcedureError::Model("empty object span"));
+        }
+        *endpoints
+            .entry(object)
+            .or_default()
+            .entry(span.start)
+            .or_default() += 1;
+        *endpoints.entry(object).or_default().entry(end).or_default() -= 1;
+    }
+
+    #[derive(Clone, Copy)]
+    struct Transfer<O> {
+        source_object: O,
+        source_span: Span,
+        destination_object: O,
+        destination_span: Span,
+    }
+
+    let mut transfers = Vec::<Transfer<O>>::new();
+    for event in blocks.iter().flatten() {
+        let Event::Write {
+            region: destination,
+            aligned_dependencies,
+            ..
+        } = event
+        else {
+            continue;
+        };
+        let Region::Exact {
+            object: destination_object,
+            span: destination_span,
+        } = *destination
+        else {
+            continue;
+        };
+        for dependency in aligned_dependencies {
+            let Some(Region::Exact {
+                object: source_object,
+                span: source_span,
+            }) = read_regions.get(&dependency.read).copied()
+            else {
+                continue;
+            };
+            let Some(destination_start) = destination_span
+                .start
+                .checked_add(dependency.destination.start)
+            else {
+                return Err(ProcedureError::Model("aligned transfer overflows usize"));
+            };
+            let mapped_destination = Span {
+                start: destination_start,
+                length: dependency.destination.length,
+            };
+            if dependency.destination.end().is_none()
+                || dependency.destination.end() > Some(destination_span.length)
+                || source_span.length != mapped_destination.length
+            {
+                return Err(ProcedureError::Model(
+                    "aligned dependency regions have different lengths",
+                ));
+            }
+            transfers.push(Transfer {
+                source_object,
+                source_span,
+                destination_object,
+                destination_span: mapped_destination,
+            });
+        }
+    }
+
+    // Copy relationships form a sparse coordinate graph. Propagate only
+    // observed access boundaries through it, so even million-bit objects cost
+    // O(accesses + propagated endpoints), never O(width).
+    let mut transfer_index = BTreeMap::<O, Vec<(usize, bool)>>::new();
+    for (index, transfer) in transfers.iter().enumerate() {
+        transfer_index
+            .entry(transfer.source_object)
+            .or_default()
+            .push((index, true));
+        transfer_index
+            .entry(transfer.destination_object)
+            .or_default()
+            .push((index, false));
+    }
+    let mut pending = std::collections::VecDeque::new();
+    for (&object, points) in &endpoints {
+        pending.extend(points.keys().map(|&point| (object, point)));
+    }
+    while let Some((object, point)) = pending.pop_front() {
+        for &(index, from_source) in transfer_index.get(&object).into_iter().flatten() {
+            let transfer = transfers[index];
+            let (from, to_object, to) = if from_source {
+                (
+                    transfer.source_span,
+                    transfer.destination_object,
+                    transfer.destination_span,
+                )
+            } else {
+                (
+                    transfer.destination_span,
+                    transfer.source_object,
+                    transfer.source_span,
+                )
+            };
+            let Some(from_end) = from.end() else {
+                return Err(ProcedureError::Model("aligned transfer overflows usize"));
+            };
+            if point < from.start || point > from_end {
+                continue;
+            }
+            let Some(mapped) = point
+                .checked_sub(from.start)
+                .and_then(|offset| to.start.checked_add(offset))
+            else {
+                return Err(ProcedureError::Model("aligned transfer overflows usize"));
+            };
+            let inserted = match endpoints.entry(to_object).or_default().entry(mapped) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(0);
+                    true
+                }
+                std::collections::btree_map::Entry::Occupied(_) => false,
+            };
+            if inserted {
+                pending.push_back((to_object, mapped));
+            }
+        }
+    }
+
+    let mut atoms = Vec::new();
+    let mut atoms_by_object = BTreeMap::<O, Vec<usize>>::new();
+    for (object, points) in endpoints {
+        let mut active = 0i64;
+        let mut previous = None;
+        for (point, delta) in points {
+            if let Some(start) = previous
+                && active > 0
+                && start < point
+            {
+                let atom = atoms.len();
+                atoms.push(Atom {
+                    object,
+                    span: Span {
+                        start,
+                        length: point - start,
+                    },
+                });
+                atoms_by_object.entry(object).or_default().push(atom);
+            }
+            active += delta;
+            previous = Some(point);
+        }
+    }
+    Ok((atoms, atoms_by_object))
+}
+
+fn expand<O: Copy + Ord>(
+    region: Region<O>,
+    atoms: &[Atom<O>],
+    atoms_by_object: &BTreeMap<O, Vec<usize>>,
+) -> Vec<usize> {
+    let (object, span) = match region {
+        Region::Exact { object, span } => (object, Some(span)),
+        Region::UnknownObject(object) => (object, None),
+        Region::UnknownAll => return Vec::new(),
+    };
+    atoms_by_object
+        .get(&object)
+        .map(|object_atoms| {
+            object_atoms
+                .iter()
+                .copied()
+                .filter(|&atom| {
+                    span.is_none_or(|span| atoms[atom].span.intersection(span).is_some())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exact(object: u8, start: usize, length: usize) -> Region<u8> {
+        Region::Exact {
+            object,
+            span: Span { start, length },
+        }
+    }
+
+    #[test]
+    fn sequential_overwrite_kills_the_entry_dependency() {
+        let procedure: Procedure<u8> = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Write {
+                    id: 0,
+                    region: exact(1, 0, 8),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                },
+                Event::Read {
+                    id: 0,
+                    region: exact(1, 0, 8),
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(1, 0, 8),
+                    dependencies: vec![(0, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+        let summary = analyze(&procedure).unwrap();
+        assert!(summary.dependencies.is_empty());
+    }
+
+    #[test]
+    fn branch_merge_retains_only_the_live_entry_arm() {
+        let procedure = Procedure {
+            entry: 0,
+            exit: 3,
+            successors: vec![vec![1, 2], vec![3], vec![3], vec![]],
+            events: vec![
+                vec![],
+                vec![Event::Write {
+                    id: 0,
+                    region: exact(1, 0, 1),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                }],
+                vec![],
+                vec![],
+            ],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(
+            summary.dependencies,
+            vec![Dependency {
+                input: exact(1, 0, 1),
+                output: exact(1, 0, 1),
+                kind: EdgeKind::Value,
+            }]
+        );
+        assert_eq!(summary.phi_count, 1);
+    }
+
+    #[test]
+    fn cost_is_independent_of_numerical_width() {
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: exact(1, 0, 1 << 30),
+                },
+                Event::Write {
+                    id: 0,
+                    region: exact(2, 0, 1 << 30),
+                    dependencies: vec![(0, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(summary.atom_count, 2);
+        assert_eq!(summary.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn aligned_copy_propagates_sparse_boundaries_without_cross_bit_taint() {
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: exact(1, 0, 1 << 30),
+                },
+                Event::Write {
+                    id: 0,
+                    region: exact(2, 0, 1 << 30),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![AlignedDependency {
+                        read: 0,
+                        kind: EdgeKind::Value,
+                        destination: Span {
+                            start: 0,
+                            length: 1 << 30,
+                        },
+                    }],
+                },
+                Event::Read {
+                    id: 1,
+                    region: exact(2, 7, 1),
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(3, 0, 1),
+                    dependencies: vec![(1, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(summary.atom_count, 7);
+        let final_dependencies = summary
+            .dependencies
+            .iter()
+            .copied()
+            .filter(|dependency| dependency.output == exact(3, 0, 1))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            final_dependencies,
+            vec![Dependency {
+                input: exact(1, 7, 1),
+                output: exact(3, 0, 1),
+                kind: EdgeKind::Value,
+            }]
+        );
+    }
+
+    #[test]
+    fn object_local_uncertainty_preserves_other_exact_dependencies() {
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Write {
+                    id: 0,
+                    region: Region::UnknownObject(1),
+                    dependencies: vec![],
+                    aligned_dependencies: vec![],
+                },
+                Event::Read {
+                    id: 0,
+                    region: exact(2, 0, 1),
+                },
+                Event::Write {
+                    id: 1,
+                    region: exact(2, 0, 1),
+                    dependencies: vec![(0, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(summary.uncertain_objects, BTreeSet::from([1]));
+        assert!(!summary.unknown_all);
+        assert_eq!(
+            summary.dependencies,
+            vec![Dependency {
+                input: exact(2, 0, 1),
+                output: exact(2, 0, 1),
+                kind: EdgeKind::Value,
+            }]
+        );
+    }
+
+    #[test]
+    fn dynamic_self_dependency_remains_structurally_visible() {
+        let procedure = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![
+                Event::Read {
+                    id: 0,
+                    region: Region::UnknownObject(1),
+                },
+                Event::Write {
+                    id: 0,
+                    region: Region::UnknownObject(1),
+                    dependencies: vec![(0, EdgeKind::Value)],
+                    aligned_dependencies: vec![],
+                },
+            ]],
+            object_spans: BTreeMap::from([(
+                1,
+                Span {
+                    start: 0,
+                    length: 8,
+                },
+            )]),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert_eq!(
+            summary.dependencies,
+            vec![Dependency {
+                input: exact(1, 0, 8),
+                output: exact(1, 0, 8),
+                kind: EdgeKind::Value,
+            }]
+        );
+    }
+
+    #[test]
+    fn global_uncertainty_is_reported_separately() {
+        let procedure: Procedure<u8> = Procedure {
+            entry: 0,
+            exit: 0,
+            successors: vec![vec![]],
+            events: vec![vec![Event::Write {
+                id: 0,
+                region: Region::UnknownAll,
+                dependencies: vec![],
+                aligned_dependencies: vec![],
+            }]],
+            object_spans: BTreeMap::new(),
+            incomplete: BTreeSet::new(),
+        };
+
+        let summary = analyze(&procedure).unwrap();
+        assert!(summary.unknown_all);
+        assert!(summary.uncertain_objects.is_empty());
+        assert!(
+            summary
+                .incomplete
+                .contains(&IncompleteReason::DynamicRegion)
+        );
+    }
+}

--- a/crates/causal/src/procedure.rs
+++ b/crates/causal/src/procedure.rs
@@ -65,6 +65,10 @@ pub struct Dependency<O> {
     pub input: Region<O>,
     pub output: Region<O>,
     pub kind: EdgeKind,
+    /// Every step from input to output preserves bit position. Call adapters
+    /// may safely project a requested output subspan back to the same relative
+    /// input subspan only when this is true.
+    pub aligned: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -139,6 +143,7 @@ enum Usage {
 struct DepVersion<O> {
     version: Version<usize, Definition>,
     kind: EdgeKind,
+    aligned: bool,
     marker: std::marker::PhantomData<O>,
 }
 
@@ -250,7 +255,7 @@ where
     let definitions = writes.values().map(|(_, atoms, _, _)| atoms.len()).sum();
     let mut version_deps = BTreeMap::<
         Version<usize, Definition>,
-        BTreeSet<(Version<usize, Definition>, EdgeKind)>,
+        BTreeSet<(Version<usize, Definition>, EdgeKind, bool)>,
     >::new();
 
     for phi in &ssa.phis {
@@ -258,7 +263,7 @@ where
         deps.extend(
             phi.inputs
                 .iter()
-                .map(|(_, input)| (*input, EdgeKind::Value)),
+                .map(|(_, input)| (*input, EdgeKind::Value, true)),
         );
     }
     for (&write, (write_region, write_atoms, dependencies, aligned_dependencies)) in &writes {
@@ -271,7 +276,7 @@ where
             };
             for &atom in atoms {
                 if let Some(&version) = ssa.uses.get(&Usage::Read { read, atom }) {
-                    incoming.insert((version, kind));
+                    incoming.insert((version, kind, false));
                 }
             }
         }
@@ -348,7 +353,7 @@ where
                             atom: source_atom,
                         })
                     {
-                        atom_incoming.insert((version, dependency.kind));
+                        atom_incoming.insert((version, dependency.kind, true));
                     }
                 }
             }
@@ -367,12 +372,13 @@ where
         let Some(&output_version) = ssa.uses.get(&Usage::Exit { atom: output_atom }) else {
             continue;
         };
-        let mut stack = vec![(output_version, EdgeKind::Value)];
+        let mut stack = vec![(output_version, EdgeKind::Value, true)];
         let mut visited = BTreeSet::new();
-        while let Some((version, path_kind)) = stack.pop() {
+        while let Some((version, path_kind, path_aligned)) = stack.pop() {
             if !visited.insert(DepVersion::<O> {
                 version,
                 kind: path_kind,
+                aligned: path_aligned,
                 marker: std::marker::PhantomData,
             }) {
                 continue;
@@ -383,15 +389,18 @@ where
                         input: atom_region(atoms[input_atom]),
                         output: atom_region(atoms[output_atom]),
                         kind: path_kind,
+                        aligned: path_aligned,
                     });
                 }
                 Version::Definition { .. } | Version::Phi { .. } => {
                     if let Some(inputs) = version_deps.get(&version) {
-                        stack.extend(
-                            inputs
-                                .iter()
-                                .map(|&(input, kind)| (input, combine_edge_kinds(path_kind, kind))),
-                        );
+                        stack.extend(inputs.iter().map(|&(input, kind, aligned)| {
+                            (
+                                input,
+                                combine_edge_kinds(path_kind, kind),
+                                path_aligned && aligned,
+                            )
+                        }));
                     }
                 }
             }
@@ -750,6 +759,7 @@ mod tests {
                 input: exact(1, 0, 1),
                 output: exact(1, 0, 1),
                 kind: EdgeKind::Value,
+                aligned: true,
             }]
         );
         assert_eq!(summary.phi_count, 1);
@@ -838,6 +848,7 @@ mod tests {
                 input: exact(1, 7, 1),
                 output: exact(3, 0, 1),
                 kind: EdgeKind::Value,
+                aligned: false,
             }]
         );
     }
@@ -880,6 +891,7 @@ mod tests {
                 input: exact(2, 0, 1),
                 output: exact(2, 0, 1),
                 kind: EdgeKind::Value,
+                aligned: false,
             }]
         );
     }
@@ -944,6 +956,7 @@ mod tests {
                 input: exact(1, 0, 8),
                 output: exact(1, 0, 8),
                 kind: EdgeKind::Value,
+                aligned: false,
             }]
         );
     }

--- a/crates/causal/src/region.rs
+++ b/crates/causal/src/region.rs
@@ -31,8 +31,9 @@ impl Span {
 /// A statically resolved region, or an unresolved access within one object.
 ///
 /// `UnknownObject` is intentionally not expanded to the object's numerical
-/// width.  Clients retain the uncertainty and decide whether a result which
-/// depends on it is a warning, a hard error, or merely an optimization barrier.
+/// width in this value. Clients with a declared object span can expand it
+/// conservatively and still produce a complete result; without that span the
+/// access remains incomplete.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Region<O> {
     Exact {

--- a/crates/causal/src/region.rs
+++ b/crates/causal/src/region.rs
@@ -1,0 +1,93 @@
+//! Width-independent region identities and conservative aliasing.
+
+/// A half-open interval measured in a client-selected unit (normally bits).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Span {
+    pub start: usize,
+    pub length: usize,
+}
+
+impl Span {
+    #[must_use]
+    pub fn end(self) -> Option<usize> {
+        self.start.checked_add(self.length)
+    }
+
+    #[must_use]
+    pub fn intersection(self, other: Self) -> Option<Self> {
+        let start = self.start.max(other.start);
+        let end = self.end()?.min(other.end()?);
+        if start < end {
+            Some(Self {
+                start,
+                length: end - start,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// A statically resolved region, or an unresolved access within one object.
+///
+/// `UnknownObject` is intentionally not expanded to the object's numerical
+/// width.  Clients retain the uncertainty and decide whether a result which
+/// depends on it is a warning, a hard error, or merely an optimization barrier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Region<O> {
+    Exact { object: O, span: Span },
+    UnknownObject(O),
+    UnknownAll,
+}
+
+impl<O: Copy + Eq> Region<O> {
+    #[must_use]
+    pub fn may_alias(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::UnknownAll, _) | (_, Self::UnknownAll) => true,
+            (Self::UnknownObject(left), Self::UnknownObject(right)) => left == right,
+            (Self::UnknownObject(object), Self::Exact { object: other, .. })
+            | (Self::Exact { object: other, .. }, Self::UnknownObject(object)) => object == other,
+            (
+                Self::Exact {
+                    object: left,
+                    span: left_span,
+                },
+                Self::Exact {
+                    object: right,
+                    span: right_span,
+                },
+            ) => left == right && left_span.intersection(right_span).is_some(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_exact(self) -> bool {
+        matches!(self, Self::Exact { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exact(object: u8, start: usize, length: usize) -> Region<u8> {
+        Region::Exact {
+            object,
+            span: Span { start, length },
+        }
+    }
+
+    #[test]
+    fn exact_regions_use_half_open_intervals() {
+        assert!(exact(1, 3, 5).may_alias(exact(1, 7, 2)));
+        assert!(!exact(1, 3, 5).may_alias(exact(1, 8, 2)));
+        assert!(!exact(1, 3, 5).may_alias(exact(2, 3, 5)));
+    }
+
+    #[test]
+    fn unknown_object_does_not_become_unknown_all() {
+        assert!(Region::UnknownObject(1).may_alias(exact(1, 1 << 30, 1)));
+        assert!(!Region::UnknownObject(1).may_alias(exact(2, 0, 1)));
+    }
+}

--- a/crates/causal/src/region.rs
+++ b/crates/causal/src/region.rs
@@ -35,7 +35,15 @@ impl Span {
 /// depends on it is a warning, a hard error, or merely an optimization barrier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Region<O> {
-    Exact { object: O, span: Span },
+    Exact {
+        object: O,
+        span: Span,
+    },
+    /// An unresolved suffix confined to a statically known prefix span.
+    UnknownRegion {
+        object: O,
+        span: Span,
+    },
     UnknownObject(O),
     UnknownAll,
 }
@@ -45,7 +53,35 @@ impl<O: Copy + Eq> Region<O> {
     pub fn may_alias(self, other: Self) -> bool {
         match (self, other) {
             (Self::UnknownAll, _) | (_, Self::UnknownAll) => true,
+            (
+                Self::UnknownRegion {
+                    object: left,
+                    span: left_span,
+                },
+                Self::UnknownRegion {
+                    object: right,
+                    span: right_span,
+                },
+            ) => left == right && left_span.intersection(right_span).is_some(),
+            (
+                Self::UnknownRegion { object, span },
+                Self::Exact {
+                    object: other,
+                    span: other_span,
+                },
+            )
+            | (
+                Self::Exact {
+                    object: other,
+                    span: other_span,
+                },
+                Self::UnknownRegion { object, span },
+            ) => object == other && span.intersection(other_span).is_some(),
             (Self::UnknownObject(left), Self::UnknownObject(right)) => left == right,
+            (Self::UnknownObject(object), Self::UnknownRegion { object: other, .. })
+            | (Self::UnknownRegion { object: other, .. }, Self::UnknownObject(object)) => {
+                object == other
+            }
             (Self::UnknownObject(object), Self::Exact { object: other, .. })
             | (Self::Exact { object: other, .. }, Self::UnknownObject(object)) => object == other,
             (
@@ -89,5 +125,19 @@ mod tests {
     fn unknown_object_does_not_become_unknown_all() {
         assert!(Region::UnknownObject(1).may_alias(exact(1, 1 << 30, 1)));
         assert!(!Region::UnknownObject(1).may_alias(exact(2, 0, 1)));
+    }
+
+    #[test]
+    fn unknown_region_aliases_only_its_static_prefix() {
+        let prefix = Region::UnknownRegion {
+            object: 1,
+            span: Span {
+                start: 8,
+                length: 8,
+            },
+        };
+        assert!(prefix.may_alias(exact(1, 12, 1)));
+        assert!(!prefix.may_alias(exact(1, 0, 8)));
+        assert!(!prefix.may_alias(exact(2, 12, 1)));
     }
 }

--- a/crates/causal/src/ssa.rs
+++ b/crates/causal/src/ssa.rs
@@ -350,6 +350,62 @@ where
     })
 }
 
+/// Construct SSA for one straight-line block without building dominance or
+/// liveness state. This is equivalent to [`build`] for a one-block CFG with no
+/// successors, but avoids paying the general CFG cost for ordinary continuous
+/// assignments and other branch-free procedures.
+pub fn build_linear<V, D, U>(events: &[Event<V, D, U>]) -> Result<SparseSsa<V, D, U>, SsaError>
+where
+    V: Copy + Ord,
+    D: Copy + Ord,
+    U: Copy + Ord,
+{
+    let mut current = BTreeMap::<V, Version<V, D>>::new();
+    let mut definitions = BTreeSet::<(V, D)>::new();
+    let mut uses = BTreeMap::<U, Version<V, D>>::new();
+    for event in events {
+        match *event {
+            Event::Use { variable, usage } => {
+                let version = current
+                    .get(&variable)
+                    .copied()
+                    .unwrap_or(Version::Entry(variable));
+                if uses.insert(usage, version).is_some() {
+                    return Err(SsaError::new(
+                        "SSA.USE_IDENTITY",
+                        Some(0),
+                        "one use identity occurs more than once",
+                    ));
+                }
+            }
+            Event::Definition {
+                variable,
+                definition,
+            } => {
+                if !definitions.insert((variable, definition)) {
+                    return Err(SsaError::new(
+                        "SSA.DEFINITION_IDENTITY",
+                        Some(0),
+                        "one variable-definition identity occurs more than once",
+                    ));
+                }
+                current.insert(
+                    variable,
+                    Version::Definition {
+                        variable,
+                        definition,
+                    },
+                );
+            }
+        }
+    }
+    Ok(SparseSsa {
+        phis: Vec::new(),
+        phis_by_block: vec![Vec::new()],
+        uses,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -467,5 +523,41 @@ mod tests {
                 definition: 2
             }
         );
+    }
+
+    #[test]
+    fn linear_builder_matches_general_one_block_ssa() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let events = vec![
+            Event::Use {
+                variable: 1,
+                usage: 10,
+            },
+            Event::Definition {
+                variable: 1,
+                definition: 20,
+            },
+            Event::Use {
+                variable: 2,
+                usage: 30,
+            },
+            Event::Definition {
+                variable: 2,
+                definition: 40,
+            },
+            Event::Use {
+                variable: 1,
+                usage: 50,
+            },
+            Event::Use {
+                variable: 2,
+                usage: 60,
+            },
+        ];
+
+        let general = build(&cfg, std::slice::from_ref(&events)).unwrap();
+        let linear = build_linear(&events).unwrap();
+
+        assert_eq!(linear, general);
     }
 }

--- a/crates/causal/src/ssa.rs
+++ b/crates/causal/src/ssa.rs
@@ -1,0 +1,471 @@
+//! Sparse pruned SSA construction over caller-defined variable identities.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt;
+
+use crate::cfg::{ControlFlowGraph, ForwardControlFlowGraph};
+
+/// Minimal CFG view required by SSA construction.
+///
+/// Clients that already own dominance information can implement this view
+/// without rebuilding postdominators, control dependence, SCCs, or loops.
+pub trait SsaCfg {
+    type FrontierIter<'a>: Iterator<Item = usize>
+    where
+        Self: 'a;
+
+    fn root(&self) -> usize;
+    fn predecessors(&self) -> &[Vec<usize>];
+    fn successors(&self) -> &[Vec<usize>];
+    fn dominator_children(&self) -> &[Vec<usize>];
+    fn dominance_frontier_len(&self) -> usize;
+    fn dominance_frontier(&self, block: usize) -> Self::FrontierIter<'_>;
+}
+
+impl SsaCfg for ControlFlowGraph {
+    type FrontierIter<'a> = std::iter::Copied<std::slice::Iter<'a, usize>>;
+
+    fn root(&self) -> usize {
+        self.root
+    }
+
+    fn predecessors(&self) -> &[Vec<usize>] {
+        &self.predecessors
+    }
+
+    fn successors(&self) -> &[Vec<usize>] {
+        &self.successors
+    }
+
+    fn dominator_children(&self) -> &[Vec<usize>] {
+        &self.dominators.children
+    }
+
+    fn dominance_frontier_len(&self) -> usize {
+        self.dominance_frontier.len()
+    }
+
+    fn dominance_frontier(&self, block: usize) -> Self::FrontierIter<'_> {
+        self.dominance_frontier[block].iter().copied()
+    }
+}
+
+impl SsaCfg for ForwardControlFlowGraph {
+    type FrontierIter<'a> = std::iter::Copied<std::slice::Iter<'a, usize>>;
+
+    fn root(&self) -> usize {
+        self.root
+    }
+
+    fn predecessors(&self) -> &[Vec<usize>] {
+        &self.predecessors
+    }
+
+    fn successors(&self) -> &[Vec<usize>] {
+        &self.successors
+    }
+
+    fn dominator_children(&self) -> &[Vec<usize>] {
+        &self.dominators.children
+    }
+
+    fn dominance_frontier_len(&self) -> usize {
+        self.dominance_frontier.len()
+    }
+
+    fn dominance_frontier(&self, block: usize) -> Self::FrontierIter<'_> {
+        self.dominance_frontier[block].iter().copied()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Version<V, D> {
+    Entry(V),
+    Definition { variable: V, definition: D },
+    Phi { variable: V, block: usize },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event<V, D, U> {
+    Use { variable: V, usage: U },
+    Definition { variable: V, definition: D },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phi<V, D> {
+    pub variable: V,
+    pub block: usize,
+    pub version: Version<V, D>,
+    pub inputs: Vec<(usize, Version<V, D>)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SparseSsa<V, D, U> {
+    pub phis: Vec<Phi<V, D>>,
+    pub phis_by_block: Vec<Vec<usize>>,
+    pub uses: BTreeMap<U, Version<V, D>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SsaError {
+    pub rule: &'static str,
+    pub block: Option<usize>,
+    pub message: String,
+}
+
+impl SsaError {
+    fn new(rule: &'static str, block: Option<usize>, message: impl Into<String>) -> Self {
+        Self {
+            rule,
+            block,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SsaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.rule)?;
+        if let Some(block) = self.block {
+            write!(formatter, " at block {block}")?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl std::error::Error for SsaError {}
+
+/// Construct pruned SSA from events already ordered within each dense block.
+pub fn build<V, D, U>(
+    cfg: &impl SsaCfg,
+    events: &[Vec<Event<V, D, U>>],
+) -> Result<SparseSsa<V, D, U>, SsaError>
+where
+    V: Copy + Ord,
+    D: Copy + Ord,
+    U: Copy + Ord,
+{
+    let blocks = cfg.successors().len();
+    if events.len() != blocks
+        || cfg.predecessors().len() != blocks
+        || cfg.dominator_children().len() != blocks
+        || cfg.dominance_frontier_len() != blocks
+    {
+        return Err(SsaError::new(
+            "SSA.MODEL_SHAPE",
+            None,
+            "CFG and event tables do not cover the same block domain",
+        ));
+    }
+
+    let mut definitions = BTreeMap::<V, BTreeSet<usize>>::new();
+    let mut definition_ids = BTreeSet::<(V, D)>::new();
+    let mut upward_uses = BTreeSet::<(V, usize)>::new();
+    let mut usage_ids = BTreeSet::<U>::new();
+    for (block, block_events) in events.iter().enumerate() {
+        let mut locally_defined = BTreeSet::<V>::new();
+        for event in block_events {
+            match *event {
+                Event::Use { variable, usage } => {
+                    if !usage_ids.insert(usage) {
+                        return Err(SsaError::new(
+                            "SSA.USE_IDENTITY",
+                            Some(block),
+                            "one use identity occurs more than once",
+                        ));
+                    }
+                    if !locally_defined.contains(&variable) {
+                        upward_uses.insert((variable, block));
+                    }
+                }
+                Event::Definition {
+                    variable,
+                    definition,
+                } => {
+                    if !definition_ids.insert((variable, definition)) {
+                        return Err(SsaError::new(
+                            "SSA.DEFINITION_IDENTITY",
+                            Some(block),
+                            "one variable-definition identity occurs more than once",
+                        ));
+                    }
+                    locally_defined.insert(variable);
+                    definitions.entry(variable).or_default().insert(block);
+                }
+            }
+        }
+    }
+
+    let definition_pairs = definitions
+        .iter()
+        .flat_map(|(&variable, blocks)| blocks.iter().map(move |&block| (variable, block)))
+        .collect::<BTreeSet<_>>();
+    let mut live_in = upward_uses.clone();
+    let mut live_work = upward_uses.into_iter().collect::<VecDeque<_>>();
+    while let Some((variable, block)) = live_work.pop_front() {
+        for &predecessor in &cfg.predecessors()[block] {
+            let pair = (variable, predecessor);
+            if !definition_pairs.contains(&pair) && live_in.insert(pair) {
+                live_work.push_back(pair);
+            }
+        }
+    }
+
+    let mut phi_pairs = BTreeSet::<(usize, V)>::new();
+    for (&variable, original_definitions) in &definitions {
+        let mut queued = original_definitions.clone();
+        let mut work = original_definitions
+            .iter()
+            .copied()
+            .collect::<VecDeque<_>>();
+        while let Some(definition) = work.pop_front() {
+            for frontier in cfg.dominance_frontier(definition) {
+                if !live_in.contains(&(variable, frontier))
+                    || !phi_pairs.insert((frontier, variable))
+                {
+                    continue;
+                }
+                if queued.insert(frontier) {
+                    work.push_back(frontier);
+                }
+            }
+        }
+    }
+
+    let mut phis = Vec::<Phi<V, D>>::with_capacity(phi_pairs.len());
+    let mut phis_by_block = vec![Vec::<usize>::new(); blocks];
+    for (block, variable) in phi_pairs {
+        let phi = phis.len();
+        phis.push(Phi {
+            variable,
+            block,
+            version: Version::Phi { variable, block },
+            inputs: Vec::with_capacity(cfg.predecessors()[block].len()),
+        });
+        phis_by_block[block].push(phi);
+    }
+
+    enum Action<V, D> {
+        Enter(usize),
+        Exit(Vec<(V, Option<Version<V, D>>)>),
+    }
+    let mut current = BTreeMap::<V, Version<V, D>>::new();
+    let mut uses = BTreeMap::<U, Version<V, D>>::new();
+    let mut actions = vec![Action::Enter(cfg.root())];
+    while let Some(action) = actions.pop() {
+        let block = match action {
+            Action::Exit(changes) => {
+                for (variable, previous) in changes.into_iter().rev() {
+                    if let Some(previous) = previous {
+                        current.insert(variable, previous);
+                    } else {
+                        current.remove(&variable);
+                    }
+                }
+                continue;
+            }
+            Action::Enter(block) => block,
+        };
+        let mut changes = Vec::new();
+        for &phi in &phis_by_block[block] {
+            let variable = phis[phi].variable;
+            changes.push((variable, current.insert(variable, phis[phi].version)));
+        }
+        for event in &events[block] {
+            match *event {
+                Event::Use { variable, usage } => {
+                    let version = current
+                        .get(&variable)
+                        .copied()
+                        .unwrap_or(Version::Entry(variable));
+                    if uses.insert(usage, version).is_some() {
+                        return Err(SsaError::new(
+                            "SSA.USE_RENAME",
+                            Some(block),
+                            "dominator rename visited one use more than once",
+                        ));
+                    }
+                }
+                Event::Definition {
+                    variable,
+                    definition,
+                } => {
+                    let version = Version::Definition {
+                        variable,
+                        definition,
+                    };
+                    changes.push((variable, current.insert(variable, version)));
+                }
+            }
+        }
+        for &successor in &cfg.successors()[block] {
+            for &phi in &phis_by_block[successor] {
+                let variable = phis[phi].variable;
+                let version = current
+                    .get(&variable)
+                    .copied()
+                    .unwrap_or(Version::Entry(variable));
+                phis[phi].inputs.push((block, version));
+            }
+        }
+        actions.push(Action::Exit(changes));
+        actions.extend(
+            cfg.dominator_children()[block]
+                .iter()
+                .rev()
+                .copied()
+                .map(Action::Enter),
+        );
+    }
+
+    if uses.len() != usage_ids.len() {
+        return Err(SsaError::new(
+            "SSA.USE_COVERAGE",
+            None,
+            "dominator rename did not visit every use",
+        ));
+    }
+    for phi in &mut phis {
+        phi.inputs
+            .sort_unstable_by_key(|(predecessor, _)| *predecessor);
+        if phi.inputs.len() != cfg.predecessors()[phi.block].len()
+            || phi
+                .inputs
+                .iter()
+                .zip(&cfg.predecessors()[phi.block])
+                .any(|((actual, _), expected)| actual != expected)
+        {
+            return Err(SsaError::new(
+                "SSA.PHI_INPUTS",
+                Some(phi.block),
+                "phi inputs do not cover every CFG predecessor exactly once",
+            ));
+        }
+    }
+
+    Ok(SparseSsa {
+        phis,
+        phis_by_block,
+        uses,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn branch_definitions_create_one_live_join_phi() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![3], vec![3], vec![]], 0).unwrap();
+        let events = vec![
+            vec![],
+            vec![Event::Definition {
+                variable: 7,
+                definition: 10,
+            }],
+            vec![Event::Definition {
+                variable: 7,
+                definition: 20,
+            }],
+            vec![Event::Use {
+                variable: 7,
+                usage: 30,
+            }],
+        ];
+
+        let ssa = build(&cfg, &events).unwrap();
+
+        assert_eq!(ssa.phis.len(), 1);
+        assert_eq!(ssa.phis[0].block, 3);
+        assert_eq!(ssa.phis[0].inputs.len(), 2);
+        assert_eq!(
+            ssa.uses[&30],
+            Version::Phi {
+                variable: 7,
+                block: 3
+            }
+        );
+    }
+
+    #[test]
+    fn dead_join_does_not_receive_a_phi() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1, 2], vec![3], vec![3], vec![]], 0).unwrap();
+        let events = vec![
+            vec![],
+            vec![Event::Definition {
+                variable: 7,
+                definition: 10,
+            }],
+            vec![Event::Definition {
+                variable: 7,
+                definition: 20,
+            }],
+            vec![],
+        ];
+
+        let ssa = build::<_, _, usize>(&cfg, &events).unwrap();
+
+        assert!(ssa.phis.is_empty());
+    }
+
+    #[test]
+    fn loop_use_observes_header_phi() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![1], vec![2, 3], vec![1], vec![]], 0).unwrap();
+        let events = vec![
+            vec![Event::Definition {
+                variable: 1,
+                definition: 0,
+            }],
+            vec![Event::Use {
+                variable: 1,
+                usage: 10,
+            }],
+            vec![Event::Definition {
+                variable: 1,
+                definition: 20,
+            }],
+            vec![],
+        ];
+
+        let ssa = build(&cfg, &events).unwrap();
+
+        assert_eq!(
+            ssa.uses[&10],
+            Version::Phi {
+                variable: 1,
+                block: 1
+            }
+        );
+        assert_eq!(ssa.phis[0].inputs.len(), 2);
+    }
+
+    #[test]
+    fn same_block_uses_observe_event_order() {
+        let cfg = ControlFlowGraph::analyze(vec![vec![]], 0).unwrap();
+        let events = vec![vec![
+            Event::Use {
+                variable: 1,
+                usage: 1,
+            },
+            Event::Definition {
+                variable: 1,
+                definition: 2,
+            },
+            Event::Use {
+                variable: 1,
+                usage: 3,
+            },
+        ]];
+
+        let ssa = build(&cfg, &events).unwrap();
+
+        assert_eq!(ssa.uses[&1], Version::Entry(1));
+        assert_eq!(
+            ssa.uses[&3],
+            Version::Definition {
+                variable: 1,
+                definition: 2
+            }
+        );
+    }
+}

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -12932,6 +12932,10 @@ fn dual_jit_wide_dynamic_assign_mixed() {
     ) {
         var mem: logic<96> [4];
         always_comb {
+            mem[0] = 0;
+            mem[1] = 0;
+            mem[2] = 0;
+            mem[3] = 0;
             mem[sel] = val;
             out = a + 1;
             wide_out = mem[0];

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -17570,7 +17570,10 @@ fn concat_lhs_with_dynamic_bit_select() {
         a: output logic<4>,
         b: output logic,
     ) {
-        assign {a[i], b} = v;
+        always_comb {
+            a = 0;
+            {a[i], b} = v;
+        }
     }
     "#;
     for config in Config::all() {
@@ -17587,8 +17590,8 @@ fn concat_lhs_with_dynamic_bit_select() {
         sim.set("i", Value::new(0, 2, false));
         sim.set("v", Value::new(0b11, 2, false));
         sim.step(&Event::Clock(VarId::SYNTHETIC));
-        // Bit 2 keeps its previous value (only a[i] is driven).
-        assert_eq!(sim.get("a").unwrap().payload_u128(), 0b0101, "{config:?}");
+        // The default assignment clears bit 2 before a[0] is selected.
+        assert_eq!(sim.get("a").unwrap().payload_u128(), 0b0001, "{config:?}");
         assert_eq!(sim.get("b").unwrap().payload_u128(), 1, "{config:?}");
     }
 }

--- a/crates/tests/benches/benchmark.rs
+++ b/crates/tests/benches/benchmark.rs
@@ -54,6 +54,19 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
     }
 
+    let loop_ir = {
+        let parser = Parser::parse(&text, &"").unwrap();
+        let prj = &metadata.project.name;
+        let analyzer = Analyzer::new(&metadata);
+        let mut context = Context::default();
+        let mut ir = veryl_analyzer::ir::Ir::default();
+        analyzer.analyze_pass1(prj, &parser.veryl);
+        Analyzer::analyze_post_pass1();
+        analyzer.analyze_pass2(&parser.veryl, &mut context, Some(&mut ir));
+        analyzer.clear();
+        ir
+    };
+
     let mut group = c.benchmark_group("throughput");
     group.throughput(Throughput::Bytes(text.len() as u64));
     group.bench_function("parse", |b| {
@@ -79,6 +92,9 @@ fn criterion_benchmark(c: &mut Criterion) {
             Analyzer::analyze_post_pass2(&ir);
             analyzer.clear();
         })
+    });
+    group.bench_function("comb_loop", |b| {
+        b.iter_with_large_drop(|| veryl_analyzer::comb_loop_detect::check(black_box(&loop_ir)))
     });
     group.finish();
 }

--- a/crates/tests/src/snapshots/combinational_loop_inst.snap
+++ b/crates/tests/src/snapshots/combinational_loop_inst.snap
@@ -1,23 +1,23 @@
 ---
 source: crates/tests/src/lib.rs
-assertion_line: 421
+assertion_line: 425
 expression: out
 ---
 combinational_loop (https://doc.veryl-lang.org/book/07_appendix/02_semantic_error.html#combinational_loop)
 
-  × combinational loop detected on "x"
+  × combinational loop detected on "y"
+    ╭─[../../testcases/error/combinational_loop_inst.veryl:14:10]
+ 13 │     var y: logic<8>;
+ 14 │     inst u: combinational_loop_inst_buf (
+    ·          ┬
+    ·          ╰── Error location
+ 15 │         i: x,
+    ╰────
     ╭─[../../testcases/error/combinational_loop_inst.veryl:18:12]
  17 │     );
  18 │     assign x = y;
     ·            ┬
-    ·            ╰── Error location
- 19 │     assign b = y;
-    ╰────
-    ╭─[../../testcases/error/combinational_loop_inst.veryl:16:12]
- 15 │         i: x,
- 16 │         o: y,
-    ·            ┬
     ·            ╰── involved in loop
- 17 │     );
+ 19 │     assign b = y;
     ╰────
   help:


### PR DESCRIPTION
Replace the current combinational-loop dependency construction with a control-flow-aware, region-based MemorySSA analysis.

The new analysis preserves:
* procedural order and reaching definitions
* partial and disjoint object regions
* value, control, and address dependencies
* function and module feedthrough
* source provenance for diagnostics
* explicit incomplete-analysis results

This PR also adds the IR-independent `veryl-causal` crate and documents the intended analysis contract in `crates/analyzer/COMBINATIONAL_LOOP_ANALYSIS.md`.

## Motivation

This work has two immediate motivations.

First, false positive caused by the current declaration-level dependency aggregation:

```veryl
always_comb {
    x[0] = a;
    $display("x3=%0d", x[3]);
    o = x[3];
}

assign x[1] = x[0];
assign x[2] = x[1];
assign x[3] = x[2];
```

The actual causal chain is:

```text
a -> x[0] -> x[1] -> x[2] -> x[3] -> o
```

The read of `x[3]` reactivates the procedure and supplies `$display` and `o`, but it does not determine the assignment to `x[0]`.

The current representation loses that distinction and invents an `x[3] -> x[0]` dependency. Restoring the old overlap check would instead miss real cross-bit cycles:

```veryl
assign x[1] = x[2];
assign x[2] = x[1];
```

This is the same underlying class of problem as #2759: once reads and writes are aggregated at declaration level, the analyzer can no longer reliably determine which read affects which write.

Second, #3135 needs a reusable dependency analysis for mutable `for` bounds.

Direct procedural mutation can be detected locally, but indirect influence through combinational logic depends on the same dependency relation used for combinational-loop detection. It also needs to distinguish established stability from an incomplete result when hierarchy, external components, or unsupported effects prevent a complete proof.

Maintaining another dependency collector for that diagnostic would duplicate the same procedural-order, region, function, and hierarchy logic.

## Implementation

Each combinational procedure is lowered to an immutable CFG containing ordered read and write events.

Sparse region MemorySSA resolves reads to their reaching definitions and produces a reusable procedure summary. Branches, loops, early exits, partial writes, and dynamic writes use the same reaching-definition model.

The region domain is partitioned only at observed access boundaries. Analysis cost therefore depends primarily on accesses, definitions, phi nodes, and CFG edges rather than directly on the declared width of a signal or array.

Supported copies, selections, concatenations, and pointwise operations preserve positional dependencies. Operations without a positional model may fall back to conservative whole-operand dependencies without discarding procedural order or unrelated region precision.

Retained entry state from an incomplete assignment is kept separate from an explicit read of the previous value. This prevents incomplete assignments from being mistaken for combinational feedback.

Known function effects and module feedthrough are summarized and composed across call and instance boundaries. FF state remains a combinational boundary.

Observer-only reads such as `$display` arguments remain separate from value dependencies. Sensitivity and value causality are related, but they are not the same graph.

## Parallel procedure analysis

`veryl-causal` owns no parser resources, global symbol-table locks, source locations, or Veryl IR references.

Each combinational procedure and function specialization is therefore an independent analysis work item. CFG, SSA, MemorySSA, and procedure-summary construction can run in parallel.

The resulting summaries are immutable and deterministic and are merged afterward in source or module-topology order.

## Incomplete analysis

The analysis distinguishes:

* a known dependency cycle
* established acyclicity
* incomplete analysis

Without this distinction, absence of a loop diagnostic may mean either that the relevant graph was proved acyclic or that a dependency was silently omitted.

This information is also intended for #3135, where mutable loop-bound analysis needs to distinguish an established error, established stability, and an unknown result.

Opaque components, unresolved hierarchy, `inout`, unsupported effects, and similar boundaries are recorded as incomplete rather than converted into guessed feedthrough for a hard error. A known cycle remains reportable even when unrelated parts of the design are incomplete.

## Why MemorySSA

I considered direct symbolic evaluation, sparse forward dataflow, direct dependence-graph construction, and lowering to a more explicit combinational representation.

Sparse region MemorySSA appeared to be the least complicated option because reaching definitions, control-flow joins, partial writes, diagnostic provenance, incomplete results, and parallel procedure analysis can share one representation.

Another possible implementation would require a specialized pipeline combining symbolic evaluation, range-based stores, expression trees, separate observer tracking, bit-boundary atomization, dependency scheduling, and cycle detection.

MemorySSA is not part of the language contract and is not claimed to be the only possible implementation. It was simply the smallest approach I found which retained the information required by the analyzer.

The implementation is still substantial because the problem covers procedural ordering, regions, control flow, functions, hierarchy, observers, diagnostics, and incomplete behavior—not only SCC detection.

## User-visible effects

The accepted set may change in both directions.

The new analysis can remove false dependencies which caused valid designs to be rejected, but it can also restore real dependencies which the previous implementation omitted.

Diagnostics now use deterministic, source-backed simple cycles.

## Tests

The expanded tests cover:

* the regression exposed by #3033
* the false-positive pattern from #2759
* real and acyclic cross-bit paths
* observer reactivation without false value dependencies
* procedural read-before-write and write-before-read
* dead and dominating writes
* branches, loops, and early exits
* partial and dynamic accesses
* functions and module feedthrough
* FF boundaries
* sparse oversized objects
* deterministic cycle selection
* explicit incomplete reasons