### PR TITLE
fix std repository path in Veryl.toml

### DIFF
--- a/crates/std/veryl/Veryl.toml
+++ b/crates/std/veryl/Veryl.toml
@@ -4,7 +4,7 @@ version     = "0.0.1"
 authors     = ["dalance@gmail.com"]
 description = "Veryl Standard Library"
 license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/veryl-lang/std"
+repository  = "https://github.com/veryl-lang/veryl/tree/master/crates/std/veryl"
 
 [build]
 target      = {type = "directory", path = "target/src"}


### PR DESCRIPTION
On https://std.veryl-lang.org/, the repository link points to an archived repository. It was not updated when std was merged into the veryl repository. It might be better to point the link at the current location so readers are not sent to an archived repository.