### PR TITLE
test(analyzer): enable imported modport feedback regression

### DIFF
--- a/crates/analyzer/src/tests/comb_loop_interface_function_tests.rs
+++ b/crates/analyzer/src/tests/comb_loop_interface_function_tests.rs
@@ -609,7 +609,6 @@ fn comb_loop_false_positive_imported_interface_function_widens_output_region() {
 }
 
 #[test]
-#[ignore = "requires imported modport function effects"]
 fn comb_loop_imported_interface_function_retains_matching_output_region_feedback() {
     assert_interface_function_comb_loop(
         r#"


### PR DESCRIPTION
The implementation is already in master via #3307; this PR now enables the remaining ignored regression for feedback through an imported modport function.
