### PR TITLE
fix(analyzer): reject a zero width or array size

### DIFF
--- a/crates/analyzer/src/conv/utils.rs
+++ b/crates/analyzer/src/conv/utils.rs
@@ -606,11 +606,7 @@ pub fn eval_size(
     if let Ok(x) = comptime.get_value() {
         let value = x.to_usize().unwrap_or(0);
         let value = context.check_size(value, expr.token_range());
-        if value == Some(0) {
-            Ok((comptime, None))
-        } else {
-            Ok((comptime, value))
-        }
+        Ok((comptime, value))
     } else {
         Ok((comptime, None))
     }

--- a/crates/simulator/src/tests/simulation.rs
+++ b/crates/simulator/src/tests/simulation.rs
@@ -26186,3 +26186,36 @@ fn narrowing_cast_of_a_signed_quotient_still_truncates() {
         assert_eq!(g, r, "a={} b={}", r.0, r.1);
     }
 }
+
+#[test]
+fn zero_width_signal_elaborates() {
+    // https://github.com/veryl-lang/veryl/issues/3347
+    let code = r#"
+    module Top #(
+        param SIDE_W: u32 = 0,
+    ) (
+        a: input  logic<32>,
+        s: input  logic<SIDE_W>,
+        c: output logic<32>,
+        d: output logic<SIDE_W>,
+    ) {
+        var z: logic<0>;
+
+        assign z = s;
+        assign d = z;
+        assign c = a + 1;
+    }
+    "#;
+
+    for config in Config::all() {
+        dbg!(&config);
+
+        let ir = analyze(code, &config);
+        let mut sim = Simulator::new(ir, None);
+
+        sim.set("a", Value::new(10, 32, false));
+        sim.step(&Event::Clock(VarId::SYNTHETIC));
+
+        assert_eq!(sim.get("c").unwrap(), Value::new(11, 32, false));
+    }
+}


### PR DESCRIPTION
Closes #3347.

Rejects a width or array size that evaluates to zero, at check time:

```
× zero_size
```

`logic<0>`, and `logic<X>` with `X = 0`, both emit `logic [X-1:0]`, and the tool
table in the issue shows that is not a width of zero anywhere that accepts it:
Verilator rejects it, and Icarus, VCS, Vivado and Design Compiler mostly make it 2
bits. So making the native simulator model 0 bits, which is what this PR did at
first, would have been a simulator/synthesis mismatch rather than a fix. Rejecting
the declaration means neither the emitter nor the simulator has to represent one.

This is a behaviour change: a zero width was accepted by `check` and `build` before.
The full suite passes, so nothing in std or the testcases declares one.

The check is a single line in `eval_size`, at the point where the analyzer already
had the value in hand and was discarding a zero into "unknown", which is how the
original report's `logic<0>` came to be diagnosed as an undeterminable width. Only a
value that is really zero is reported: one with X/Z bits, or too wide for `usize`,
falls through to the unknown-size path as before, so a non-constant cast operand
(`i_x as (i_x)`, via #3356) is still `invalid_operand` and not a zero size.

The alternative raised on the issue, eliding a zero-width signal from the output so
the parameterised pattern in the report keeps working, is still open. I have not
seen a call on it, and this PR does not preclude it; it just stops shipping SV that
the tools disagree on in the meantime.
