### PR TITLE
fix(veryl): add files required by unreferenced definitions to filelist

### DIFF
--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -610,6 +610,31 @@ impl TypeDag {
         ret
     }
 
+    /// `files` and the files they depend on, transitively.
+    /// `move_to` keeps the visited set, so the seeds share one traversal.
+    fn required_files(&self, files: &HashSet<PathId>) -> HashSet<PathId> {
+        // Reverse edge to traverse files which the given file depends on
+        let graph = Reversed(self.file_dag.graph());
+
+        let mut ret = HashSet::default();
+        let mut dfs = Dfs::empty(graph);
+        for file in files {
+            // A file whose symbols never entered the DAG has no node
+            let Some(node) = self.file_nodes.get_by_left(file) else {
+                ret.insert(*file);
+                continue;
+            };
+            dfs.move_to((*node).into());
+            while let Some(x) = dfs.next(graph) {
+                if let Some(path) = self.file_nodes.get_by_right(&(x.index() as u32)) {
+                    ret.insert(*path);
+                }
+            }
+        }
+
+        ret
+    }
+
     fn dependent_files(&self) -> HashMap<PathId, Vec<PathId>> {
         let mut ret = HashMap::default();
         let graph = self.file_dag.graph().clone();
@@ -748,6 +773,10 @@ pub fn connected_files(prj: &Namespace) -> HashSet<PathId> {
 
 pub fn dependent_files() -> HashMap<PathId, Vec<PathId>> {
     TYPE_DAG.with(|f| f.borrow().dependent_files())
+}
+
+pub fn required_files(files: &HashSet<PathId>) -> HashSet<PathId> {
+    TYPE_DAG.with(|f| f.borrow().required_files(files))
 }
 
 pub fn dump() -> String {

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -758,6 +758,9 @@ mod filelist {
             "c_pkg.veryl",
             "d_01_pkg.veryl",
             "d_02_module.veryl",
+            "e_01_02_module.veryl",
+            "e_03_pkg.veryl",
+            "e_04_pkg.veryl",
         ];
         check_list(&paths, all);
 
@@ -780,6 +783,9 @@ mod filelist {
         check_order(&paths, "b_pkg.veryl", "22_dependency_r.veryl");
         check_order(&paths, "d_02_module.veryl", "22_dependency_r.veryl");
         check_order(&paths, "d_01_pkg.veryl", "d_02_module.veryl");
+        check_order(&paths, "e_01_02_module.veryl", "22_dependency_r.veryl");
+        check_order(&paths, "e_03_pkg.veryl", "e_01_02_module.veryl");
+        check_order(&paths, "e_04_pkg.veryl", "e_01_02_module.veryl");
         // 23_embed_s is opaque, so it must not float ahead of files with a visible dependency
         check_order(&paths, "22_dependency_r.veryl", "23_embed_s.veryl");
     }

--- a/crates/veryl/src/cmd_build.rs
+++ b/crates/veryl/src/cmd_build.rs
@@ -341,6 +341,10 @@ impl CmdBuild {
             candidate_files.extend(symbol_table::get_test_files(&prj_namespace));
         }
 
+        // A file is emitted as a whole, so the files it depends on are required too
+        // even when the symbol holding the dependency is unreachable from the project.
+        let candidate_files = type_dag::required_files(&candidate_files);
+
         // `PathId`'s `Display` is lossy; the table is keyed on the interned path.
         let mut used_paths = HashMap::new();
         for file in candidate_files {

--- a/testcases/filelist/a/Veryl.lock
+++ b/testcases/filelist/a/Veryl.lock
@@ -25,3 +25,10 @@ source = "../d"
 dependencies = []
 
 [projects.properties]
+
+[[projects]]
+name = "e"
+source = "../e"
+dependencies = []
+
+[projects.properties]

--- a/testcases/filelist/a/Veryl.toml
+++ b/testcases/filelist/a/Veryl.toml
@@ -8,3 +8,4 @@ sourcemap_target = {type = "none"}
 [dependencies]
 b = {path = "../b"}
 d = {path = "../d"}
+e = {path = "../e"}

--- a/testcases/filelist/a/src/22_dependency_r.veryl
+++ b/testcases/filelist/a/src/22_dependency_r.veryl
@@ -7,4 +7,5 @@ package r_pkg {
 
 module r_module {
     inst u_d: d::d_02_top;
+    inst u_e: e::e_01_top;
 }

--- a/testcases/filelist/e/Veryl.toml
+++ b/testcases/filelist/e/Veryl.toml
@@ -1,0 +1,6 @@
+[project]
+name = "filelist_e"
+version = "0.1.0"
+
+[build]
+sourcemap_target = {type = "none"}

--- a/testcases/filelist/e/src/e_01_02_module.veryl
+++ b/testcases/filelist/e/src/e_01_02_module.veryl
@@ -1,0 +1,7 @@
+pub module e_01_top {
+  let _e: logic<e_03_pkg::W> = 0;
+}
+
+pub module e_02_top {
+  let _e: logic<e_04_pkg::W> = 0;
+}

--- a/testcases/filelist/e/src/e_03_pkg.veryl
+++ b/testcases/filelist/e/src/e_03_pkg.veryl
@@ -1,0 +1,3 @@
+package e_03_pkg {
+    const W: u32 = 8;
+}

--- a/testcases/filelist/e/src/e_04_pkg.veryl
+++ b/testcases/filelist/e/src/e_04_pkg.veryl
@@ -1,0 +1,3 @@
+package e_04_pkg {
+    const W: u32 = 8;
+}


### PR DESCRIPTION
fix veryl-lang/veryl#3341

Currently, filelist is generated based on symbols shown from the root project. Therefore, `c.veryl` shown in the issue is not added to the filelist.

To resolve this, all dependent files that files resolved by appeared symbols depend on also added to the filelist.