### PR TITLE
Fix wrong filelist order when a source file contains multiple components

### DIFF
--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -523,14 +523,14 @@ impl TypeDag {
         }
     }
 
-    fn toposort(&self) -> Vec<Symbol> {
-        let nodes = algo::toposort(self.dag.graph(), None).unwrap();
+    /// Files in dependency order.
+    fn toposort_file(&self) -> Vec<PathId> {
+        let nodes = algo::toposort(self.file_dag.graph(), None).unwrap();
         let mut ret = vec![];
         for node in nodes {
             let index = node.index() as u32;
-            if self.paths.contains_key(&index) {
-                let sym = self.get_symbol(index);
-                ret.push(sym);
+            if let Some(path) = self.file_nodes.get_by_right(&index) {
+                ret.push(*path);
             }
         }
         ret
@@ -689,8 +689,8 @@ pub fn apply() -> Vec<AnalyzerError> {
     TYPE_DAG.with(|f| f.borrow_mut().apply())
 }
 
-pub fn toposort() -> Vec<Symbol> {
-    TYPE_DAG.with(|f| f.borrow().toposort())
+pub fn toposort_file() -> Vec<PathId> {
+    TYPE_DAG.with(|f| f.borrow().toposort_file())
 }
 
 pub fn connected_components() -> Vec<Vec<Symbol>> {

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -755,6 +755,8 @@ mod filelist {
             "axi_pkg.veryl",
             "b_pkg.veryl",
             "c_pkg.veryl",
+            "d_01_pkg.veryl",
+            "d_02_module.veryl",
         ];
         check_list(&paths, all);
 
@@ -775,6 +777,8 @@ mod filelist {
         check_order(&paths, "20_module_p.veryl", "21_alias_q.veryl");
         check_order(&paths, "c_pkg.veryl", "b_pkg.veryl");
         check_order(&paths, "b_pkg.veryl", "22_dependency_r.veryl");
+        check_order(&paths, "d_02_module.veryl", "22_dependency_r.veryl");
+        check_order(&paths, "d_01_pkg.veryl", "d_02_module.veryl");
     }
 }
 

--- a/crates/veryl/src/cmd_build.rs
+++ b/crates/veryl/src/cmd_build.rs
@@ -335,17 +335,10 @@ impl CmdBuild {
         }
 
         let mut ret = vec![];
-        let sorted_symbols = type_dag::toposort();
-        for symbol in sorted_symbols {
-            if matches!(
-                symbol.kind,
-                SymbolKind::Module(_) | SymbolKind::Interface(_) | SymbolKind::Package(_)
-            ) && let TokenSource::File { path, .. } = symbol.token.source
-            {
-                let path = PathBuf::from(format!("{path}"));
-                if let Some(x) = used_paths.remove(&path) {
-                    ret.push(x.clone());
-                }
+        for path in type_dag::toposort_file() {
+            let path = PathBuf::from(format!("{path}"));
+            if let Some(x) = used_paths.remove(&path) {
+                ret.push(x.clone());
             }
         }
 

--- a/testcases/filelist/a/Veryl.lock
+++ b/testcases/filelist/a/Veryl.lock
@@ -6,6 +6,8 @@ version = 1
 name = "b"
 source = "../b"
 
+[projects.properties]
+
 [[projects.dependencies]]
 name = "c"
 source = "../c"
@@ -14,3 +16,12 @@ source = "../c"
 name = "c"
 source = "../c"
 dependencies = []
+
+[projects.properties]
+
+[[projects]]
+name = "d"
+source = "../d"
+dependencies = []
+
+[projects.properties]

--- a/testcases/filelist/a/Veryl.toml
+++ b/testcases/filelist/a/Veryl.toml
@@ -7,3 +7,4 @@ sourcemap_target = {type = "none"}
 
 [dependencies]
 b = {path = "../b"}
+d = {path = "../d"}

--- a/testcases/filelist/a/src/22_dependency_r.veryl
+++ b/testcases/filelist/a/src/22_dependency_r.veryl
@@ -4,3 +4,7 @@ package r_pkg {
         return B;
     }
 }
+
+module r_module {
+    inst u_d: d::d_02_top;
+}

--- a/testcases/filelist/d/Veryl.toml
+++ b/testcases/filelist/d/Veryl.toml
@@ -1,0 +1,6 @@
+[project]
+name = "filelist_d"
+version = "0.1.0"
+
+[build]
+sourcemap_target = {type = "none"}

--- a/testcases/filelist/d/src/d_01_pkg.veryl
+++ b/testcases/filelist/d/src/d_01_pkg.veryl
@@ -1,0 +1,3 @@
+package d_01_pkg {
+    const D: u32 = 8;
+}

--- a/testcases/filelist/d/src/d_02_module.veryl
+++ b/testcases/filelist/d/src/d_02_module.veryl
@@ -1,0 +1,7 @@
+module d_02_top {
+  let _d: logic<d_01_pkg::D> = '0;
+  inst u_sub: d_02_sub;
+}
+
+module d_02_sub {
+}


### PR DESCRIPTION
fix veryl-lang/veryl#3314

Use file tag instead of symbol dag to get correct filelist.
